### PR TITLE
Flatpak-style filesystem sandbox (Linux/Landlock v1) + permissions, repair, integrity

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -36,3 +36,10 @@ jobs:
       run: dotnet build --no-restore -c Release
     - name: Test
       run: dotnet test --no-build -c Release --verbosity normal
+    - name: Landlock sandbox integration probe
+      run: |
+        HINA="$(find Hina.CLI/bin/Release -type f -name Hina.CLI | head -1)"
+        if [ -z "$HINA" ]; then echo "hina binary not found" >&2; exit 1; fi
+        echo "Using hina: $HINA (kernel $(uname -r))"
+        chmod +x scripts/landlock-probe.sh
+        bash scripts/landlock-probe.sh "$HINA"

--- a/Hina.CLI/CommandRouter.cs
+++ b/Hina.CLI/CommandRouter.cs
@@ -56,6 +56,8 @@ namespace Hina.CLI
                 case "run":
                     return RunCommand.RunAsync(ctx, args);
                 case "perms":
+                case "permissions":
+                case "permessi":
                     return PermsCommand.RunAsync(ctx, args);
                 case "verify":
                     return VerifyCommand.RunAsync(ctx, args);

--- a/Hina.CLI/CommandRouter.cs
+++ b/Hina.CLI/CommandRouter.cs
@@ -53,6 +53,10 @@ namespace Hina.CLI
                     return UpdateCommand.RunAsync(ctx, args);
                 case "reinstall":
                     return ReinstallCommand.RunAsync(ctx, args);
+                case "run":
+                    return RunCommand.RunAsync(ctx, args);
+                case "perms":
+                    return PermsCommand.RunAsync(ctx, args);
                 case "verify":
                     return VerifyCommand.RunAsync(ctx, args);
                 case "version":

--- a/Hina.CLI/CommandRouter.cs
+++ b/Hina.CLI/CommandRouter.cs
@@ -60,6 +60,7 @@ namespace Hina.CLI
                 case "permessi":
                     return PermsCommand.RunAsync(ctx, args);
                 case "verify":
+                case "repair":
                     return VerifyCommand.RunAsync(ctx, args);
                 case "version":
                     return Task.FromResult(VersionCommand.Run());

--- a/Hina.CLI/Commands/DevCommand.cs
+++ b/Hina.CLI/Commands/DevCommand.cs
@@ -4,6 +4,7 @@ using System.Threading;
 using Hina.Core.Configuration;
 using Hina.Core.Patching;
 using Hina.PackageManager.Descriptor;
+using Hina.PackageManager.Sandbox;
 using Microsoft.Extensions.Logging;
 
 namespace Hina.CLI.Commands
@@ -41,6 +42,14 @@ namespace Hina.CLI.Commands
             if (subcommand == "sign-descriptor")
             {
                 return RunSignDescriptor(args, logger);
+            }
+
+            // sandbox-run applies a filesystem sandbox then execs a command. Used by the
+            // Landlock integration test (and handy for manual sandbox debugging). It does
+            // not operate on a patch dir, so route it before the --dir check.
+            if (subcommand == "sandbox-run")
+            {
+                return RunSandbox(args, logger);
             }
 
             if (string.IsNullOrWhiteSpace(root))
@@ -115,6 +124,57 @@ namespace Hina.CLI.Commands
             Console.WriteLine("Publisher subcommands:");
             Console.WriteLine("  sign-descriptor --in <hina.app.json> --key <ed25519.priv.b64> [--out <path>]");
             Console.WriteLine("                       Attach an Ed25519 signature to a descriptor file.");
+            Console.WriteLine();
+            Console.WriteLine("Sandbox subcommand:");
+            Console.WriteLine("  sandbox-run --app-dir <dir> [--allow <path>[:ro|:rw] ...] [--host] -- <exec> [args...]");
+            Console.WriteLine("                       Apply a filesystem sandbox (Landlock on Linux) then exec.");
+        }
+
+        // `hina dev sandbox-run --app-dir <dir> [--allow <path>[:ro|:rw] ...] [--host] -- <exec> [args...]`
+        // Applies a filesystem sandbox (Landlock on Linux) then execs the command. On
+        // success the process image is replaced, so the exec's exit code is the result.
+        // Drives the Landlock integration test; also useful for manual sandbox probing.
+        private static int RunSandbox(string[] args, ILogger logger)
+        {
+            string? appDir = Args.GetValue(args, "--app-dir");
+            if (string.IsNullOrWhiteSpace(appDir))
+            {
+                logger.LogError("Missing required --app-dir <path>");
+                return 2;
+            }
+
+            // Everything after the first bare "--" is the command to run.
+            int sep = Array.IndexOf(args, "--");
+            if (sep < 0 || sep + 1 >= args.Length)
+            {
+                logger.LogError("Missing '-- <exec> [args...]'");
+                return 2;
+            }
+            string exec = args[sep + 1];
+            System.Collections.Generic.List<string> execArgs = new System.Collections.Generic.List<string>();
+            for (int i = sep + 2; i < args.Length; i++) execArgs.Add(args[i]);
+
+            // Collect every --allow <path>[:ro|:rw] before the separator.
+            System.Collections.Generic.List<ResolvedFsRule> rules = new System.Collections.Generic.List<ResolvedFsRule>
+            {
+                new ResolvedFsRule(Path.GetFullPath(appDir), canWrite: false),
+            };
+            bool unrestricted = false;
+            for (int i = 0; i < sep; i++)
+            {
+                if (args[i] == "--host") { unrestricted = true; continue; }
+                if (args[i] != "--allow" || i + 1 >= sep) continue;
+                string spec = args[++i];
+                bool rw = spec.EndsWith(":rw", StringComparison.Ordinal);
+                string p = (spec.EndsWith(":rw", StringComparison.Ordinal) || spec.EndsWith(":ro", StringComparison.Ordinal))
+                    ? spec[..^3] : spec;
+                rules.Add(new ResolvedFsRule(Path.GetFullPath(p), rw));
+            }
+
+            SandboxPlan plan = new SandboxPlan(unrestricted, rules);
+            ISandboxLauncher launcher = SandboxLauncherFactory.Current(logger);
+            logger.LogDebug("Sandbox backend supported: {Supported}", launcher.IsSupported);
+            return launcher.Launch(Path.GetFullPath(exec), execArgs, plan, CancellationToken.None);
         }
 
         // `hina dev sign-descriptor --in hina.app.json --key priv.b64 [--out path]`

--- a/Hina.CLI/Commands/PermsCommand.cs
+++ b/Hina.CLI/Commands/PermsCommand.cs
@@ -1,50 +1,45 @@
 using System;
+using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using System.Threading.Tasks;
+using Hina.PackageManager.Descriptor;
 using Hina.PackageManager.Registry;
+using Hina.PackageManager.Sandbox;
 using Microsoft.Extensions.Logging;
 
 namespace Hina.CLI.Commands
 {
-    // `hina perms <app> [--list] [--grant <path>[:ro|:rw]] [--revoke <path>]`
-    // Manages the user's runtime filesystem grants for a sandboxed app — the paths
-    // allowed beyond what the descriptor declared. Mutations take the registry lock.
+    // Aliases: perms / permissions / permessi.
+    //   hina perms [list]                  → table of all installed apps' permissions
+    //   hina perms <app>                   → full permission detail for one app
+    //   hina perms <app> --grant <path>[:ro|:rw] | --revoke <path>
+    //                                      → manage the user's runtime filesystem grants
+    // Mutations take the registry lock; reads go through the shared read-lock helper.
     internal static class PermsCommand
     {
         public static async Task<int> RunAsync(CommandContext ctx, string[] args)
         {
             string? name = Args.FirstPositional(args, startIndex: 1);
-            if (string.IsNullOrWhiteSpace(name))
-            {
-                ctx.Logger.LogError("Usage: hina perms <app> [--list] [--grant <path>[:ro|:rw]] [--revoke <path>]");
-                return 2;
-            }
-
             string? grant = Args.GetValue(args, "--grant");
             string? revoke = Args.GetValue(args, "--revoke");
 
-            // List-only path: read under lock, no write.
+            // No app (or the literal "list") and no mutation → overview table.
+            if ((string.IsNullOrWhiteSpace(name) || name == "list") && grant == null && revoke == null)
+            {
+                return await PrintTableAsync(ctx);
+            }
+
+            if (string.IsNullOrWhiteSpace(name))
+            {
+                ctx.Logger.LogError("Usage: hina perms [list] | <app> [--grant <path>[:ro|:rw]] [--revoke <path>]");
+                return 2;
+            }
+
+            // App given, no mutation → detail view.
             if (grant == null && revoke == null)
             {
-                Registry registry = await ctx.LoadRegistryLockedAsync();
-                if (!registry.Apps.TryGetValue(name, out InstalledApp? app))
-                {
-                    ctx.Logger.LogError("'{Name}' is not installed.", name);
-                    return 1;
-                }
-                if (app.UserGrants.Count == 0)
-                {
-                    Console.WriteLine($"{name}: no user grants.");
-                }
-                else
-                {
-                    Console.WriteLine($"{name} user grants:");
-                    foreach (FsGrant g in app.UserGrants)
-                    {
-                        Console.WriteLine($"  {g.Access}  {g.Path}");
-                    }
-                }
-                return 0;
+                return await PrintDetailAsync(ctx, name);
             }
 
             LockManager locks = ctx.NewLockManager();
@@ -77,6 +72,52 @@ namespace Hina.CLI.Commands
 
             await store.SaveAsync(reg, ctx.Ct);
             return 0;
+        }
+
+        private static async Task<int> PrintTableAsync(CommandContext ctx)
+        {
+            Registry registry = await ctx.LoadRegistryLockedAsync();
+            if (registry.Apps.Count == 0)
+            {
+                Console.WriteLine("No apps installed.");
+                return 0;
+            }
+
+            List<AppPermissions> perms = registry.Apps.Values
+                .OrderBy(a => a.Name, StringComparer.Ordinal)
+                .Select(a => AppPermissions.From(LoadDescriptorOrEmpty(ctx, a.Name), a))
+                .ToList();
+
+            Console.Write(PermissionsFormatter.Table(perms));
+            return 0;
+        }
+
+        private static async Task<int> PrintDetailAsync(CommandContext ctx, string name)
+        {
+            Registry registry = await ctx.LoadRegistryLockedAsync();
+            if (!registry.Apps.TryGetValue(name, out InstalledApp? app))
+            {
+                ctx.Logger.LogError("'{Name}' is not installed.", name);
+                return 1;
+            }
+
+            AppPermissions perms = AppPermissions.From(LoadDescriptorOrEmpty(ctx, name), app);
+            Console.Write(PermissionsFormatter.Detail(perms));
+            return 0;
+        }
+
+        // The cached descriptor carries the declared sandbox scope + capabilities.
+        // Pre-sandbox installs (or a missing/corrupt cache) simply read as "no
+        // sandbox declared" rather than failing the whole listing.
+        private static AppDescriptor LoadDescriptorOrEmpty(CommandContext ctx, string name)
+        {
+            string path = ctx.Paths.DescriptorCache(name);
+            if (File.Exists(path))
+            {
+                try { return DescriptorParser.Parse(File.ReadAllText(path)); }
+                catch { /* fall through to empty */ }
+            }
+            return new AppDescriptor { Name = name };
         }
 
         private static (string path, string access) ParseGrant(string spec)

--- a/Hina.CLI/Commands/PermsCommand.cs
+++ b/Hina.CLI/Commands/PermsCommand.cs
@@ -1,0 +1,101 @@
+using System;
+using System.IO;
+using System.Threading.Tasks;
+using Hina.PackageManager.Registry;
+using Microsoft.Extensions.Logging;
+
+namespace Hina.CLI.Commands
+{
+    // `hina perms <app> [--list] [--grant <path>[:ro|:rw]] [--revoke <path>]`
+    // Manages the user's runtime filesystem grants for a sandboxed app — the paths
+    // allowed beyond what the descriptor declared. Mutations take the registry lock.
+    internal static class PermsCommand
+    {
+        public static async Task<int> RunAsync(CommandContext ctx, string[] args)
+        {
+            string? name = Args.FirstPositional(args, startIndex: 1);
+            if (string.IsNullOrWhiteSpace(name))
+            {
+                ctx.Logger.LogError("Usage: hina perms <app> [--list] [--grant <path>[:ro|:rw]] [--revoke <path>]");
+                return 2;
+            }
+
+            string? grant = Args.GetValue(args, "--grant");
+            string? revoke = Args.GetValue(args, "--revoke");
+
+            // List-only path: read under lock, no write.
+            if (grant == null && revoke == null)
+            {
+                Registry registry = await ctx.LoadRegistryLockedAsync();
+                if (!registry.Apps.TryGetValue(name, out InstalledApp? app))
+                {
+                    ctx.Logger.LogError("'{Name}' is not installed.", name);
+                    return 1;
+                }
+                if (app.UserGrants.Count == 0)
+                {
+                    Console.WriteLine($"{name}: no user grants.");
+                }
+                else
+                {
+                    Console.WriteLine($"{name} user grants:");
+                    foreach (FsGrant g in app.UserGrants)
+                    {
+                        Console.WriteLine($"  {g.Access}  {g.Path}");
+                    }
+                }
+                return 0;
+            }
+
+            LockManager locks = ctx.NewLockManager();
+            using RegistryLock l = await locks.AcquireAsync(ctx.Ct);
+            RegistryStore store = ctx.NewRegistryStore();
+            Registry reg = await store.LoadAsync(ctx.Ct);
+
+            if (!reg.Apps.TryGetValue(name, out InstalledApp? target))
+            {
+                ctx.Logger.LogError("'{Name}' is not installed.", name);
+                return 1;
+            }
+
+            if (grant != null)
+            {
+                (string path, string access) = ParseGrant(grant);
+                target.UserGrants.RemoveAll(g => string.Equals(g.Path, path, StringComparison.Ordinal));
+                target.UserGrants.Add(new FsGrant { Path = path, Access = access });
+                ctx.Logger.LogInformation("Granted {Access} {Path} to '{Name}'.", access, path, name);
+            }
+
+            if (revoke != null)
+            {
+                string path = AbsPath(revoke);
+                int removed = target.UserGrants.RemoveAll(g => string.Equals(g.Path, path, StringComparison.Ordinal));
+                ctx.Logger.LogInformation(removed > 0
+                    ? $"Revoked {path} from '{name}'."
+                    : $"No grant for {path} on '{name}'.");
+            }
+
+            await store.SaveAsync(reg, ctx.Ct);
+            return 0;
+        }
+
+        private static (string path, string access) ParseGrant(string spec)
+        {
+            string access = "ro";
+            string pathPart = spec;
+            if (spec.EndsWith(":rw", StringComparison.Ordinal)) { access = "rw"; pathPart = spec[..^3]; }
+            else if (spec.EndsWith(":ro", StringComparison.Ordinal)) { pathPart = spec[..^3]; }
+            return (AbsPath(pathPart), access);
+        }
+
+        private static string AbsPath(string p)
+        {
+            if (p.StartsWith("~", StringComparison.Ordinal))
+            {
+                string home = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
+                p = home + p[1..];
+            }
+            return Path.GetFullPath(p);
+        }
+    }
+}

--- a/Hina.CLI/Commands/RunCommand.cs
+++ b/Hina.CLI/Commands/RunCommand.cs
@@ -1,0 +1,98 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Runtime.InteropServices;
+using System.Threading.Tasks;
+using Hina.PackageManager.Descriptor;
+using Hina.PackageManager.Registry;
+using Hina.PackageManager.Sandbox;
+using Microsoft.Extensions.Logging;
+
+namespace Hina.CLI.Commands
+{
+    // `hina run <app> [entryId] [-- appArgs...]`
+    // The launch chokepoint: shell shortcuts for sandboxed apps point here instead
+    // of at the app binary, so Hina can install the filesystem sandbox before exec.
+    internal static class RunCommand
+    {
+        public static async Task<int> RunAsync(CommandContext ctx, string[] args)
+        {
+            List<string> positionals = new List<string>();
+            List<string> appArgs = new List<string>();
+            bool afterSep = false;
+            for (int i = 1; i < args.Length; i++)
+            {
+                if (!afterSep && args[i] == "--") { afterSep = true; continue; }
+                (afterSep ? appArgs : positionals).Add(args[i]);
+            }
+
+            if (positionals.Count == 0)
+            {
+                ctx.Logger.LogError("Usage: hina run <app> [entryId] [-- args...]");
+                return 2;
+            }
+
+            string name = positionals[0];
+            string? entryId = positionals.Count > 1 ? positionals[1] : null;
+
+            Registry registry = await ctx.LoadRegistryLockedAsync();
+            if (!registry.Apps.TryGetValue(name, out InstalledApp? app))
+            {
+                ctx.Logger.LogError("'{Name}' is not installed.", name);
+                return 1;
+            }
+
+            string descPath = ctx.Paths.DescriptorCache(name);
+            if (!File.Exists(descPath))
+            {
+                ctx.Logger.LogError("Cached descriptor for '{Name}' is missing; cannot launch.", name);
+                return 1;
+            }
+            AppDescriptor desc = DescriptorParser.Parse(await File.ReadAllTextAsync(descPath, ctx.Ct));
+
+            string? execRel = ResolveExecRel(desc, entryId, out string? err);
+            if (execRel == null)
+            {
+                ctx.Logger.LogError("{Error}", err);
+                return 1;
+            }
+            string execAbs = Path.Combine(app.InstallPath, execRel);
+
+            SandboxPlan plan = desc.Sandbox?.Enabled == true
+                ? SandboxPlanner.Build(desc.Sandbox, app.UserGrants, app.InstallPath, SandboxEnv.FromSystem())
+                : new SandboxPlan(unrestricted: true, new List<ResolvedFsRule>());
+
+            ISandboxLauncher launcher = SandboxLauncherFactory.Current(ctx.Logger);
+            return launcher.Launch(execAbs, appArgs, plan, ctx.Ct);
+        }
+
+        private static string? ResolveExecRel(AppDescriptor desc, string? entryId, out string? err)
+        {
+            err = null;
+            if (entryId != null)
+            {
+                foreach (ShellEntry e in desc.Entries)
+                {
+                    if (string.Equals(e.Id, entryId, StringComparison.Ordinal)) return e.Exec;
+                }
+                err = $"entry '{entryId}' is not defined by this app.";
+                return null;
+            }
+            if (desc.Entries.Count > 0)
+            {
+                return desc.Entries[0].Exec;
+            }
+            string? fromMap = OsExec(desc.Exec);
+            if (fromMap == null) err = "app defines no entry or executable for this OS.";
+            return fromMap;
+        }
+
+        private static string? OsExec(ExecMap exec)
+        {
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux)) return exec.Linux;
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX)) return exec.Macos;
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows)) return exec.Windows;
+            return null;
+        }
+    }
+}

--- a/Hina.CLI/Commands/RunCommand.cs
+++ b/Hina.CLI/Commands/RunCommand.cs
@@ -42,13 +42,34 @@ namespace Hina.CLI.Commands
                 return 1;
             }
 
+            // Install dir can be gone if the user deleted it by hand. (Each logger template binds
+            // placeholders positionally, so every {Token} must have exactly one matching argument —
+            // no repeated tokens.)
+            if (!Directory.Exists(app.InstallPath))
+            {
+                ctx.Logger.LogError("Install directory for '{Name}' is missing ({Path}). Restore it with `hina reinstall`.", name, app.InstallPath);
+                return 1;
+            }
+
             string descPath = ctx.Paths.DescriptorCache(name);
             if (!File.Exists(descPath))
             {
-                ctx.Logger.LogError("Cached descriptor for '{Name}' is missing; cannot launch.", name);
+                // Never fall back to launching unsandboxed: without the descriptor we cannot know
+                // the app's sandbox scope, and silently dropping isolation would defeat the point.
+                ctx.Logger.LogError("Cached descriptor for '{Name}' is missing; cannot launch safely. Restore it with `hina reinstall`.", name);
                 return 1;
             }
-            AppDescriptor desc = DescriptorParser.Parse(await File.ReadAllTextAsync(descPath, ctx.Ct));
+
+            AppDescriptor desc;
+            try
+            {
+                desc = DescriptorParser.Parse(await File.ReadAllTextAsync(descPath, ctx.Ct));
+            }
+            catch (Exception ex)
+            {
+                ctx.Logger.LogError("Cached descriptor for '{Name}' is corrupt ({Message}); cannot launch safely. Restore it with `hina reinstall`.", name, ex.Message);
+                return 1;
+            }
 
             string? execRel = ResolveExecRel(desc, entryId, out string? err);
             if (execRel == null)
@@ -57,6 +78,11 @@ namespace Hina.CLI.Commands
                 return 1;
             }
             string execAbs = Path.Combine(app.InstallPath, execRel);
+            if (!File.Exists(execAbs))
+            {
+                ctx.Logger.LogError("Executable '{Exec}' is missing from '{Name}'. Restore it with `hina reinstall`.", execRel, name);
+                return 1;
+            }
 
             SandboxPlan plan = desc.Sandbox?.Enabled == true
                 ? SandboxPlanner.Build(desc.Sandbox, app.UserGrants, app.InstallPath, SandboxEnv.FromSystem())

--- a/Hina.CLI/Commands/UpdateCommand.cs
+++ b/Hina.CLI/Commands/UpdateCommand.cs
@@ -13,6 +13,7 @@ namespace Hina.CLI.Commands
             string? name = Args.FirstPositional(args, startIndex: 1);
             bool force = Args.HasFlag(args, "--force");
             bool allowDowngrade = Args.HasFlag(args, "--allow-downgrade");
+            bool acceptNewPerms = Args.HasFlag(args, "--accept-new-permissions");
 
             int jobs = 4;
             string? jobsArg = Args.GetValue(args, "--jobs");
@@ -26,6 +27,7 @@ namespace Hina.CLI.Commands
             {
                 Force = force,
                 AllowDowngrade = allowDowngrade,
+                AcceptNewPermissions = acceptNewPerms,
                 MaxParallelism = jobs,
                 Network = NetworkArgs.FromArgs(args)
             };

--- a/Hina.CLI/Commands/VerifyCommand.cs
+++ b/Hina.CLI/Commands/VerifyCommand.cs
@@ -15,15 +15,20 @@ namespace Hina.CLI.Commands
         public static async Task<int> RunAsync(CommandContext ctx, string[] args)
         {
             string? name = Args.FirstPositional(args, startIndex: 1);
-            bool repair = Args.HasFlag(args, "--repair");
+            // `hina repair [name]` is `hina verify [name] --repair`.
+            bool repair = Args.HasFlag(args, "--repair")
+                          || args[0].Equals("repair", StringComparison.OrdinalIgnoreCase);
 
             RegistryVerifier verifier = ctx.NewRegistryVerifier();
 
             try
             {
                 List<AppDiagnostic> diags = verifier.Inspect(name);
+                // Orphan artifacts (leftovers after a manual registry deletion) are global, not
+                // tied to one app — only meaningful for a whole-system check.
+                List<string> orphans = name == null ? verifier.FindOrphanArtifacts() : new List<string>();
 
-                if (diags.Count == 0)
+                if (diags.Count == 0 && orphans.Count == 0)
                 {
                     Console.WriteLine(name != null
                         ? $"'{name}' is not in the registry."
@@ -57,6 +62,16 @@ namespace Hina.CLI.Commands
                     }
                 }
 
+                if (orphans.Count > 0)
+                {
+                    problemCount++;
+                    Console.WriteLine($"orphaned artifacts (no registry entry): {orphans.Count}");
+                    foreach (string o in orphans)
+                    {
+                        Console.WriteLine($"  - orphan: {o}");
+                    }
+                }
+
                 if (problemCount == 0)
                 {
                     return 0;
@@ -65,13 +80,22 @@ namespace Hina.CLI.Commands
                 if (!repair)
                 {
                     Console.WriteLine();
-                    Console.WriteLine("Run `hina verify --repair` to remove orphaned entries and side-effects.");
+                    Console.WriteLine("Run `hina repair` to remove orphaned entries and side-effects.");
                     return 1;
                 }
 
                 Console.WriteLine();
                 Console.WriteLine("Repairing...");
                 List<AppRepairResult> repaired = await verifier.RepairAsync(name, ctx.Ct);
+
+                if (name == null)
+                {
+                    List<string> removedOrphans = await verifier.RepairOrphanArtifactsAsync(ctx.Ct);
+                    foreach (string o in removedOrphans)
+                    {
+                        Console.WriteLine($"  removed orphan artifact: {o}");
+                    }
+                }
 
                 int healed = 0;
                 foreach (AppRepairResult r in repaired)

--- a/Hina.CLI/Commands/VerifyCommand.cs
+++ b/Hina.CLI/Commands/VerifyCommand.cs
@@ -1,7 +1,10 @@
 using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
+using Hina.Core.Configuration;
+using Hina.Core.Patching;
 using Hina.PackageManager.Diagnostics;
+using Hina.PackageManager.Install;
 using Hina.PackageManager.Registry;
 using Microsoft.Extensions.Logging;
 
@@ -18,8 +21,11 @@ namespace Hina.CLI.Commands
             // `hina repair [name]` is `hina verify [name] --repair`.
             bool repair = Args.HasFlag(args, "--repair")
                           || args[0].Equals("repair", StringComparison.OrdinalIgnoreCase);
+            bool deep = Args.HasFlag(args, "--deep");
 
             RegistryVerifier verifier = ctx.NewRegistryVerifier();
+            bool suggestReinstall = false;
+            bool repairable = false;
 
             try
             {
@@ -51,6 +57,21 @@ namespace Hina.CLI.Commands
                     if (d.AppDirMissing)
                     {
                         Console.WriteLine($"  STATUS: app directory missing");
+                        repairable = true;
+                    }
+                    if (d.DanglingShellEntries.Count > 0 || d.DanglingHooks.Count > 0)
+                    {
+                        repairable = true;
+                    }
+                    if (d.DescriptorCacheMissing)
+                    {
+                        Console.WriteLine($"  - descriptor cache missing");
+                        suggestReinstall = true;
+                    }
+                    foreach (string f in d.MissingFiles)
+                    {
+                        Console.WriteLine($"  - missing file: {f}");
+                        suggestReinstall = true;
                     }
                     foreach (ShellEntryRecord entry in d.DanglingShellEntries)
                     {
@@ -65,10 +86,37 @@ namespace Hina.CLI.Commands
                 if (orphans.Count > 0)
                 {
                     problemCount++;
+                    repairable = true;
                     Console.WriteLine($"orphaned artifacts (no registry entry): {orphans.Count}");
                     foreach (string o in orphans)
                     {
                         Console.WriteLine($"  - orphan: {o}");
+                    }
+                }
+
+                // Deep check: re-fetch the manifest and hash every file (detects modified /
+                // truncated content the offline check can't). Needs network.
+                if (deep)
+                {
+                    Registry registry = await ctx.LoadRegistryLockedAsync();
+                    foreach (AppDiagnostic d in diags)
+                    {
+                        if (d.AppDirMissing || !registry.Apps.TryGetValue(d.Name, out InstalledApp? row)) continue;
+                        int broken = await DeepVerifyAsync(ctx, args, row);
+                        if (broken < 0)
+                        {
+                            Console.WriteLine($"{d.Name}: could not deep-verify (offline or manifest unavailable).");
+                        }
+                        else if (broken > 0)
+                        {
+                            problemCount++;
+                            suggestReinstall = true;
+                            Console.WriteLine($"{d.Name}: {broken} file(s) corrupt or missing (hash check).");
+                        }
+                        else
+                        {
+                            Console.WriteLine($"{d.Name} — deep check OK");
+                        }
                     }
                 }
 
@@ -77,10 +125,19 @@ namespace Hina.CLI.Commands
                     return 0;
                 }
 
-                if (!repair)
+                if (suggestReinstall)
                 {
                     Console.WriteLine();
-                    Console.WriteLine("Run `hina repair` to remove orphaned entries and side-effects.");
+                    Console.WriteLine("Some apps are missing files — run `hina reinstall <app>` to restore them.");
+                }
+
+                if (!repair)
+                {
+                    if (repairable)
+                    {
+                        Console.WriteLine();
+                        Console.WriteLine("Run `hina repair` to remove orphaned entries and dangling side-effects.");
+                    }
                     return 1;
                 }
 
@@ -118,6 +175,23 @@ namespace Hina.CLI.Commands
             {
                 ctx.Logger.LogError("Verify failed: {Message}", ex.Message);
                 return 2;
+            }
+        }
+
+        // Manifest hash verification for one app. Returns the broken-file count, 0 if all
+        // good, or -1 if the manifest couldn't be reached (offline / server down).
+        private static async Task<int> DeepVerifyAsync(CommandContext ctx, string[] args, InstalledApp app)
+        {
+            try
+            {
+                PatcherConfig cfg = NetworkArgs.FromArgs(args)
+                    .ToPatchConfig(app.BaseUrl, app.Channel, app.PublicKey, backup: false);
+                VerifyResult res = await new PatchClient(cfg).VerifyAsync(app.InstallPath, ctx.Ct);
+                return res.Success ? 0 : res.BrokenFiles.Count;
+            }
+            catch
+            {
+                return -1;
             }
         }
     }

--- a/Hina.PackageManager.Tests/AppPermissionsTests.cs
+++ b/Hina.PackageManager.Tests/AppPermissionsTests.cs
@@ -1,0 +1,71 @@
+using System.Collections.Generic;
+using Hina.PackageManager.Descriptor;
+using Hina.PackageManager.Registry;
+using Hina.PackageManager.Sandbox;
+
+namespace Hina.PackageManager.Tests
+{
+    public class AppPermissionsTests
+    {
+        private static AppDescriptor Desc(SandboxSpec? sandbox) => new AppDescriptor
+        {
+            Name = "demo",
+            Sandbox = sandbox,
+        };
+
+        [Fact]
+        public void From_NoSandbox_AllFalseEmpty()
+        {
+            AppPermissions p = AppPermissions.From(Desc(null), new InstalledApp { Name = "demo" });
+
+            Assert.Equal("demo", p.Name);
+            Assert.False(p.SandboxEnabled);
+            Assert.Empty(p.FilesystemDeclared);
+            Assert.Empty(p.UserGrants);
+            Assert.False(p.Network);
+            Assert.False(p.Devices);
+        }
+
+        [Fact]
+        public void From_MapsFilesystemAndGrants()
+        {
+            SandboxSpec s = new SandboxSpec
+            {
+                Enabled = true,
+                Filesystem = new List<FsRule> { new FsRule { Path = "home", Access = "ro" } },
+            };
+            InstalledApp app = new InstalledApp
+            {
+                Name = "demo",
+                UserGrants = new List<FsGrant> { new FsGrant { Path = "/home/u/Music", Access = "rw" } },
+            };
+
+            AppPermissions p = AppPermissions.From(Desc(s), app);
+
+            Assert.True(p.SandboxEnabled);
+            Assert.Single(p.FilesystemDeclared);
+            Assert.Equal("home", p.FilesystemDeclared[0].Path);
+            Assert.Single(p.UserGrants);
+            Assert.Equal("/home/u/Music", p.UserGrants[0].Path);
+        }
+
+        [Fact]
+        public void From_MapsCapabilities()
+        {
+            SandboxSpec s = new SandboxSpec
+            {
+                Enabled = true,
+                Capabilities = new CapabilitySpec { Network = true, Microphone = true, Devices = true },
+            };
+
+            AppPermissions p = AppPermissions.From(Desc(s), new InstalledApp { Name = "demo" });
+
+            Assert.True(p.Network);
+            Assert.True(p.Microphone);
+            Assert.True(p.Devices);
+            Assert.False(p.Audio);
+            Assert.False(p.Screen);
+            Assert.False(p.Input);
+        }
+    }
+}

--- a/Hina.PackageManager.Tests/AtomicFileTests.cs
+++ b/Hina.PackageManager.Tests/AtomicFileTests.cs
@@ -1,0 +1,40 @@
+using System.IO;
+using Hina.PackageManager.Io;
+using Xunit;
+
+namespace Hina.PackageManager.Tests
+{
+    public class AtomicFileTests
+    {
+        [Fact]
+        public void WriteAllText_WritesContent_AndLeavesNoTmp()
+        {
+            string dir = Path.Combine(Path.GetTempPath(), "hina-atomic-" + Path.GetRandomFileName());
+            Directory.CreateDirectory(dir);
+            try
+            {
+                string target = Path.Combine(dir, "sub", "file.json");
+                AtomicFile.WriteAllText(target, "{\"a\":1}");
+
+                Assert.Equal("{\"a\":1}", File.ReadAllText(target));
+                Assert.False(File.Exists(target + ".tmp"), "temp file must be renamed away");
+            }
+            finally { Directory.Delete(dir, recursive: true); }
+        }
+
+        [Fact]
+        public void WriteAllText_OverwritesExisting()
+        {
+            string dir = Path.Combine(Path.GetTempPath(), "hina-atomic-" + Path.GetRandomFileName());
+            Directory.CreateDirectory(dir);
+            try
+            {
+                string target = Path.Combine(dir, "file.txt");
+                File.WriteAllText(target, "old");
+                AtomicFile.WriteAllText(target, "new");
+                Assert.Equal("new", File.ReadAllText(target));
+            }
+            finally { Directory.Delete(dir, recursive: true); }
+        }
+    }
+}

--- a/Hina.PackageManager.Tests/DescriptorValidatorInjectionTests.cs
+++ b/Hina.PackageManager.Tests/DescriptorValidatorInjectionTests.cs
@@ -37,6 +37,32 @@ namespace Hina.PackageManager.Tests
         }
 
         [Theory]
+        [InlineData("main")]
+        [InlineData("Main-2")]
+        [InlineData("com.acme.app_v1")]
+        public void EntryId_SafeCharset_IsAccepted(string id)
+        {
+            AppDescriptor d = Base();
+            d.Entries[0].Id = id;
+            Assert.True(DescriptorValidator.Validate(d).IsValid, string.Join("; ", DescriptorValidator.Validate(d).Errors));
+        }
+
+        [Theory]
+        [InlineData("x;touch /tmp/pwned")]   // shell metachars (reaches .desktop Exec via launchOverride)
+        [InlineData("main app")]              // space splits the freedesktop Exec line
+        [InlineData("../evil")]               // path separator (also the .desktop filename)
+        [InlineData("a\tb")]                  // control char
+        [InlineData("-leading")]              // must start alphanumeric
+        public void EntryId_UnsafeCharset_IsRejected(string id)
+        {
+            AppDescriptor d = Base();
+            d.Entries[0].Id = id;
+            ValidationResult r = DescriptorValidator.Validate(d);
+            Assert.False(r.IsValid);
+            Assert.Contains(r.Errors, e => e.Contains("id"));
+        }
+
+        [Theory]
         [InlineData("text/plain\nExec=/bin/sh")]
         [InlineData("not a mime")]
         [InlineData("text/")]

--- a/Hina.PackageManager.Tests/IntegrityTests.cs
+++ b/Hina.PackageManager.Tests/IntegrityTests.cs
@@ -1,0 +1,77 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using Hina.PackageManager.Diagnostics;
+using Hina.PackageManager.Paths;
+using Hina.PackageManager.Registry;
+using Xunit;
+
+namespace Hina.PackageManager.Tests
+{
+    // `hina verify` local integrity: detects a missing executable / missing entry files
+    // inside an existing install dir, and a missing descriptor cache.
+    public class IntegrityTests : IDisposable
+    {
+        private readonly string _root;
+        private readonly InstallPaths _paths;
+        private readonly FakePlatformIntegration _platform = new FakePlatformIntegration();
+        private readonly string _appDir;
+
+        public IntegrityTests()
+        {
+            _root = Path.Combine(Path.GetTempPath(), "hina-integrity-" + Path.GetRandomFileName());
+            _appDir = Path.Combine(_root, "Apps", "demo");
+            Directory.CreateDirectory(Path.Combine(_appDir, "bin"));
+            _paths = InstallPaths.ForRoot(_root);
+            Seed();
+        }
+
+        public void Dispose()
+        {
+            try { Directory.Delete(_root, recursive: true); } catch { }
+        }
+
+        private void Seed()
+        {
+            File.WriteAllText(Path.Combine(_appDir, "bin", "demo"), "#!/bin/sh\n");
+            Registry.Registry reg = new Registry.Registry();
+            reg.Apps["demo"] = new InstalledApp { Name = "demo", InstalledVersion = "1.0.0", InstallPath = _appDir };
+            new RegistryStore(_paths.RegistryFile).SaveAsync(reg).GetAwaiter().GetResult();
+
+            Directory.CreateDirectory(_paths.DescriptorCacheRoot);
+            File.WriteAllText(_paths.DescriptorCache("demo"),
+                "{\"name\":\"demo\",\"exec\":{\"windows\":\"bin/demo\",\"linux\":\"bin/demo\",\"macos\":\"bin/demo\"}," +
+                "\"entries\":[{\"id\":\"main\",\"name\":\"Demo\",\"exec\":\"bin/demo\"}]}");
+        }
+
+        private AppDiagnostic Inspect() => new RegistryVerifier(_paths, _platform).Inspect("demo").Single();
+
+        [Fact]
+        public void Healthy_WhenAllFilesPresent()
+        {
+            AppDiagnostic d = Inspect();
+            Assert.True(d.IsHealthy, string.Join(",", d.MissingFiles));
+            Assert.Empty(d.MissingFiles);
+            Assert.False(d.DescriptorCacheMissing);
+        }
+
+        [Fact]
+        public void DetectsMissingExecutable()
+        {
+            File.Delete(Path.Combine(_appDir, "bin", "demo"));
+            AppDiagnostic d = Inspect();
+            Assert.False(d.IsHealthy);
+            Assert.Contains(d.MissingFiles, f => f.Contains("bin/demo"));
+        }
+
+        [Fact]
+        public void DetectsMissingDescriptorCache()
+        {
+            File.Delete(_paths.DescriptorCache("demo"));
+            AppDiagnostic d = Inspect();
+            Assert.True(d.DescriptorCacheMissing);
+            Assert.False(d.IsHealthy);
+        }
+    }
+}

--- a/Hina.PackageManager.Tests/LinuxSandboxShortcutTests.cs
+++ b/Hina.PackageManager.Tests/LinuxSandboxShortcutTests.cs
@@ -1,0 +1,61 @@
+using System;
+using System.IO;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Hina.PackageManager.Descriptor;
+using Hina.PackageManager.Platform.Linux;
+using Xunit;
+
+namespace Hina.PackageManager.Tests
+{
+    // When an app is sandboxed, its .desktop launcher must route through `hina run`
+    // (the launchOverride) instead of pointing straight at the app binary — otherwise
+    // clicking the icon bypasses the sandbox entirely.
+    public class LinuxSandboxShortcutTests : IDisposable
+    {
+        private readonly string _tempDir;
+        private readonly LinuxPlatformIntegration _platform;
+
+        public LinuxSandboxShortcutTests()
+        {
+            _tempDir = Path.Combine(Path.GetTempPath(), "hina-sbx-" + Path.GetRandomFileName());
+            Directory.CreateDirectory(_tempDir);
+            _platform = new LinuxPlatformIntegration(
+                Path.Combine(_tempDir, "bin"),
+                Path.Combine(_tempDir, "apps"),
+                Path.Combine(_tempDir, "fonts"),
+                Path.Combine(_tempDir, "autostart"));
+        }
+
+        public void Dispose()
+        {
+            try { Directory.Delete(_tempDir, recursive: true); } catch { }
+        }
+
+        private static async Task<string> ExecLine(string path)
+        {
+            string[] lines = await File.ReadAllLinesAsync(path);
+            return lines.Single(l => l.StartsWith("Exec=", StringComparison.Ordinal));
+        }
+
+        private static ShellEntry Entry() => new ShellEntry { Id = "main", Name = "Demo", Exec = "bin/demo" };
+
+        [Fact]
+        public async Task LaunchOverride_SetsExecToOverride()
+        {
+            string path = await _platform.CreateMenuShortcut(Entry(), "/apps/demo", "hina run demo main", CancellationToken.None);
+            string exec = await ExecLine(path);
+            Assert.Contains("hina run demo main", exec);
+            Assert.DoesNotContain("/apps/demo/bin/demo", exec);
+        }
+
+        [Fact]
+        public async Task NullOverride_PointsAtAppBinary()
+        {
+            string path = await _platform.CreateMenuShortcut(Entry(), "/apps/demo", null, CancellationToken.None);
+            string exec = await ExecLine(path);
+            Assert.Contains("/apps/demo/bin/demo", exec);
+        }
+    }
+}

--- a/Hina.PackageManager.Tests/NoOpSandboxTests.cs
+++ b/Hina.PackageManager.Tests/NoOpSandboxTests.cs
@@ -1,0 +1,34 @@
+using System.Collections.Generic;
+using Hina.PackageManager.Sandbox;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace Hina.PackageManager.Tests
+{
+    public class NoOpSandboxTests
+    {
+        private static readonly SandboxPlan EmptyPlan = new SandboxPlan(false, new List<ResolvedFsRule>());
+
+        [Fact]
+        public void IsSupported_IsFalse()
+        {
+            Assert.False(new NoOpSandbox(NullLogger.Instance).IsSupported);
+        }
+
+        [Fact]
+        public void Launch_RunsProcess_ReturnsExitCode()
+        {
+            NoOpSandbox sandbox = new NoOpSandbox(NullLogger.Instance);
+            int code = sandbox.Launch("/bin/sh", new List<string> { "-c", "exit 7" }, EmptyPlan, default);
+            Assert.Equal(7, code);
+        }
+
+        [Fact]
+        public void Launch_PassesArgs()
+        {
+            NoOpSandbox sandbox = new NoOpSandbox(NullLogger.Instance);
+            // sh -c 'exit $#' arg0 a b c  -> exit code = number of extra args after the -c command name
+            int code = sandbox.Launch("/bin/sh", new List<string> { "-c", "exit $#", "x", "a", "b" }, EmptyPlan, default);
+            Assert.Equal(2, code);
+        }
+    }
+}

--- a/Hina.PackageManager.Tests/OrphanArtifactsTests.cs
+++ b/Hina.PackageManager.Tests/OrphanArtifactsTests.cs
@@ -1,0 +1,98 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Hina.PackageManager.Diagnostics;
+using Hina.PackageManager.Paths;
+using Hina.PackageManager.Platform.Linux;
+using Hina.PackageManager.Registry;
+using Xunit;
+
+namespace Hina.PackageManager.Tests
+{
+    // `hina repair` orphan scan: artifacts left on disk after a manual registry deletion —
+    // a hina-*.desktop with no registry row referencing it — are detected and removed, while
+    // referenced ones are left alone.
+    public class OrphanArtifactsTests : IDisposable
+    {
+        private readonly string _root;
+        private readonly string _appsDir;
+        private readonly InstallPaths _paths;
+        private readonly LinuxPlatformIntegration _platform;
+
+        public OrphanArtifactsTests()
+        {
+            _root = Path.Combine(Path.GetTempPath(), "hina-orphan-" + Path.GetRandomFileName());
+            _appsDir = Path.Combine(_root, "applications");
+            Directory.CreateDirectory(_appsDir);
+            _paths = InstallPaths.ForRoot(_root);
+            _platform = new LinuxPlatformIntegration(
+                Path.Combine(_root, "bin"), _appsDir,
+                Path.Combine(_root, "fonts"), Path.Combine(_root, "autostart"));
+        }
+
+        public void Dispose()
+        {
+            try { Directory.Delete(_root, recursive: true); } catch { }
+        }
+
+        private string MakeDesktop(string name)
+        {
+            string p = Path.Combine(_appsDir, name);
+            File.WriteAllText(p, "[Desktop Entry]\nX-Hina-Managed=true\n");
+            return p;
+        }
+
+        private void SeedRegistryReferencing(string referencedDesktopPath)
+        {
+            Registry.Registry reg = new Registry.Registry();
+            reg.Apps["demo"] = new InstalledApp
+            {
+                Name = "demo",
+                InstallPath = _root, // exists
+                ShellEntries = { new ShellEntryRecord { Id = "main", Evidence = referencedDesktopPath } },
+            };
+            new RegistryStore(_paths.RegistryFile).SaveAsync(reg).GetAwaiter().GetResult();
+        }
+
+        [Fact]
+        public void FindOrphanArtifacts_DetectsOnlyUnreferenced()
+        {
+            string referenced = MakeDesktop("hina-main.desktop");
+            string orphan = MakeDesktop("hina-ghost.desktop");
+            SeedRegistryReferencing(referenced);
+
+            List<string> orphans = new RegistryVerifier(_paths, _platform).FindOrphanArtifacts();
+
+            Assert.Contains(orphan, orphans);
+            Assert.DoesNotContain(referenced, orphans);
+        }
+
+        [Fact]
+        public async Task RepairOrphanArtifacts_RemovesOrphan_KeepsReferenced()
+        {
+            string referenced = MakeDesktop("hina-main.desktop");
+            string orphan = MakeDesktop("hina-ghost.desktop");
+            SeedRegistryReferencing(referenced);
+
+            List<string> removed = await new RegistryVerifier(_paths, _platform).RepairOrphanArtifactsAsync(CancellationToken.None);
+
+            Assert.Contains(orphan, removed);
+            Assert.False(File.Exists(orphan), "orphan must be deleted");
+            Assert.True(File.Exists(referenced), "referenced artifact must survive");
+        }
+
+        [Fact]
+        public void FindOrphanArtifacts_IgnoresNonHinaFiles()
+        {
+            File.WriteAllText(Path.Combine(_appsDir, "firefox.desktop"), "[Desktop Entry]\n");
+            SeedRegistryReferencing(MakeDesktop("hina-main.desktop"));
+
+            List<string> orphans = new RegistryVerifier(_paths, _platform).FindOrphanArtifacts();
+
+            Assert.DoesNotContain(orphans, p => p.EndsWith("firefox.desktop", StringComparison.Ordinal));
+        }
+    }
+}

--- a/Hina.PackageManager.Tests/PermissionsFormatterTests.cs
+++ b/Hina.PackageManager.Tests/PermissionsFormatterTests.cs
@@ -1,0 +1,98 @@
+using System.Collections.Generic;
+using Hina.PackageManager.Descriptor;
+using Hina.PackageManager.Registry;
+using Hina.PackageManager.Sandbox;
+
+namespace Hina.PackageManager.Tests
+{
+    public class PermissionsFormatterTests
+    {
+        private static AppPermissions Sample() => new AppPermissions
+        {
+            Name = "signal",
+            SandboxEnabled = true,
+            FilesystemDeclared = new List<FsRule>
+            {
+                new FsRule { Path = "home", Access = "ro" },
+                new FsRule { Path = "xdg-documents", Access = "rw" },
+            },
+            UserGrants = new List<FsGrant> { new FsGrant { Path = "/home/u/Music", Access = "rw" } },
+            Network = true,
+            Microphone = true,
+        };
+
+        [Fact]
+        public void Table_HasHeaderAndLegend()
+        {
+            string t = PermissionsFormatter.Table(new[] { Sample() });
+            Assert.Contains("APP", t);
+            Assert.Contains("NET", t);
+            Assert.Contains("DEV", t);
+            // Legend must state only filesystem is enforced.
+            Assert.Contains("only filesystem", t.ToLowerInvariant());
+        }
+
+        [Fact]
+        public void Table_RowShowsDeclaredMarks()
+        {
+            string t = PermissionsFormatter.Table(new[] { Sample() });
+            Assert.Contains("signal", t);
+            // declared capability marker present, undeclared shown as dash
+            Assert.Contains("✓", t);
+            Assert.Contains("—", t);
+        }
+
+        [Fact]
+        public void Table_HostScopeFlaggedLoudly()
+        {
+            AppPermissions p = new AppPermissions
+            {
+                Name = "gimp",
+                SandboxEnabled = true,
+                FilesystemDeclared = new List<FsRule> { new FsRule { Path = "host", Access = "rw" } },
+            };
+            string t = PermissionsFormatter.Table(new[] { p });
+            Assert.Contains("host(!)", t);
+        }
+
+        [Fact]
+        public void Table_UnsandboxedAppRowRendered()
+        {
+            string t = PermissionsFormatter.Table(new[]
+            {
+                new AppPermissions { Name = "oldapp", SandboxEnabled = false },
+            });
+            Assert.Contains("oldapp", t);
+            Assert.Contains("no", t);
+        }
+
+        [Fact]
+        public void Detail_ListsEnforcedFilesystemAndGrants()
+        {
+            string d = PermissionsFormatter.Detail(Sample());
+            Assert.Contains("signal", d);
+            Assert.Contains("home", d);
+            Assert.Contains("/home/u/Music", d);
+            Assert.Contains("user grant", d.ToLowerInvariant());
+            Assert.Contains("enforced", d.ToLowerInvariant());
+        }
+
+        [Fact]
+        public void Detail_CapabilitiesShowNotEnforcedCaveat()
+        {
+            string d = PermissionsFormatter.Detail(Sample());
+            Assert.Contains("Network", d);
+            Assert.Contains("Microphone", d);
+            // declared caps carry the not-enforced marker
+            Assert.Contains("not enforced", d.ToLowerInvariant());
+        }
+
+        [Fact]
+        public void Detail_DisabledSandboxWarnsNoIsolation()
+        {
+            string d = PermissionsFormatter.Detail(new AppPermissions { Name = "oldapp", SandboxEnabled = false });
+            Assert.Contains("oldapp", d);
+            Assert.Contains("no isolation", d.ToLowerInvariant());
+        }
+    }
+}

--- a/Hina.PackageManager.Tests/SandboxDiffTests.cs
+++ b/Hina.PackageManager.Tests/SandboxDiffTests.cs
@@ -1,0 +1,97 @@
+using System.Collections.Generic;
+using System.Linq;
+using Hina.PackageManager.Descriptor;
+using Hina.PackageManager.Sandbox;
+
+namespace Hina.PackageManager.Tests
+{
+    public class SandboxDiffTests
+    {
+        private static SandboxSpec Sb(bool enabled, IEnumerable<(string path, string access)>? fs = null, CapabilitySpec? caps = null)
+            => new SandboxSpec
+            {
+                Enabled = enabled,
+                Filesystem = (fs ?? System.Array.Empty<(string, string)>())
+                    .Select(t => new FsRule { Path = t.path, Access = t.access }).ToList(),
+                Capabilities = caps,
+            };
+
+        [Fact]
+        public void NoChange_NotBroadened()
+        {
+            SandboxSpec s = Sb(true, new[] { ("home", "ro") });
+            Assert.False(SandboxDiff.Compute(s, Sb(true, new[] { ("home", "ro") })).Broadened);
+        }
+
+        [Fact]
+        public void NewPath_Broadened()
+        {
+            SandboxDiff d = SandboxDiff.Compute(Sb(true, new[] { ("home", "ro") }),
+                                                Sb(true, new[] { ("home", "ro"), ("xdg-documents", "ro") }));
+            Assert.True(d.Broadened);
+            Assert.Contains(d.Added, a => a.Contains("xdg-documents"));
+        }
+
+        [Fact]
+        public void RoToRw_Broadened()
+        {
+            SandboxDiff d = SandboxDiff.Compute(Sb(true, new[] { ("home", "ro") }),
+                                                Sb(true, new[] { ("home", "rw") }));
+            Assert.True(d.Broadened);
+        }
+
+        [Fact]
+        public void HostAdded_Broadened()
+        {
+            SandboxDiff d = SandboxDiff.Compute(Sb(true, new[] { ("home", "ro") }),
+                                                Sb(true, new[] { ("host", "rw") }));
+            Assert.True(d.Broadened);
+            Assert.Contains(d.Added, a => a.Contains("host"));
+        }
+
+        [Fact]
+        public void CapabilityAdded_Broadened()
+        {
+            SandboxDiff d = SandboxDiff.Compute(Sb(true), Sb(true, caps: new CapabilitySpec { Network = true }));
+            Assert.True(d.Broadened);
+            Assert.Contains(d.Added, a => a.ToLowerInvariant().Contains("network"));
+        }
+
+        [Fact]
+        public void SandboxRemoved_Broadened()
+        {
+            // Was sandboxed, new version drops it entirely → app regains full access.
+            SandboxDiff d = SandboxDiff.Compute(Sb(true, new[] { ("home", "ro") }), Sb(false));
+            Assert.True(d.Broadened);
+        }
+
+        [Fact]
+        public void PathRemoved_NotBroadened()
+        {
+            SandboxDiff d = SandboxDiff.Compute(Sb(true, new[] { ("home", "ro"), ("tmp", "rw") }),
+                                                Sb(true, new[] { ("home", "ro") }));
+            Assert.False(d.Broadened);
+            Assert.Contains(d.Removed, r => r.Contains("tmp"));
+        }
+
+        [Fact]
+        public void RwToRo_NotBroadened()
+        {
+            Assert.False(SandboxDiff.Compute(Sb(true, new[] { ("home", "rw") }),
+                                             Sb(true, new[] { ("home", "ro") })).Broadened);
+        }
+
+        [Fact]
+        public void SandboxNewlyEnabled_NotBroadened()
+        {
+            // Was unsandboxed (full access), new version sandboxes it → strictly narrowing.
+            Assert.False(SandboxDiff.Compute(null, Sb(true, new[] { ("home", "ro") })).Broadened);
+        }
+
+        [Fact]
+        public void BothUnsandboxed_NotBroadened()
+        {
+            Assert.False(SandboxDiff.Compute(null, null).Broadened);
+        }
+    }
+}

--- a/Hina.PackageManager.Tests/SandboxPlannerTests.cs
+++ b/Hina.PackageManager.Tests/SandboxPlannerTests.cs
@@ -1,0 +1,97 @@
+using System.Collections.Generic;
+using System.Linq;
+using Hina.PackageManager.Descriptor;
+using Hina.PackageManager.Registry;
+using Hina.PackageManager.Sandbox;
+
+namespace Hina.PackageManager.Tests
+{
+    public class SandboxPlannerTests
+    {
+        private static readonly SandboxEnv Env = new SandboxEnv(
+            home: "/home/u",
+            documents: "/home/u/Documents",
+            download: "/home/u/Downloads",
+            config: "/home/u/.config",
+            tmp: "/tmp");
+
+        private const string AppDir = "/apps/demo";
+
+        [Fact]
+        public void Resolve_App_IsInstallDir()
+        {
+            Assert.Equal(AppDir, SandboxPaths.Resolve(SandboxTokens.App, AppDir, Env));
+        }
+
+        [Fact]
+        public void Resolve_XdgDocuments_UsesEnv()
+        {
+            Assert.Equal("/home/u/Documents", SandboxPaths.Resolve(SandboxTokens.XdgDocuments, AppDir, Env));
+        }
+
+        [Fact]
+        public void Resolve_Host_IsNull()
+        {
+            Assert.Null(SandboxPaths.Resolve(SandboxTokens.Host, AppDir, Env));
+        }
+
+        [Fact]
+        public void Build_AlwaysIncludesAppDirReadOnly()
+        {
+            SandboxSpec spec = new SandboxSpec { Enabled = true };
+            SandboxPlan plan = SandboxPlanner.Build(spec, new List<FsGrant>(), AppDir, Env);
+
+            Assert.False(plan.Unrestricted);
+            ResolvedFsRule appRule = plan.Rules.Single(r => r.Path == AppDir);
+            Assert.False(appRule.CanWrite);
+        }
+
+        [Fact]
+        public void Build_HostRule_MarksUnrestricted()
+        {
+            SandboxSpec spec = new SandboxSpec
+            {
+                Enabled = true,
+                Filesystem = new List<FsRule> { new FsRule { Path = SandboxTokens.Host, Access = "rw" } },
+            };
+            SandboxPlan plan = SandboxPlanner.Build(spec, new List<FsGrant>(), AppDir, Env);
+            Assert.True(plan.Unrestricted);
+        }
+
+        [Fact]
+        public void Build_RwRule_IsWritable()
+        {
+            SandboxSpec spec = new SandboxSpec
+            {
+                Enabled = true,
+                Filesystem = new List<FsRule> { new FsRule { Path = SandboxTokens.XdgDocuments, Access = "rw" } },
+            };
+            SandboxPlan plan = SandboxPlanner.Build(spec, new List<FsGrant>(), AppDir, Env);
+            ResolvedFsRule docs = plan.Rules.Single(r => r.Path == "/home/u/Documents");
+            Assert.True(docs.CanWrite);
+        }
+
+        [Fact]
+        public void Build_UserGrants_AreIncluded()
+        {
+            SandboxSpec spec = new SandboxSpec { Enabled = true };
+            List<FsGrant> grants = new List<FsGrant> { new FsGrant { Path = "/home/u/Music", Access = "ro" } };
+            SandboxPlan plan = SandboxPlanner.Build(spec, grants, AppDir, Env);
+            Assert.Contains(plan.Rules, r => r.Path == "/home/u/Music" && !r.CanWrite);
+        }
+
+        [Fact]
+        public void Build_DuplicatePath_RwWins()
+        {
+            SandboxSpec spec = new SandboxSpec
+            {
+                Enabled = true,
+                Filesystem = new List<FsRule> { new FsRule { Path = SandboxTokens.XdgConfig, Access = "ro" } },
+            };
+            List<FsGrant> grants = new List<FsGrant> { new FsGrant { Path = "/home/u/.config", Access = "rw" } };
+            SandboxPlan plan = SandboxPlanner.Build(spec, grants, AppDir, Env);
+            ResolvedFsRule cfg = plan.Rules.Single(r => r.Path == "/home/u/.config");
+            Assert.True(cfg.CanWrite);
+        }
+    }
+}

--- a/Hina.PackageManager.Tests/SandboxValidationTests.cs
+++ b/Hina.PackageManager.Tests/SandboxValidationTests.cs
@@ -1,0 +1,80 @@
+using System.Collections.Generic;
+using Hina.Core.Crypto;
+using Hina.PackageManager.Descriptor;
+
+namespace Hina.PackageManager.Tests
+{
+    public class SandboxValidationTests
+    {
+        private static AppDescriptor WithSandbox(SandboxSpec? sandbox)
+        {
+            (_, string pub) = KeyGenerator.GenerateEd25519();
+            return new AppDescriptor
+            {
+                SchemaVersion = 1,
+                Name = "demo",
+                DisplayName = "Demo",
+                Version = "1.0.0",
+                Publisher = "Acme",
+                Channel = "stable",
+                BaseUrl = "https://example.com/demo/",
+                PublicKey = pub,
+                Exec = new ExecMap { Linux = "bin/demo" },
+                Sandbox = sandbox,
+            };
+        }
+
+        [Fact]
+        public void Validate_NoSandbox_IsValid()
+        {
+            Assert.True(DescriptorValidator.Validate(WithSandbox(null)).IsValid);
+        }
+
+        [Fact]
+        public void Validate_SandboxDisabledEmpty_IsValid()
+        {
+            Assert.True(DescriptorValidator.Validate(WithSandbox(new SandboxSpec { Enabled = false })).IsValid);
+        }
+
+        [Theory]
+        [InlineData("home", "ro")]
+        [InlineData("xdg-documents", "rw")]
+        [InlineData("app", "ro")]
+        [InlineData("host", "rw")]
+        public void Validate_KnownTokenAndAccess_IsValid(string path, string access)
+        {
+            SandboxSpec s = new SandboxSpec
+            {
+                Enabled = true,
+                Filesystem = new List<FsRule> { new FsRule { Path = path, Access = access } },
+            };
+            Assert.True(DescriptorValidator.Validate(WithSandbox(s)).IsValid);
+        }
+
+        [Fact]
+        public void Validate_UnknownToken_IsRejected()
+        {
+            SandboxSpec s = new SandboxSpec
+            {
+                Enabled = true,
+                Filesystem = new List<FsRule> { new FsRule { Path = "/etc/passwd", Access = "ro" } },
+            };
+            ValidationResult r = DescriptorValidator.Validate(WithSandbox(s));
+            Assert.False(r.IsValid);
+            Assert.Contains(r.Errors, e => e.Contains("sandbox"));
+        }
+
+        [Fact]
+        public void Validate_BadAccess_IsRejected()
+        {
+            SandboxSpec s = new SandboxSpec
+            {
+                Enabled = true,
+                Filesystem = new List<FsRule> { new FsRule { Path = "home", Access = "rwx" } },
+            };
+            ValidationResult r = DescriptorValidator.Validate(WithSandbox(s));
+            Assert.False(r.IsValid);
+            Assert.Contains(r.Errors, e => e.Contains("sandbox"));
+        }
+    }
+}

--- a/Hina.PackageManager.Tests/UpdateServiceTests.cs
+++ b/Hina.PackageManager.Tests/UpdateServiceTests.cs
@@ -322,6 +322,73 @@ namespace Hina.PackageManager.Tests
             await install.InstallAsync(new Uri(descriptorUrl), new InstallOptions { AssumeTrustOnFirstUse = true }, CancellationToken.None);
         }
 
+        private async Task InstallSandboxedV1(SandboxSpec sandbox)
+        {
+            AppDescriptor v1 = BuildDescriptor(_pubKey, version: "1.0.0");
+            v1.Sandbox = sandbox;
+            DescriptorSigner.AttachSignature(v1, Convert.FromBase64String(_privKey));
+            InstallService install = new InstallService(
+                _paths, _platform,
+                fetcher: new StubFetcher(v1),
+                patchClientFactory: cfg => new FakePatchClient(cfg, NewExecFiles()));
+            await install.InstallAsync(new Uri("https://example.com/demo.json"),
+                new InstallOptions { AssumeTrustOnFirstUse = true }, CancellationToken.None);
+        }
+
+        private async Task<UpdateResult> UpdateToSandboxed(SandboxSpec? sandbox, bool acceptNewPerms)
+        {
+            AppDescriptor v2 = BuildDescriptor(_pubKey, version: "1.1.0");
+            v2.Sandbox = sandbox;
+            DescriptorSigner.AttachSignature(v2, Convert.FromBase64String(_privKey));
+            UpdateService svc = new UpdateService(
+                _paths, _platform,
+                fetcher: new StubFetcher(v2),
+                patchClientFactory: cfg => new FakePatchClient(cfg, NewExecFiles()));
+            return await svc.UpdateAsync("demo",
+                new UpdateOptions { AcceptNewPermissions = acceptNewPerms }, CancellationToken.None);
+        }
+
+        private static SandboxSpec Sandbox(string path, string access) => new SandboxSpec
+        {
+            Enabled = true,
+            Filesystem = { new FsRule { Path = path, Access = access } },
+        };
+
+        [Fact]
+        public async Task Update_BroaderPermissions_WithoutConsent_IsRefused()
+        {
+            await InstallSandboxedV1(Sandbox("home", "ro"));
+
+            UpdateResult result = await UpdateToSandboxed(Sandbox("home", "rw"), acceptNewPerms: false);
+
+            Assert.Equal(UpdateStatus.Failed, result.Status);
+            Assert.Contains("permission", result.Message.ToLowerInvariant());
+            Registry.Registry reg = new RegistryStore(_paths.RegistryFile).Load();
+            Assert.Equal("1.0.0", reg.Apps["demo"].InstalledVersion);
+        }
+
+        [Fact]
+        public async Task Update_BroaderPermissions_WithConsent_Proceeds()
+        {
+            await InstallSandboxedV1(Sandbox("home", "ro"));
+
+            UpdateResult result = await UpdateToSandboxed(Sandbox("home", "rw"), acceptNewPerms: true);
+
+            Assert.Equal(UpdateStatus.Updated, result.Status);
+            Registry.Registry reg = new RegistryStore(_paths.RegistryFile).Load();
+            Assert.Equal("1.1.0", reg.Apps["demo"].InstalledVersion);
+        }
+
+        [Fact]
+        public async Task Update_NarrowerPermissions_ProceedsWithoutConsent()
+        {
+            await InstallSandboxedV1(Sandbox("home", "rw"));
+
+            UpdateResult result = await UpdateToSandboxed(Sandbox("home", "ro"), acceptNewPerms: false);
+
+            Assert.Equal(UpdateStatus.Updated, result.Status);
+        }
+
         private static AppDescriptor BuildDescriptor(string publicKey, string name = "demo", string version = "1.0.0")
         {
             return new AppDescriptor

--- a/Hina.PackageManager/Descriptor/AppDescriptor.cs
+++ b/Hina.PackageManager/Descriptor/AppDescriptor.cs
@@ -26,6 +26,9 @@ namespace Hina.PackageManager.Descriptor
         public List<ShellEntry> Entries { get; set; } = new List<ShellEntry>();
         public List<HookAction> PostInstall { get; set; } = new List<HookAction>();
 
+        // Optional Flatpak-style filesystem isolation. Null/disabled ⇒ unsandboxed.
+        public SandboxSpec? Sandbox { get; set; }
+
         public DescriptorSignature? DescriptorSignature { get; set; }
     }
 }

--- a/Hina.PackageManager/Descriptor/CapabilitySpec.cs
+++ b/Hina.PackageManager/Descriptor/CapabilitySpec.cs
@@ -1,0 +1,17 @@
+namespace Hina.PackageManager.Descriptor
+{
+    // Non-filesystem capabilities an app declares in its signed sandbox block.
+    // v1 does NOT enforce any of these — only filesystem scope is enforced
+    // (Linux/Landlock). They are declared intent, surfaced to the user by
+    // `hina perms` with a "declared — not enforced" marker. Enforcement (portals,
+    // PipeWire, Wayland, per-OS device policy) is future work.
+    public sealed class CapabilitySpec
+    {
+        public bool Network { get; set; }
+        public bool Audio { get; set; }
+        public bool Microphone { get; set; }
+        public bool Screen { get; set; }
+        public bool Input { get; set; }
+        public bool Devices { get; set; }
+    }
+}

--- a/Hina.PackageManager/Descriptor/DescriptorValidator.cs
+++ b/Hina.PackageManager/Descriptor/DescriptorValidator.cs
@@ -132,7 +132,33 @@ namespace Hina.PackageManager.Descriptor
                 errors.Add($"minHinaVersion '{descriptor.MinHinaVersion}' is not valid SemVer.");
             }
 
+            ValidateSandbox(descriptor.Sandbox, errors);
+
             return new ValidationResult(errors);
+        }
+
+        private static void ValidateSandbox(SandboxSpec? sandbox, List<string> errors)
+        {
+            if (sandbox == null)
+            {
+                return;
+            }
+
+            for (int i = 0; i < sandbox.Filesystem.Count; i++)
+            {
+                FsRule rule = sandbox.Filesystem[i];
+                string prefix = $"sandbox.filesystem[{i}]";
+
+                if (!SandboxTokens.IsKnown(rule.Path))
+                {
+                    errors.Add($"{prefix}.path '{rule.Path}' is not a known sandbox path token.");
+                }
+
+                if (rule.Access != "ro" && rule.Access != "rw")
+                {
+                    errors.Add($"{prefix}.access '{rule.Access}' must be 'ro' or 'rw'.");
+                }
+            }
         }
 
         private static void ValidateHook(HookAction hook, int index, HashSet<string> entryIds, List<string> errors)

--- a/Hina.PackageManager/Descriptor/DescriptorValidator.cs
+++ b/Hina.PackageManager/Descriptor/DescriptorValidator.cs
@@ -23,6 +23,10 @@ namespace Hina.PackageManager.Descriptor
         private static readonly Regex SchemeRegex = new Regex(@"^[a-z][a-z0-9+.-]{0,63}$", RegexOptions.Compiled);
         private static readonly Regex ExtensionRegex = new Regex(@"^\.?[A-Za-z0-9][A-Za-z0-9._-]{0,63}$", RegexOptions.Compiled);
         private static readonly Regex CategoryRegex = new Regex(@"^[A-Za-z0-9-]{1,64}$", RegexOptions.Compiled);
+        // entries[].id is written into the .desktop filename (SanitizeId) and, for sandboxed apps,
+        // into the .desktop Exec= line via the `hina run <app> <id>` launchOverride. Constrain it to
+        // a safe token so a signed-but-hostile descriptor can't inject metacharacters / path separators.
+        private static readonly Regex EntryIdRegex = new Regex(@"^[A-Za-z0-9][A-Za-z0-9._-]{0,63}$", RegexOptions.Compiled);
 
         public static ValidationResult Validate(AppDescriptor descriptor, ValidationContext? ctx = null)
         {
@@ -93,6 +97,10 @@ namespace Hina.PackageManager.Descriptor
                 if (string.IsNullOrWhiteSpace(e.Id))
                 {
                     errors.Add($"{prefix}.id is required.");
+                }
+                else if (!EntryIdRegex.IsMatch(e.Id))
+                {
+                    errors.Add($"{prefix}.id '{e.Id}' must match {EntryIdRegex}.");
                 }
                 else if (!entryIds.Add(e.Id))
                 {

--- a/Hina.PackageManager/Descriptor/SandboxSpec.cs
+++ b/Hina.PackageManager/Descriptor/SandboxSpec.cs
@@ -1,0 +1,28 @@
+using System.Collections.Generic;
+
+namespace Hina.PackageManager.Descriptor
+{
+    // Optional Flatpak-style filesystem isolation block in hina.app.json.
+    // Absent or Enabled=false ⇒ the app launches unsandboxed (legacy behavior).
+    // When Enabled, the app sees only the install dir plus the paths listed here
+    // (and any extra paths the user grants at runtime). Linux-only enforcement in
+    // v1 (Landlock); other OSes degrade to no-op. Filesystem-only — network and
+    // devices are not restricted yet.
+    public sealed class SandboxSpec
+    {
+        public bool Enabled { get; set; }
+
+        public List<FsRule> Filesystem { get; set; } = new List<FsRule>();
+    }
+
+    // A requested filesystem grant. Path is an abstract token (never a raw host
+    // path) so the same descriptor resolves correctly across machines/users.
+    public sealed class FsRule
+    {
+        // One of SandboxTokens.Known. "host" means no filesystem restriction.
+        public string Path { get; set; } = string.Empty;
+
+        // "ro" (read-only) or "rw" (read-write). Exec is implied for the app dir only.
+        public string Access { get; set; } = "ro";
+    }
+}

--- a/Hina.PackageManager/Descriptor/SandboxSpec.cs
+++ b/Hina.PackageManager/Descriptor/SandboxSpec.cs
@@ -13,6 +13,10 @@ namespace Hina.PackageManager.Descriptor
         public bool Enabled { get; set; }
 
         public List<FsRule> Filesystem { get; set; } = new List<FsRule>();
+
+        // Declared non-filesystem capabilities (network, audio, …). Not enforced
+        // in v1 — shown to the user as declared intent. Null ⇒ none declared.
+        public CapabilitySpec? Capabilities { get; set; }
     }
 
     // A requested filesystem grant. Path is an abstract token (never a raw host

--- a/Hina.PackageManager/Descriptor/SandboxTokens.cs
+++ b/Hina.PackageManager/Descriptor/SandboxTokens.cs
@@ -1,0 +1,29 @@
+using System;
+using System.Collections.Generic;
+
+namespace Hina.PackageManager.Descriptor
+{
+    // The closed set of abstract path tokens a sandbox FsRule may name. Kept here
+    // (next to the wire model) so both DescriptorValidator and the runtime path
+    // resolver agree on what's legal. Unknown tokens are rejected at validation —
+    // fail closed, never silently grant.
+    public static class SandboxTokens
+    {
+        // App install directory. Always implicitly granted (ro+exec); listing it is harmless.
+        public const string App = "app";
+        public const string Home = "home";
+        public const string XdgDocuments = "xdg-documents";
+        public const string XdgDownload = "xdg-download";
+        public const string XdgConfig = "xdg-config";
+        public const string Tmp = "tmp";
+        // Escape hatch: no filesystem restriction. Must be explicit and surfaced loudly.
+        public const string Host = "host";
+
+        public static readonly IReadOnlySet<string> Known = new HashSet<string>(StringComparer.Ordinal)
+        {
+            App, Home, XdgDocuments, XdgDownload, XdgConfig, Tmp, Host,
+        };
+
+        public static bool IsKnown(string token) => Known.Contains(token);
+    }
+}

--- a/Hina.PackageManager/Diagnostics/RegistryVerifier.cs
+++ b/Hina.PackageManager/Diagnostics/RegistryVerifier.cs
@@ -75,6 +75,62 @@ namespace Hina.PackageManager.Diagnostics
             return results;
         }
 
+        // Read-only. Hina-managed artifacts on disk that NO registry row references —
+        // the leftovers after a manual `registry.json` (or whole-row) deletion that
+        // per-app Inspect/Repair can't see. Empty on platforms without an artifact scanner.
+        public List<string> FindOrphanArtifacts()
+        {
+            Registry.Registry registry = new RegistryStore(_paths.RegistryFile, _logger).Load();
+            HashSet<string> referenced = ReferencedArtifactPaths(registry);
+
+            List<string> orphans = new List<string>();
+            foreach (string path in _platform.EnumerateManagedArtifacts())
+            {
+                if (!referenced.Contains(path)) orphans.Add(path);
+            }
+            return orphans;
+        }
+
+        // Mutating. Removes the orphan artifacts found above (fail-soft). Takes the lock
+        // so the registry read used to compute "referenced" is consistent with writers.
+        public async Task<List<string>> RepairOrphanArtifactsAsync(CancellationToken ct)
+        {
+            LockManager locks = new LockManager(_paths.LockFile);
+            using RegistryLock l = await locks.AcquireAsync(ct);
+
+            Registry.Registry registry = new RegistryStore(_paths.RegistryFile, _logger).Load();
+            HashSet<string> referenced = ReferencedArtifactPaths(registry);
+
+            List<string> removed = new List<string>();
+            foreach (string path in _platform.EnumerateManagedArtifacts())
+            {
+                if (referenced.Contains(path)) continue;
+                // RemoveMenuShortcut is a plain fail-soft file delete; reused for any artifact path.
+                try { await _platform.RemoveMenuShortcut(path, ct); removed.Add(path); }
+                catch { /* fail-soft */ }
+            }
+            return removed;
+        }
+
+        // Every artifact path the registry still points at. Font hook evidence packs
+        // multiple paths joined with '|' (see HookExecutor), so split on it.
+        private static HashSet<string> ReferencedArtifactPaths(Registry.Registry registry)
+        {
+            HashSet<string> referenced = new HashSet<string>(StringComparer.Ordinal);
+            foreach (InstalledApp app in registry.Apps.Values)
+            {
+                foreach (ShellEntryRecord e in app.ShellEntries) referenced.Add(e.Evidence);
+                foreach (HookEvidence ev in app.ExecutedHooks)
+                {
+                    foreach (string p in ev.Evidence.Split('|', StringSplitOptions.RemoveEmptyEntries))
+                    {
+                        referenced.Add(p);
+                    }
+                }
+            }
+            return referenced;
+        }
+
         // Mutating. Takes the registry lock for the duration of repairs.
         public async Task<List<AppRepairResult>> RepairAsync(string? appName, CancellationToken ct)
         {

--- a/Hina.PackageManager/Diagnostics/RegistryVerifier.cs
+++ b/Hina.PackageManager/Diagnostics/RegistryVerifier.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
+using Hina.PackageManager.Descriptor;
 using Hina.PackageManager.Hooks;
 using Hina.PackageManager.Install;
 using Hina.PackageManager.Paths;
@@ -70,9 +71,45 @@ namespace Hina.PackageManager.Diagnostics
                         d.DanglingHooks.Add(ev);
                     }
                 }
+
+                // Local integrity: the cached descriptor tells us which files the app must
+                // have. Only meaningful when the dir itself is present.
+                if (!d.AppDirMissing)
+                {
+                    CheckFiles(app, d);
+                }
                 results.Add(d);
             }
             return results;
+        }
+
+        // Confirms the files the cached descriptor says the app must have actually exist.
+        // A missing executable / entry file means the install is incomplete (deleted by hand
+        // or a botched patch) — reinstall, not repair, is the fix.
+        private void CheckFiles(InstalledApp app, AppDiagnostic d)
+        {
+            string descPath = _paths.DescriptorCache(app.Name);
+            if (!File.Exists(descPath))
+            {
+                d.DescriptorCacheMissing = true;
+                return;
+            }
+
+            AppDescriptor descriptor;
+            try { descriptor = DescriptorParser.Parse(File.ReadAllText(descPath)); }
+            catch { d.DescriptorCacheMissing = true; return; }
+
+            void Require(string? rel)
+            {
+                if (string.IsNullOrEmpty(rel)) return;
+                if (!File.Exists(Path.Combine(app.InstallPath, rel)) && !d.MissingFiles.Contains(rel))
+                {
+                    d.MissingFiles.Add(rel);
+                }
+            }
+
+            Require(InstallService.ExecForCurrentOs(descriptor));
+            foreach (ShellEntry e in descriptor.Entries) Require(e.Exec);
         }
 
         // Read-only. Hina-managed artifacts on disk that NO registry row references —
@@ -246,10 +283,13 @@ namespace Hina.PackageManager.Diagnostics
         public string Version { get; set; } = string.Empty;
         public string InstallPath { get; set; } = string.Empty;
         public bool AppDirMissing { get; set; }
+        public bool DescriptorCacheMissing { get; set; }
+        public List<string> MissingFiles { get; } = new List<string>();
         public List<ShellEntryRecord> DanglingShellEntries { get; } = new List<ShellEntryRecord>();
         public List<HookEvidence> DanglingHooks { get; } = new List<HookEvidence>();
 
-        public bool IsHealthy => !AppDirMissing && DanglingShellEntries.Count == 0 && DanglingHooks.Count == 0;
+        public bool IsHealthy => !AppDirMissing && !DescriptorCacheMissing && MissingFiles.Count == 0
+            && DanglingShellEntries.Count == 0 && DanglingHooks.Count == 0;
     }
 
     public sealed class AppRepairResult

--- a/Hina.PackageManager/Install/InstallService.cs
+++ b/Hina.PackageManager/Install/InstallService.cs
@@ -8,6 +8,7 @@ using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using Hina.Core.Configuration;
+using Hina.PackageManager.Io;
 using Hina.Core.Patching;
 using Hina.PackageManager.Descriptor;
 using Hina.PackageManager.Hooks;
@@ -176,17 +177,22 @@ namespace Hina.PackageManager.Install
                 }
 
                 // [12] Shell entries. Sandboxed apps launch via `hina run` so the
-                // filesystem sandbox is installed before the app process starts.
-                bool sandboxed = descriptor.Sandbox?.Enabled == true;
-                if (sandboxed)
+                // filesystem sandbox is installed before the app process starts — but only Linux
+                // enforces it today. On other OSes the launchOverride is ignored (the app launches
+                // directly), so we must NOT route through `hina run` (it would gain nothing) and we
+                // must tell the user the sandbox is not actually enforced here.
+                bool sandboxRequested = descriptor.Sandbox?.Enabled == true;
+                bool sandboxEnforceable = RuntimeInformation.IsOSPlatform(OSPlatform.Linux);
+                if (sandboxRequested)
                 {
-                    DiscloseSandbox(descriptor.Sandbox!);
+                    DiscloseSandbox(descriptor.Sandbox!, sandboxEnforceable);
                 }
+                bool routeThroughHina = sandboxRequested && sandboxEnforceable;
                 string hinaExe = Environment.ProcessPath ?? "hina";
                 foreach (ShellEntry entry in descriptor.Entries)
                 {
-                    string? launchOverride = sandboxed
-                        ? $"\"{hinaExe}\" run {descriptor.Name} {entry.Id}"
+                    string? launchOverride = routeThroughHina
+                        ? $"\"{hinaExe}\" run {descriptor.Name} \"{entry.Id}\""
                         : null;
                     string evidence = await _platform.CreateMenuShortcut(entry, appDir, launchOverride, ct);
                     tx.RecordShellEntry(evidence);
@@ -201,13 +207,15 @@ namespace Hina.PackageManager.Install
                     newApp.ExecutedHooks.Add(evidence);
                 }
 
-                // [14] Commit registry entry.
+                // [14] Cache descriptor FIRST (atomic), so the committed registry row below always
+                // has a readable descriptor — `run`/`perms`/`update` depend on it. A crash between
+                // the two writes then leaves a cache with no registry row (harmless) rather than a
+                // registry row with no cache (breaks run/perms).
+                AtomicFile.WriteAllText(_paths.DescriptorCache(descriptor.Name), DescriptorParser.Serialize(descriptor));
+
+                // [15] Commit registry entry.
                 registry.Apps[descriptor.Name] = newApp;
                 await store.SaveAsync(registry, ct);
-
-                // [15] Cache descriptor.
-                Directory.CreateDirectory(_paths.DescriptorCacheRoot);
-                await File.WriteAllTextAsync(_paths.DescriptorCache(descriptor.Name), DescriptorParser.Serialize(descriptor), ct);
             }
             catch
             {
@@ -223,11 +231,22 @@ namespace Hina.PackageManager.Install
             };
         }
 
-        // Tell the user exactly what filesystem scope a sandboxed app is getting,
-        // with extra emphasis on the unrestricted "host" escape hatch.
-        private void DiscloseSandbox(SandboxSpec sandbox)
+        // Tell the user exactly what filesystem scope a sandboxed app declares, with extra
+        // emphasis on the unrestricted "host" escape hatch. `enforceable` is false on OSes whose
+        // sandbox backend isn't implemented yet (macOS/Windows) — there the scope is declared but
+        // NOT applied, so we must say so plainly instead of implying isolation that won't happen.
+        private void DiscloseSandbox(SandboxSpec sandbox, bool enforceable)
         {
-            _logger.LogInformation("This app runs sandboxed. It can access only:");
+            if (!enforceable)
+            {
+                _logger.LogWarning(
+                    "This app DECLARES a filesystem sandbox, but Hina does not enforce sandboxing on this OS yet. " +
+                    "The app will run with FULL user privileges (no isolation). Its declared scope:");
+            }
+            else
+            {
+                _logger.LogInformation("This app runs sandboxed. It can access only:");
+            }
             _logger.LogInformation("  - its own install directory (read-only)");
             foreach (FsRule rule in sandbox.Filesystem)
             {
@@ -240,7 +259,10 @@ namespace Hina.PackageManager.Install
                     _logger.LogInformation("  - {Path} ({Access})", rule.Path, rule.Access);
                 }
             }
-            _logger.LogInformation("Grant more paths later with: hina perms {Name} --grant <path>[:rw]", "<app>");
+            if (enforceable)
+            {
+                _logger.LogInformation("Grant more paths later with: hina perms {Name} --grant <path>[:rw]", "<app>");
+            }
         }
 
         public static string? ExecForCurrentOs(AppDescriptor descriptor)

--- a/Hina.PackageManager/Install/InstallService.cs
+++ b/Hina.PackageManager/Install/InstallService.cs
@@ -175,10 +175,20 @@ namespace Hina.PackageManager.Install
                     throw new InvalidDataException($"Declared exec '{execRelative}' is missing from installed files.");
                 }
 
-                // [12] Shell entries.
+                // [12] Shell entries. Sandboxed apps launch via `hina run` so the
+                // filesystem sandbox is installed before the app process starts.
+                bool sandboxed = descriptor.Sandbox?.Enabled == true;
+                if (sandboxed)
+                {
+                    DiscloseSandbox(descriptor.Sandbox!);
+                }
+                string hinaExe = Environment.ProcessPath ?? "hina";
                 foreach (ShellEntry entry in descriptor.Entries)
                 {
-                    string evidence = await _platform.CreateMenuShortcut(entry, appDir, ct);
+                    string? launchOverride = sandboxed
+                        ? $"\"{hinaExe}\" run {descriptor.Name} {entry.Id}"
+                        : null;
+                    string evidence = await _platform.CreateMenuShortcut(entry, appDir, launchOverride, ct);
                     tx.RecordShellEntry(evidence);
                     newApp.ShellEntries.Add(new ShellEntryRecord { Id = entry.Id, Evidence = evidence });
                 }
@@ -211,6 +221,26 @@ namespace Hina.PackageManager.Install
                 Version = descriptor.Version,
                 InstallPath = appDir
             };
+        }
+
+        // Tell the user exactly what filesystem scope a sandboxed app is getting,
+        // with extra emphasis on the unrestricted "host" escape hatch.
+        private void DiscloseSandbox(SandboxSpec sandbox)
+        {
+            _logger.LogInformation("This app runs sandboxed. It can access only:");
+            _logger.LogInformation("  - its own install directory (read-only)");
+            foreach (FsRule rule in sandbox.Filesystem)
+            {
+                if (rule.Path == SandboxTokens.Host)
+                {
+                    _logger.LogWarning("  - host: UNRESTRICTED filesystem access ({Access}) — this app is NOT isolated.", rule.Access);
+                }
+                else
+                {
+                    _logger.LogInformation("  - {Path} ({Access})", rule.Path, rule.Access);
+                }
+            }
+            _logger.LogInformation("Grant more paths later with: hina perms {Name} --grant <path>[:rw]", "<app>");
         }
 
         public static string? ExecForCurrentOs(AppDescriptor descriptor)

--- a/Hina.PackageManager/Install/UpdateOptions.cs
+++ b/Hina.PackageManager/Install/UpdateOptions.cs
@@ -15,6 +15,12 @@ namespace Hina.PackageManager.Install
         // could otherwise force a rollback to a known-vulnerable version.
         public bool AllowDowngrade { get; init; }
 
+        // Consent to a new version that BROADENS the app's sandbox (new filesystem paths,
+        // host access, ro→rw, new capabilities, or dropping the sandbox entirely). Without
+        // this, such an update is refused so an app can't silently gain access across a
+        // version bump. Narrowing changes apply without it.
+        public bool AcceptNewPermissions { get; init; }
+
         // How many apps UpdateAllAsync updates concurrently. Each per-app update is
         // still serial within itself; this just lets the registry-of-N walk overlap
         // network and disk I/O across apps. Default 4 mirrors PatchClient.Concurrency.

--- a/Hina.PackageManager/Install/UpdateService.cs
+++ b/Hina.PackageManager/Install/UpdateService.cs
@@ -7,6 +7,7 @@ using Hina.Core.Configuration;
 using Hina.Core.Patching;
 using Hina.PackageManager.Descriptor;
 using Hina.PackageManager.Hooks;
+using Hina.PackageManager.Io;
 using Hina.PackageManager.Paths;
 using Hina.PackageManager.Platform;
 using Hina.PackageManager.Registry;
@@ -60,6 +61,19 @@ namespace Hina.PackageManager.Install
                     return new UpdateResult { Name = name, Status = UpdateStatus.Failed, Message = $"'{name}' is not installed." };
                 }
                 app = found;
+            }
+
+            // [0] The install dir can be gone if the user deleted it by hand. Patching a missing
+            // directory would crash mid-operation; fail cleanly and point at the recovery path.
+            if (!Directory.Exists(app.InstallPath))
+            {
+                return new UpdateResult
+                {
+                    Name = name,
+                    FromVersion = app.InstalledVersion,
+                    Status = UpdateStatus.Failed,
+                    Message = $"Install directory for '{name}' is missing ({app.InstallPath}). Run `hina reinstall {name}` to restore it."
+                };
             }
 
             // [1] Re-fetch descriptor.
@@ -344,13 +358,17 @@ namespace Hina.PackageManager.Install
                 };
             }
 
-            // [8] Refresh descriptor cache.
+            // [8] Refresh descriptor cache (atomic). Not fatal if it fails — a cache from the
+            // previous version already exists, so the worst case is `run`/`perms` showing stale
+            // scope until the next update/reinstall — but log it rather than swallow silently.
             try
             {
-                Directory.CreateDirectory(_paths.DescriptorCacheRoot);
-                await File.WriteAllTextAsync(_paths.DescriptorCache(name), DescriptorParser.Serialize(descriptor), ct);
+                AtomicFile.WriteAllText(_paths.DescriptorCache(name), DescriptorParser.Serialize(descriptor));
             }
-            catch { /* non-critical */ }
+            catch (Exception cacheEx)
+            {
+                _logger.LogWarning(cacheEx, "Updated {Name} but could not refresh its descriptor cache; run/perms may show stale scope until the next update.", name);
+            }
 
             return new UpdateResult
             {

--- a/Hina.PackageManager/Install/UpdateService.cs
+++ b/Hina.PackageManager/Install/UpdateService.cs
@@ -11,6 +11,7 @@ using Hina.PackageManager.Io;
 using Hina.PackageManager.Paths;
 using Hina.PackageManager.Platform;
 using Hina.PackageManager.Registry;
+using Hina.PackageManager.Sandbox;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 
@@ -175,6 +176,31 @@ namespace Hina.PackageManager.Install
             // longer lists them, so it can't be the restore source.
             InstalledApp previousSnapshot = CloneInstalledApp(app);
             AppDescriptor? previousDescriptor = TryLoadCachedDescriptor(name);
+
+            // [5a] Sandbox permission diff. A new version that BROADENS the app's access
+            // (new paths, host, ro→rw, new capabilities, or dropping the sandbox) must be
+            // consented to — refuse BEFORE touching disk so nothing is half-applied.
+            SandboxDiff permDiff = SandboxDiff.Compute(previousDescriptor?.Sandbox, descriptor.Sandbox);
+            if (permDiff.Broadened && !options.AcceptNewPermissions)
+            {
+                _logger.LogWarning("Update of {Name} requests BROADER permissions:", name);
+                foreach (string a in permDiff.Added) _logger.LogWarning("  + {Added}", a);
+                return new UpdateResult
+                {
+                    Name = name,
+                    FromVersion = app.InstalledVersion,
+                    ToVersion = descriptor.Version,
+                    Status = UpdateStatus.Failed,
+                    Message = $"'{name}' {descriptor.Version} requests broader permissions ({string.Join(", ", permDiff.Added)}). " +
+                              "Re-run with `--accept-new-permissions` to allow it."
+                };
+            }
+            if (permDiff.Added.Count > 0 || permDiff.Removed.Count > 0)
+            {
+                _logger.LogInformation("Permission changes for {Name}:", name);
+                foreach (string a in permDiff.Added) _logger.LogInformation("  + {Added}", a);
+                foreach (string r in permDiff.Removed) _logger.LogInformation("  - {Removed}", r);
+            }
 
             // [6] PatchClient delta.
             PatcherConfig patchCfg = options.Network.ToPatchConfig(

--- a/Hina.PackageManager/Io/AtomicFile.cs
+++ b/Hina.PackageManager/Io/AtomicFile.cs
@@ -1,0 +1,30 @@
+using System.IO;
+using System.Text;
+
+namespace Hina.PackageManager.Io
+{
+    // Crash-safe text write: serialize to a sibling .tmp, flush to disk, then
+    // atomically rename over the target. A crash mid-write leaves the old file
+    // intact (or no file) — never a truncated one. Same pattern RegistryStore
+    // uses for registry.json; centralised so the descriptor cache and any future
+    // small-file writes share it.
+    public static class AtomicFile
+    {
+        public static void WriteAllText(string path, string content)
+        {
+            string dir = Path.GetDirectoryName(path) ?? ".";
+            Directory.CreateDirectory(dir);
+
+            string tmp = path + ".tmp";
+            using (FileStream fs = new FileStream(tmp, FileMode.Create, FileAccess.Write, FileShare.None))
+            {
+                byte[] bytes = Encoding.UTF8.GetBytes(content);
+                fs.Write(bytes, 0, bytes.Length);
+                fs.Flush(flushToDisk: true);
+            }
+
+            // Atomic on POSIX and Windows for a same-volume rename.
+            File.Move(tmp, path, overwrite: true);
+        }
+    }
+}

--- a/Hina.PackageManager/Json/PackageManagerJsonContext.cs
+++ b/Hina.PackageManager/Json/PackageManagerJsonContext.cs
@@ -13,11 +13,14 @@ namespace Hina.PackageManager.Json
     [JsonSerializable(typeof(AutostartHook))]
     [JsonSerializable(typeof(ShellEntry))]
     [JsonSerializable(typeof(ExecMap))]
+    [JsonSerializable(typeof(SandboxSpec))]
+    [JsonSerializable(typeof(FsRule))]
     [JsonSerializable(typeof(DescriptorSignature))]
     [JsonSerializable(typeof(Registry.Registry))]
     [JsonSerializable(typeof(Registry.InstalledApp))]
     [JsonSerializable(typeof(Registry.HookEvidence))]
     [JsonSerializable(typeof(Registry.ShellEntryRecord))]
+    [JsonSerializable(typeof(Registry.FsGrant))]
     public partial class PackageManagerJsonContext : JsonSerializerContext { }
 
     [JsonSourceGenerationOptions(WriteIndented = true, PropertyNamingPolicy = JsonKnownNamingPolicy.CamelCase)]

--- a/Hina.PackageManager/Json/PackageManagerJsonContext.cs
+++ b/Hina.PackageManager/Json/PackageManagerJsonContext.cs
@@ -15,6 +15,7 @@ namespace Hina.PackageManager.Json
     [JsonSerializable(typeof(ExecMap))]
     [JsonSerializable(typeof(SandboxSpec))]
     [JsonSerializable(typeof(FsRule))]
+    [JsonSerializable(typeof(CapabilitySpec))]
     [JsonSerializable(typeof(DescriptorSignature))]
     [JsonSerializable(typeof(Registry.Registry))]
     [JsonSerializable(typeof(Registry.InstalledApp))]

--- a/Hina.PackageManager/Platform/IPlatformIntegration.cs
+++ b/Hina.PackageManager/Platform/IPlatformIntegration.cs
@@ -51,5 +51,13 @@ namespace Hina.PackageManager.Platform
         // the shellEntry / shellEntryLink synthetic actions documented in
         // RegistryVerifier.
         bool IsEvidenceDangling(string action, string evidence) => false;
+
+        // All Hina-managed artifact paths currently on disk, identified by their
+        // markers (e.g. X-Hina-Managed `.desktop` files, `hina-*` fonts) — independent
+        // of the registry. `hina repair` subtracts the registry-referenced ones to find
+        // true orphans left after a manual `registry.json` deletion. Default: none
+        // (platforms without an orphan scanner). Each path can be removed with
+        // RemoveMenuShortcut (a plain file delete).
+        System.Collections.Generic.IEnumerable<string> EnumerateManagedArtifacts() => System.Array.Empty<string>();
     }
 }

--- a/Hina.PackageManager/Platform/IPlatformIntegration.cs
+++ b/Hina.PackageManager/Platform/IPlatformIntegration.cs
@@ -14,6 +14,12 @@ namespace Hina.PackageManager.Platform
         string UserAppsDir { get; }
 
         Task<string> CreateMenuShortcut(ShellEntry entry, string appDir, CancellationToken ct);
+        // Sandbox-aware overload: when launchOverride is non-null the shortcut's launch
+        // command is set to it verbatim (e.g. "hina run app entry") instead of pointing
+        // directly at the app binary, so launches route through Hina's sandbox. Default
+        // impl ignores the override so platforms without a sandbox backend are unaffected.
+        Task<string> CreateMenuShortcut(ShellEntry entry, string appDir, string? launchOverride, CancellationToken ct)
+            => CreateMenuShortcut(entry, appDir, ct);
         Task RemoveMenuShortcut(string evidencePath, CancellationToken ct);
 
         Task<string> AddToPath(string name, string targetExec, CancellationToken ct);

--- a/Hina.PackageManager/Platform/Linux/LinuxPlatformIntegration.cs
+++ b/Hina.PackageManager/Platform/Linux/LinuxPlatformIntegration.cs
@@ -269,6 +269,32 @@ namespace Hina.PackageManager.Platform.Linux
             return Task.CompletedTask;
         }
 
+        // All Hina-managed artifacts on disk, by their `hina-*` filename marker: shortcuts +
+        // mime/url handlers in the applications dir, autostart entries, and per-app fonts. Bin
+        // symlinks are intentionally NOT scanned — they carry no Hina prefix, so distinguishing
+        // them from the user's own symlinks safely isn't possible. `hina repair` subtracts the
+        // registry-referenced paths from this to find true orphans.
+        public IEnumerable<string> EnumerateManagedArtifacts()
+        {
+            List<string> found = new List<string>();
+            AddManaged(found, _userAppsDir, "hina-*.desktop");
+            AddManaged(found, _userAutostartDir, "hina-*.desktop");
+            AddManaged(found, _userFontsDir, "hina-*");
+            return found;
+        }
+
+        private static void AddManaged(List<string> into, string dir, string pattern)
+        {
+            try
+            {
+                if (Directory.Exists(dir))
+                {
+                    into.AddRange(Directory.EnumerateFiles(dir, pattern));
+                }
+            }
+            catch { /* fail-soft: a scan error must not break repair */ }
+        }
+
         // ---- Helpers ----
 
         private static string Escape(string value)

--- a/Hina.PackageManager/Platform/Linux/LinuxPlatformIntegration.cs
+++ b/Hina.PackageManager/Platform/Linux/LinuxPlatformIntegration.cs
@@ -46,6 +46,9 @@ namespace Hina.PackageManager.Platform.Linux
         // ---- Menu shortcut ----
 
         public Task<string> CreateMenuShortcut(ShellEntry entry, string appDir, CancellationToken ct)
+            => CreateMenuShortcut(entry, appDir, launchOverride: null, ct);
+
+        public Task<string> CreateMenuShortcut(ShellEntry entry, string appDir, string? launchOverride, CancellationToken ct)
         {
             Directory.CreateDirectory(_userAppsDir);
 
@@ -55,11 +58,16 @@ namespace Hina.PackageManager.Platform.Linux
             string execAbs = Path.Combine(appDir, entry.Exec);
             string? iconAbs = entry.Icon != null ? Path.Combine(appDir, entry.Icon) : null;
 
+            // A sandboxed app routes through `hina run` (launchOverride) so the
+            // sandbox is installed before the app starts. The override is built by
+            // InstallService from trusted values (app name + validated entry id).
+            string execLine = launchOverride != null ? StripControl(launchOverride) : QuoteExec(execAbs);
+
             StringBuilder sb = new StringBuilder();
             sb.AppendLine("[Desktop Entry]");
             sb.AppendLine("Type=Application");
             sb.AppendLine($"Name={Escape(entry.Name)}");
-            sb.AppendLine($"Exec={QuoteExec(execAbs)}");
+            sb.AppendLine($"Exec={execLine}");
             if (iconAbs != null) sb.AppendLine($"Icon={Escape(iconAbs)}");
             sb.AppendLine($"Terminal={(entry.Terminal ? "true" : "false")}");
             if (entry.Categories.Count > 0)

--- a/Hina.PackageManager/Registry/Registry.cs
+++ b/Hina.PackageManager/Registry/Registry.cs
@@ -32,6 +32,19 @@ namespace Hina.PackageManager.Registry
         // same hooks/entries.
         public List<HookEvidence> ExecutedHooks { get; set; } = new List<HookEvidence>();
         public List<ShellEntryRecord> ShellEntries { get; set; } = new List<ShellEntryRecord>();
+
+        // Extra filesystem paths the user has granted this app at runtime, beyond
+        // what the descriptor's sandbox block declared. Absolute resolved paths.
+        // Additive and default-empty so older registries round-trip unchanged.
+        public List<FsGrant> UserGrants { get; set; } = new List<FsGrant>();
+    }
+
+    // A user-granted absolute filesystem path for a sandboxed app.
+    public sealed class FsGrant
+    {
+        public string Path { get; set; } = string.Empty;
+        // "ro" or "rw".
+        public string Access { get; set; } = "ro";
     }
 
     public sealed class HookEvidence

--- a/Hina.PackageManager/Sandbox/AppPermissions.cs
+++ b/Hina.PackageManager/Sandbox/AppPermissions.cs
@@ -1,0 +1,47 @@
+using System.Collections.Generic;
+using Hina.PackageManager.Descriptor;
+using Hina.PackageManager.Registry;
+
+namespace Hina.PackageManager.Sandbox
+{
+    // A flat, display-ready view of one app's permissions, folded from its cached
+    // descriptor (declared scope + capabilities) and registry row (user grants).
+    // Pure mapping — no I/O — so the CLI formatters stay trivial and testable.
+    public sealed class AppPermissions
+    {
+        public string Name { get; init; } = string.Empty;
+        public bool SandboxEnabled { get; init; }
+
+        // Filesystem is the only ENFORCED category (Linux/Landlock).
+        public IReadOnlyList<FsRule> FilesystemDeclared { get; init; } = new List<FsRule>();
+        public IReadOnlyList<FsGrant> UserGrants { get; init; } = new List<FsGrant>();
+
+        // Declared-only, not enforced in v1.
+        public bool Network { get; init; }
+        public bool Audio { get; init; }
+        public bool Microphone { get; init; }
+        public bool Screen { get; init; }
+        public bool Input { get; init; }
+        public bool Devices { get; init; }
+
+        public static AppPermissions From(AppDescriptor descriptor, InstalledApp app)
+        {
+            SandboxSpec? sandbox = descriptor.Sandbox;
+            CapabilitySpec caps = sandbox?.Capabilities ?? new CapabilitySpec();
+
+            return new AppPermissions
+            {
+                Name = app.Name,
+                SandboxEnabled = sandbox?.Enabled == true,
+                FilesystemDeclared = sandbox?.Filesystem ?? new List<FsRule>(),
+                UserGrants = app.UserGrants,
+                Network = caps.Network,
+                Audio = caps.Audio,
+                Microphone = caps.Microphone,
+                Screen = caps.Screen,
+                Input = caps.Input,
+                Devices = caps.Devices,
+            };
+        }
+    }
+}

--- a/Hina.PackageManager/Sandbox/ISandboxLauncher.cs
+++ b/Hina.PackageManager/Sandbox/ISandboxLauncher.cs
@@ -1,0 +1,21 @@
+using System.Collections.Generic;
+using System.Threading;
+
+namespace Hina.PackageManager.Sandbox
+{
+    // Per-OS sandboxed process launcher. Mirrors IPlatformIntegration's "one impl
+    // per OS, selected by a factory" shape. v1 enforces filesystem scope only.
+    //
+    // Launch semantics: the returned int is the app's exit code. A backend MAY
+    // replace the current process image (execve) instead of spawning a child — in
+    // that case Launch never returns on success and only throws on exec failure.
+    public interface ISandboxLauncher
+    {
+        // True when this host can actually enforce the plan (e.g. kernel supports
+        // Landlock). When false the launcher still runs the app, unsandboxed, after
+        // warning once — it must never block a launch.
+        bool IsSupported { get; }
+
+        int Launch(string execAbs, IReadOnlyList<string> appArgs, SandboxPlan plan, CancellationToken ct);
+    }
+}

--- a/Hina.PackageManager/Sandbox/LinuxLandlockSandbox.cs
+++ b/Hina.PackageManager/Sandbox/LinuxLandlockSandbox.cs
@@ -1,0 +1,227 @@
+using System;
+using System.Collections.Generic;
+using System.Runtime.InteropServices;
+using System.Threading;
+using Microsoft.Extensions.Logging;
+
+namespace Hina.PackageManager.Sandbox
+{
+    // Linux filesystem sandbox using Landlock (kernel 5.13+). Unprivileged, no
+    // root/bubblewrap. Strategy: build a ruleset that "handles" (i.e. denies by
+    // default) every filesystem access right the running ABI knows, then grant
+    // back only the resolved paths. Restrictions are applied to THIS process via
+    // landlock_restrict_self and then inherited across execv — so `hina run`
+    // replaces its own image with the sandboxed app (the app's PID is hina's).
+    //
+    // Enforcement is Linux-only; the P/Invoke declarations compile everywhere but
+    // are never called off Linux (the factory hands back NoOpSandbox instead).
+    public sealed class LinuxLandlockSandbox : ISandboxLauncher
+    {
+        // syscall numbers — identical on x86_64 and aarch64 (added together in 5.13).
+        private const long SYS_landlock_create_ruleset = 444;
+        private const long SYS_landlock_add_rule = 445;
+        private const long SYS_landlock_restrict_self = 446;
+
+        private const uint LANDLOCK_CREATE_RULESET_VERSION = 1u << 0;
+        private const int LANDLOCK_RULE_PATH_BENEATH = 1;
+
+        private const int PR_SET_NO_NEW_PRIVS = 38;
+        private const int O_PATH = 0x200000;
+        private const int O_CLOEXEC = 0x80000;
+
+        // Access-right bits (ABI v1 unless noted).
+        private const ulong FS_EXECUTE = 1ul << 0;
+        private const ulong FS_WRITE_FILE = 1ul << 1;
+        private const ulong FS_READ_FILE = 1ul << 2;
+        private const ulong FS_READ_DIR = 1ul << 3;
+        private const ulong FS_REMOVE_DIR = 1ul << 4;
+        private const ulong FS_REMOVE_FILE = 1ul << 5;
+        private const ulong FS_MAKE_CHAR = 1ul << 6;
+        private const ulong FS_MAKE_DIR = 1ul << 7;
+        private const ulong FS_MAKE_REG = 1ul << 8;
+        private const ulong FS_MAKE_SOCK = 1ul << 9;
+        private const ulong FS_MAKE_FIFO = 1ul << 10;
+        private const ulong FS_MAKE_BLOCK = 1ul << 11;
+        private const ulong FS_MAKE_SYM = 1ul << 12;
+        private const ulong FS_REFER = 1ul << 13;      // ABI v2
+        private const ulong FS_TRUNCATE = 1ul << 14;   // ABI v3
+
+        private readonly ILogger _logger;
+        private readonly int _abi;
+
+        public LinuxLandlockSandbox(ILogger logger)
+        {
+            _logger = logger;
+            _abi = ProbeAbi();
+        }
+
+        public bool IsSupported => _abi >= 1;
+
+        private static int ProbeAbi()
+        {
+            if (!OperatingSystem.IsLinux())
+            {
+                return 0;
+            }
+            try
+            {
+                long r = syscall(SYS_landlock_create_ruleset, IntPtr.Zero, UIntPtr.Zero, LANDLOCK_CREATE_RULESET_VERSION);
+                return r < 0 ? 0 : (int)r;
+            }
+            catch (DllNotFoundException)
+            {
+                return 0;
+            }
+            catch (EntryPointNotFoundException)
+            {
+                return 0;
+            }
+        }
+
+        public int Launch(string execAbs, IReadOnlyList<string> appArgs, SandboxPlan plan, CancellationToken ct)
+        {
+            if (plan.Unrestricted || !IsSupported)
+            {
+                // Nothing to enforce (host rule) or kernel can't — just exec.
+                return Exec(execAbs, appArgs);
+            }
+
+            ulong handled = HandledMask(_abi);
+
+            RulesetAttr attr = new RulesetAttr { handled_access_fs = handled };
+            long rulesetFd = syscall(SYS_landlock_create_ruleset, ref attr, (UIntPtr)Marshal.SizeOf<RulesetAttr>(), 0u);
+            if (rulesetFd < 0)
+            {
+                _logger.LogWarning("Landlock ruleset creation failed; running unsandboxed.");
+                return Exec(execAbs, appArgs);
+            }
+
+            try
+            {
+                foreach (ResolvedFsRule rule in plan.Rules)
+                {
+                    AddPath(rulesetFd, rule, handled);
+                }
+
+                if (prctl(PR_SET_NO_NEW_PRIVS, 1, 0, 0, 0) != 0)
+                {
+                    _logger.LogWarning("prctl(NO_NEW_PRIVS) failed; running unsandboxed.");
+                    return Exec(execAbs, appArgs);
+                }
+
+                if (syscall(SYS_landlock_restrict_self, (IntPtr)rulesetFd, 0u, 0u) != 0)
+                {
+                    _logger.LogWarning("landlock_restrict_self failed; running unsandboxed.");
+                    return Exec(execAbs, appArgs);
+                }
+            }
+            finally
+            {
+                close((int)rulesetFd);
+            }
+
+            // Restrictions now bound to this process; execv inherits them.
+            return Exec(execAbs, appArgs);
+        }
+
+        private void AddPath(long rulesetFd, ResolvedFsRule rule, ulong handled)
+        {
+            int fd = open(rule.Path, O_PATH | O_CLOEXEC, 0);
+            if (fd < 0)
+            {
+                // Path doesn't exist / unreadable — skip; it simply won't be granted.
+                _logger.LogDebug("Sandbox path '{Path}' could not be opened; skipping grant.", rule.Path);
+                return;
+            }
+            try
+            {
+                ulong allowed = (FS_READ_FILE | FS_READ_DIR | FS_EXECUTE);
+                if (rule.CanWrite)
+                {
+                    allowed |= FS_WRITE_FILE | FS_REMOVE_DIR | FS_REMOVE_FILE
+                             | FS_MAKE_CHAR | FS_MAKE_DIR | FS_MAKE_REG | FS_MAKE_SOCK
+                             | FS_MAKE_FIFO | FS_MAKE_BLOCK | FS_MAKE_SYM | FS_REFER | FS_TRUNCATE;
+                }
+                allowed &= handled;
+
+                PathBeneathAttr pb = new PathBeneathAttr { allowed_access = allowed, parent_fd = fd };
+                if (syscall(SYS_landlock_add_rule, (IntPtr)rulesetFd, (IntPtr)LANDLOCK_RULE_PATH_BENEATH, ref pb, 0u) != 0)
+                {
+                    _logger.LogWarning("Failed to add sandbox rule for '{Path}'.", rule.Path);
+                }
+            }
+            finally
+            {
+                close(fd);
+            }
+        }
+
+        private static ulong HandledMask(int abi)
+        {
+            ulong mask = FS_EXECUTE | FS_WRITE_FILE | FS_READ_FILE | FS_READ_DIR
+                       | FS_REMOVE_DIR | FS_REMOVE_FILE | FS_MAKE_CHAR | FS_MAKE_DIR
+                       | FS_MAKE_REG | FS_MAKE_SOCK | FS_MAKE_FIFO | FS_MAKE_BLOCK | FS_MAKE_SYM;
+            if (abi >= 2) mask |= FS_REFER;
+            if (abi >= 3) mask |= FS_TRUNCATE;
+            return mask;
+        }
+
+        // Replace the current process image. Returns only on failure.
+        private int Exec(string execAbs, IReadOnlyList<string> appArgs)
+        {
+            IntPtr[] argv = new IntPtr[appArgs.Count + 2];
+            argv[0] = Marshal.StringToCoTaskMemUTF8(execAbs);
+            for (int i = 0; i < appArgs.Count; i++)
+            {
+                argv[i + 1] = Marshal.StringToCoTaskMemUTF8(appArgs[i]);
+            }
+            argv[^1] = IntPtr.Zero;
+
+            execv(execAbs, argv);
+            // If we got here, execv failed.
+            int err = Marshal.GetLastPInvokeError();
+            foreach (IntPtr p in argv)
+            {
+                if (p != IntPtr.Zero) Marshal.FreeCoTaskMem(p);
+            }
+            throw new InvalidOperationException($"Failed to exec '{execAbs}' (errno {err}).");
+        }
+
+        [StructLayout(LayoutKind.Sequential)]
+        private struct RulesetAttr
+        {
+            public ulong handled_access_fs;
+        }
+
+        [StructLayout(LayoutKind.Sequential, Pack = 1)]
+        private struct PathBeneathAttr
+        {
+            public ulong allowed_access;
+            public int parent_fd;
+        }
+
+        [DllImport("libc", SetLastError = true)]
+        private static extern long syscall(long number, IntPtr arg1, UIntPtr arg2, uint arg3);
+
+        [DllImport("libc", SetLastError = true)]
+        private static extern long syscall(long number, ref RulesetAttr attr, UIntPtr size, uint flags);
+
+        [DllImport("libc", SetLastError = true)]
+        private static extern long syscall(long number, IntPtr rulesetFd, IntPtr ruleType, ref PathBeneathAttr attr, uint flags);
+
+        [DllImport("libc", SetLastError = true)]
+        private static extern long syscall(long number, IntPtr rulesetFd, uint flags, uint unused);
+
+        [DllImport("libc", SetLastError = true)]
+        private static extern int prctl(int option, ulong arg2, ulong arg3, ulong arg4, ulong arg5);
+
+        [DllImport("libc", SetLastError = true, CharSet = CharSet.Ansi)]
+        private static extern int open([MarshalAs(UnmanagedType.LPUTF8Str)] string path, int flags, int mode);
+
+        [DllImport("libc", SetLastError = true)]
+        private static extern int close(int fd);
+
+        [DllImport("libc", SetLastError = true, CharSet = CharSet.Ansi)]
+        private static extern int execv([MarshalAs(UnmanagedType.LPUTF8Str)] string path, IntPtr[] argv);
+    }
+}

--- a/Hina.PackageManager/Sandbox/NoOpSandbox.cs
+++ b/Hina.PackageManager/Sandbox/NoOpSandbox.cs
@@ -1,0 +1,47 @@
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Threading;
+using Microsoft.Extensions.Logging;
+
+namespace Hina.PackageManager.Sandbox
+{
+    // Fallback launcher for hosts without a real sandbox backend (macOS, Windows,
+    // or a Linux kernel too old for Landlock). Runs the app with no restriction,
+    // warning once if the plan asked for any. Never blocks a launch.
+    public sealed class NoOpSandbox : ISandboxLauncher
+    {
+        private readonly ILogger _logger;
+
+        public NoOpSandbox(ILogger logger)
+        {
+            _logger = logger;
+        }
+
+        public bool IsSupported => false;
+
+        public int Launch(string execAbs, IReadOnlyList<string> appArgs, SandboxPlan plan, CancellationToken ct)
+        {
+            if (!plan.Unrestricted && plan.Rules.Count > 1)
+            {
+                // >1 because the app dir is always present; more than that means the
+                // descriptor requested real scoping this host cannot enforce.
+                _logger.LogWarning(
+                    "This app requested filesystem sandboxing, but this platform cannot enforce it. Running unsandboxed.");
+            }
+
+            ProcessStartInfo psi = new ProcessStartInfo
+            {
+                FileName = execAbs,
+                UseShellExecute = false,
+            };
+            foreach (string a in appArgs)
+            {
+                psi.ArgumentList.Add(a);
+            }
+
+            using Process proc = Process.Start(psi)!;
+            proc.WaitForExit();
+            return proc.ExitCode;
+        }
+    }
+}

--- a/Hina.PackageManager/Sandbox/PermissionsFormatter.cs
+++ b/Hina.PackageManager/Sandbox/PermissionsFormatter.cs
@@ -1,0 +1,138 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using Hina.PackageManager.Descriptor;
+
+namespace Hina.PackageManager.Sandbox
+{
+    // Renders AppPermissions as the `hina perms` table (all apps) and detail
+    // (one app). Pure string output. Every non-filesystem capability is rendered
+    // with a "not enforced" caveat so the display never implies isolation Hina
+    // does not provide.
+    public static class PermissionsFormatter
+    {
+        private const string Yes = "✓";
+        private const string No = "—";
+
+        private static readonly string[] Headers = { "APP", "SANDBOX", "FS", "NET", "AUDIO", "MIC", "SCREEN", "INPUT", "DEV" };
+
+        public static string Table(IEnumerable<AppPermissions> apps)
+        {
+            List<string[]> rows = new List<string[]> { Headers };
+            foreach (AppPermissions p in apps)
+            {
+                rows.Add(new[]
+                {
+                    p.Name,
+                    p.SandboxEnabled ? "yes" : "no",
+                    FsSummary(p),
+                    Mark(p.Network),
+                    Mark(p.Audio),
+                    Mark(p.Microphone),
+                    Mark(p.Screen),
+                    Mark(p.Input),
+                    Mark(p.Devices),
+                });
+            }
+
+            int cols = Headers.Length;
+            int[] widths = new int[cols];
+            foreach (string[] row in rows)
+            {
+                for (int c = 0; c < cols; c++)
+                {
+                    widths[c] = Math.Max(widths[c], DisplayWidth(row[c]));
+                }
+            }
+
+            StringBuilder sb = new StringBuilder();
+            foreach (string[] row in rows)
+            {
+                for (int c = 0; c < cols; c++)
+                {
+                    sb.Append(Pad(row[c], widths[c]));
+                    if (c < cols - 1) sb.Append("  ");
+                }
+                sb.Append('\n');
+            }
+
+            sb.Append('\n');
+            sb.Append("Only filesystem (FS) is enforced — Linux/Landlock. NET/AUDIO/MIC/SCREEN/INPUT/DEV are\n");
+            sb.Append("declared by the app but NOT yet enforced. Run `hina perms <app>` for details.\n");
+            return sb.ToString();
+        }
+
+        public static string Detail(AppPermissions p)
+        {
+            StringBuilder sb = new StringBuilder();
+            sb.Append(p.Name).Append('\n');
+
+            if (!p.SandboxEnabled)
+            {
+                sb.Append("  Sandbox: disabled — app runs with full user privileges (no isolation).\n");
+                return sb.ToString();
+            }
+
+            sb.Append("  Sandbox: enabled\n");
+            sb.Append("  Filesystem (enforced):\n");
+            sb.Append("    ro   <install dir>   (app itself)\n");
+            foreach (FsRule rule in p.FilesystemDeclared)
+            {
+                string label = rule.Path == SandboxTokens.Host ? "host — UNRESTRICTED, no isolation" : rule.Path;
+                sb.Append("    ").Append(PadRight(rule.Access, 4)).Append(' ').Append(label).Append("   (declared)\n");
+            }
+            foreach (var grant in p.UserGrants)
+            {
+                sb.Append("    ").Append(PadRight(grant.Access, 4)).Append(' ').Append(grant.Path).Append("   (user grant)\n");
+            }
+            if (p.FilesystemDeclared.Count == 0 && p.UserGrants.Count == 0)
+            {
+                sb.Append("    (nothing beyond the install dir)\n");
+            }
+
+            Capability(sb, "Network", p.Network);
+            Capability(sb, "Audio", p.Audio);
+            Capability(sb, "Microphone", p.Microphone);
+            Capability(sb, "Screen", p.Screen);
+            Capability(sb, "Input", p.Input);
+            Capability(sb, "Devices", p.Devices);
+            return sb.ToString();
+        }
+
+        private static void Capability(StringBuilder sb, string name, bool declared)
+        {
+            sb.Append("  ").Append(PadRight(name + ":", 12)).Append(' ');
+            sb.Append(declared ? "declared (not enforced)" : "not declared").Append('\n');
+        }
+
+        private static string Mark(bool b) => b ? Yes : No;
+
+        private static string FsSummary(AppPermissions p)
+        {
+            if (!p.SandboxEnabled) return No;
+
+            List<string> tokens = p.FilesystemDeclared.Select(r => r.Path).ToList();
+            if (tokens.Contains(SandboxTokens.Host))
+            {
+                return "host(!)";
+            }
+
+            string baseScope = tokens.Count > 0 ? string.Join(",", tokens) : "";
+            if (p.UserGrants.Count > 0)
+            {
+                baseScope = baseScope.Length > 0 ? $"{baseScope}+{p.UserGrants.Count}g" : $"+{p.UserGrants.Count}g";
+            }
+            return baseScope.Length > 0 ? baseScope : No;
+        }
+
+        // ✓ and — are single display columns but multi-byte in UTF-8; measure by
+        // text-element count, not byte length, so padding lines up.
+        private static int DisplayWidth(string s) => new System.Globalization.StringInfo(s).LengthInTextElements;
+
+        private static string Pad(string s, int width)
+            => s + new string(' ', Math.Max(0, width - DisplayWidth(s)));
+
+        private static string PadRight(string s, int width) => Pad(s, width);
+    }
+}

--- a/Hina.PackageManager/Sandbox/SandboxDiff.cs
+++ b/Hina.PackageManager/Sandbox/SandboxDiff.cs
@@ -1,0 +1,106 @@
+using System;
+using System.Collections.Generic;
+using Hina.PackageManager.Descriptor;
+
+namespace Hina.PackageManager.Sandbox
+{
+    // Compares the sandbox an app declared in its OLD (cached) descriptor against the
+    // NEW one fetched during an update, and decides whether the new version BROADENS
+    // the app's access. Broadening requires user consent (`hina update --accept-new-
+    // permissions`); narrowing applies silently.
+    //
+    // Baseline model: a null/disabled sandbox means "unsandboxed = full access". So
+    // enabling/tightening a sandbox can only narrow; dropping or loosening one broadens.
+    public sealed class SandboxDiff
+    {
+        public bool Broadened => Added.Count > 0;
+        public List<string> Added { get; } = new List<string>();
+        public List<string> Removed { get; } = new List<string>();
+
+        public static SandboxDiff Compute(SandboxSpec? oldSpec, SandboxSpec? newSpec)
+        {
+            SandboxDiff diff = new SandboxDiff();
+
+            bool oldOn = oldSpec?.Enabled == true;
+            bool newOn = newSpec?.Enabled == true;
+
+            // Unsandboxed (full access) on both sides — nothing changes.
+            if (!oldOn && !newOn) return diff;
+
+            // Was restricted, now unrestricted → the app regains full filesystem access.
+            if (oldOn && !newOn)
+            {
+                diff.Added.Add("host (sandbox removed — full filesystem access)");
+                return diff;
+            }
+
+            // Was unrestricted, now restricted → strictly narrowing.
+            if (!oldOn && newOn)
+            {
+                diff.Removed.Add("(app is now sandboxed)");
+                return diff;
+            }
+
+            // Both restricted — compare declared scope.
+            Dictionary<string, string> oldFs = ToMap(oldSpec!);
+            Dictionary<string, string> newFs = ToMap(newSpec!);
+
+            foreach (KeyValuePair<string, string> kv in newFs)
+            {
+                if (!oldFs.TryGetValue(kv.Key, out string? oldAccess))
+                {
+                    diff.Added.Add($"{kv.Key} ({kv.Value})");
+                }
+                else if (oldAccess == "ro" && kv.Value == "rw")
+                {
+                    diff.Added.Add($"{kv.Key} (ro → rw)");
+                }
+            }
+            foreach (KeyValuePair<string, string> kv in oldFs)
+            {
+                if (!newFs.ContainsKey(kv.Key))
+                {
+                    diff.Removed.Add($"{kv.Key} ({kv.Value})");
+                }
+                else if (kv.Value == "rw" && newFs[kv.Key] == "ro")
+                {
+                    diff.Removed.Add($"{kv.Key} (rw → ro)");
+                }
+            }
+
+            CompareCapabilities(oldSpec!.Capabilities, newSpec!.Capabilities, diff);
+            return diff;
+        }
+
+        // path token -> highest access (rw wins over ro if a token were listed twice).
+        private static Dictionary<string, string> ToMap(SandboxSpec spec)
+        {
+            Dictionary<string, string> map = new Dictionary<string, string>(StringComparer.Ordinal);
+            foreach (FsRule r in spec.Filesystem)
+            {
+                if (map.TryGetValue(r.Path, out string? existing) && existing == "rw") continue;
+                map[r.Path] = r.Access;
+            }
+            return map;
+        }
+
+        private static void CompareCapabilities(CapabilitySpec? oldCaps, CapabilitySpec? newCaps, SandboxDiff diff)
+        {
+            oldCaps ??= new CapabilitySpec();
+            newCaps ??= new CapabilitySpec();
+            foreach ((string name, bool o, bool n) in new[]
+            {
+                ("network", oldCaps.Network, newCaps.Network),
+                ("audio", oldCaps.Audio, newCaps.Audio),
+                ("microphone", oldCaps.Microphone, newCaps.Microphone),
+                ("screen", oldCaps.Screen, newCaps.Screen),
+                ("input", oldCaps.Input, newCaps.Input),
+                ("devices", oldCaps.Devices, newCaps.Devices),
+            })
+            {
+                if (!o && n) diff.Added.Add($"capability: {name}");
+                else if (o && !n) diff.Removed.Add($"capability: {name}");
+            }
+        }
+    }
+}

--- a/Hina.PackageManager/Sandbox/SandboxEnv.cs
+++ b/Hina.PackageManager/Sandbox/SandboxEnv.cs
@@ -1,0 +1,44 @@
+using System;
+using System.IO;
+
+namespace Hina.PackageManager.Sandbox
+{
+    // Resolved user-directory roots that abstract sandbox tokens map onto.
+    // Constructed explicitly in tests for determinism; FromSystem() reads the
+    // live environment (XDG vars with home-relative fallbacks).
+    public readonly struct SandboxEnv
+    {
+        public string Home { get; }
+        public string Documents { get; }
+        public string Download { get; }
+        public string Config { get; }
+        public string Tmp { get; }
+
+        public SandboxEnv(string home, string documents, string download, string config, string tmp)
+        {
+            Home = home;
+            Documents = documents;
+            Download = download;
+            Config = config;
+            Tmp = tmp;
+        }
+
+        public static SandboxEnv FromSystem()
+        {
+            string home = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
+            string config = EnvOr("XDG_CONFIG_HOME", Path.Combine(home, ".config"));
+            return new SandboxEnv(
+                home: home,
+                documents: EnvOr("XDG_DOCUMENTS_DIR", Path.Combine(home, "Documents")),
+                download: EnvOr("XDG_DOWNLOAD_DIR", Path.Combine(home, "Downloads")),
+                config: config,
+                tmp: Path.GetTempPath());
+        }
+
+        private static string EnvOr(string var, string fallback)
+        {
+            string? v = Environment.GetEnvironmentVariable(var);
+            return string.IsNullOrEmpty(v) ? fallback : v;
+        }
+    }
+}

--- a/Hina.PackageManager/Sandbox/SandboxLauncherFactory.cs
+++ b/Hina.PackageManager/Sandbox/SandboxLauncherFactory.cs
@@ -1,0 +1,23 @@
+using System.Runtime.InteropServices;
+using Microsoft.Extensions.Logging;
+
+namespace Hina.PackageManager.Sandbox
+{
+    // Selects the sandbox backend for this OS. Linux → Landlock when the kernel
+    // supports it, otherwise NoOp. macOS/Windows → NoOp until their backends land.
+    public static class SandboxLauncherFactory
+    {
+        public static ISandboxLauncher Current(ILogger logger)
+        {
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
+            {
+                LinuxLandlockSandbox landlock = new LinuxLandlockSandbox(logger);
+                if (landlock.IsSupported)
+                {
+                    return landlock;
+                }
+            }
+            return new NoOpSandbox(logger);
+        }
+    }
+}

--- a/Hina.PackageManager/Sandbox/SandboxPaths.cs
+++ b/Hina.PackageManager/Sandbox/SandboxPaths.cs
@@ -1,0 +1,25 @@
+using Hina.PackageManager.Descriptor;
+
+namespace Hina.PackageManager.Sandbox
+{
+    // Maps an abstract sandbox token to a concrete absolute path. Returns null
+    // for the "host" token, which means "no filesystem restriction" rather than
+    // a single path. Unknown tokens (already rejected by DescriptorValidator)
+    // also return null and are ignored by the planner.
+    public static class SandboxPaths
+    {
+        public static string? Resolve(string token, string appDir, SandboxEnv env)
+        {
+            return token switch
+            {
+                SandboxTokens.App => appDir,
+                SandboxTokens.Home => env.Home,
+                SandboxTokens.XdgDocuments => env.Documents,
+                SandboxTokens.XdgDownload => env.Download,
+                SandboxTokens.XdgConfig => env.Config,
+                SandboxTokens.Tmp => env.Tmp,
+                _ => null, // host or unknown
+            };
+        }
+    }
+}

--- a/Hina.PackageManager/Sandbox/SandboxPlan.cs
+++ b/Hina.PackageManager/Sandbox/SandboxPlan.cs
@@ -1,0 +1,33 @@
+using System.Collections.Generic;
+
+namespace Hina.PackageManager.Sandbox
+{
+    // A concrete, resolved set of filesystem permissions for one app launch.
+    // Consumed by an ISandboxLauncher backend (Landlock on Linux).
+    public sealed class SandboxPlan
+    {
+        // True if a "host" rule was present — the backend should not restrict
+        // the filesystem at all (other isolation, if any, may still apply).
+        public bool Unrestricted { get; }
+
+        public IReadOnlyList<ResolvedFsRule> Rules { get; }
+
+        public SandboxPlan(bool unrestricted, IReadOnlyList<ResolvedFsRule> rules)
+        {
+            Unrestricted = unrestricted;
+            Rules = rules;
+        }
+    }
+
+    public sealed class ResolvedFsRule
+    {
+        public string Path { get; }
+        public bool CanWrite { get; }
+
+        public ResolvedFsRule(string path, bool canWrite)
+        {
+            Path = path;
+            CanWrite = canWrite;
+        }
+    }
+}

--- a/Hina.PackageManager/Sandbox/SandboxPlanner.cs
+++ b/Hina.PackageManager/Sandbox/SandboxPlanner.cs
@@ -1,0 +1,54 @@
+using System.Collections.Generic;
+using Hina.PackageManager.Descriptor;
+using Hina.PackageManager.Registry;
+
+namespace Hina.PackageManager.Sandbox
+{
+    // Folds the descriptor's declared filesystem rules and the user's extra
+    // runtime grants into one resolved plan. The app's own install dir is always
+    // granted read-only. A "host" rule short-circuits to Unrestricted. When the
+    // same concrete path appears more than once, read-write wins over read-only.
+    public static class SandboxPlanner
+    {
+        public static SandboxPlan Build(SandboxSpec spec, IEnumerable<FsGrant> userGrants, string appDir, SandboxEnv env)
+        {
+            Dictionary<string, bool> byPath = new Dictionary<string, bool>(); // path -> canWrite
+
+            void Add(string? path, bool canWrite)
+            {
+                if (string.IsNullOrEmpty(path))
+                {
+                    return;
+                }
+                byPath[path] = byPath.TryGetValue(path, out bool existing) ? existing || canWrite : canWrite;
+            }
+
+            // App dir always readable (exec implied by the backend).
+            Add(appDir, canWrite: false);
+
+            bool unrestricted = false;
+            foreach (FsRule rule in spec.Filesystem)
+            {
+                if (rule.Path == SandboxTokens.Host)
+                {
+                    unrestricted = true;
+                    continue;
+                }
+                Add(SandboxPaths.Resolve(rule.Path, appDir, env), rule.Access == "rw");
+            }
+
+            foreach (FsGrant grant in userGrants)
+            {
+                Add(grant.Path, grant.Access == "rw");
+            }
+
+            List<ResolvedFsRule> rules = new List<ResolvedFsRule>();
+            foreach (KeyValuePair<string, bool> kv in byPath)
+            {
+                rules.Add(new ResolvedFsRule(kv.Key, kv.Value));
+            }
+
+            return new SandboxPlan(unrestricted, rules);
+        }
+    }
+}

--- a/docs/Architecture.md
+++ b/docs/Architecture.md
@@ -12,7 +12,7 @@ Hina is organized into five projects plus two test projects:
 |---------|------|-------------|
 | **Hina.Core** | Class Library | Core engine: patching, rsync matching, manifest handling, chunking, hashing, signing, compression, networking, configuration |
 | **Hina.PackageManager** | Class Library | Package-manager layer: descriptor schema, validator, signer/fetcher, install/uninstall/update/reinstall services, hook executor, per-OS shell integration, local registry |
-| **Hina.CLI** | Console App (NativeAOT) | End-user CLI (`hina install/update/uninstall/list/info/which/reinstall`) plus developer subcommands under `hina dev <cmd>` |
+| **Hina.CLI** | Console App (NativeAOT) | End-user CLI (`hina install/update/uninstall/list/info/which/reinstall/run/perms/verify`) plus developer subcommands under `hina dev <cmd>` |
 | **Hina.Builder** | Console App | Manifest generator and chunk store builder |
 | **Hina.Host** | ASP.NET Core App | Lightweight static file server for serving patches |
 | **Hina.Core.Tests** | xUnit Test Project | Unit and integration tests for the core engine |
@@ -164,7 +164,8 @@ The local index of installed apps.
 | Class | Purpose |
 |-------|---------|
 | `Registry` | Root JSON object: `apps: Dictionary<name, InstalledApp>` |
-| `InstalledApp` | Per-app row: pinned baseUrl/publicKey/channel, install path, descriptorUrl, executed hooks, shell entries |
+| `InstalledApp` | Per-app row: pinned baseUrl/publicKey/channel, install path, descriptorUrl, executed hooks, shell entries, plus `UserGrants` (the extra filesystem paths the user has granted a sandboxed app at runtime, as resolved absolute `FsGrant` rows) |
+| `FsGrant` | A user-granted absolute filesystem path for a sandboxed app: `Path` + `Access` (`ro`/`rw`). Additive and default-empty so older registries round-trip; `schemaVersion` stays 1. |
 | `HookEvidence` | What was actually written on disk by a hook — read at uninstall time |
 | `ShellEntryRecord` | Id-keyed pair so update-flow diff can replace renamed/removed entries |
 | `RegistryStore` | Atomic read/write (tmp + fsync + rename); uses source-gen JSON |
@@ -196,11 +197,11 @@ Per-OS shell integration. Pure interface + factory + three implementations.
 
 | Class | Purpose |
 |-------|---------|
-| `IPlatformIntegration` | All shell-touching operations: shortcuts, AddToPath, MIME, URL scheme, font, autostart (+ `Remove`/`Unregister` counterparts). Returns "evidence" strings stored in the registry. |
+| `IPlatformIntegration` | All shell-touching operations: shortcuts, AddToPath, MIME, URL scheme, font, autostart (+ `Remove`/`Unregister` counterparts). Returns "evidence" strings stored in the registry. Two sandbox-related additions, both with default-impl fallbacks so platforms without a backend are unaffected: a 4-arg `CreateMenuShortcut(entry, appDir, launchOverride, ct)` overload that sets the shortcut's launch command to `launchOverride` verbatim (e.g. `hina run <app> <entry>`) instead of the app binary; and `EnumerateManagedArtifacts()`, which returns every Hina-managed artifact path on disk (independent of the registry) so `FindOrphanArtifacts` can find leftovers. |
 | `PlatformIntegrationFactory` | Picks the right impl via `RuntimeInformation.IsOSPlatform` |
-| `LinuxPlatformIntegration` | `.desktop` files in `~/.local/share/applications`, symlinks in `~/.local/bin`, fonts in `~/.local/share/fonts`, `~/.config/autostart/*.desktop` |
-| `WindowsPlatformIntegration` | `.lnk` shortcuts via COM `IShellLink`, `.cmd` shims in `%LOCALAPPDATA%\Hina\bin` (PATH-extended), HKCU registry for MIME/URL/autostart, per-user fonts |
-| `MacOSPlatformIntegration` | Minimal `.app` bundles in `~/Applications` with generated Info.plist, helper bundles with `CFBundleDocumentTypes` / `CFBundleURLTypes`, `~/Library/Fonts`, `~/Library/LaunchAgents/*.plist` |
+| `LinuxPlatformIntegration` | `.desktop` files in `~/.local/share/applications`, symlinks in `~/.local/bin`, fonts in `~/.local/share/fonts`, `~/.config/autostart/*.desktop`. The only impl that honors `launchOverride` (writes it as the `.desktop` `Exec` line) and implements `EnumerateManagedArtifacts()` (scans `hina-*` shortcuts / handlers / fonts; bin symlinks are excluded as they carry no Hina marker). |
+| `WindowsPlatformIntegration` | `.lnk` shortcuts via COM `IShellLink`, `.cmd` shims in `%LOCALAPPDATA%\Hina\bin` (PATH-extended), HKCU registry for MIME/URL/autostart, per-user fonts. Falls back to the default `CreateMenuShortcut` (ignores `launchOverride`) and `EnumerateManagedArtifacts` (empty) — no sandbox enforcement yet. |
+| `MacOSPlatformIntegration` | Minimal `.app` bundles in `~/Applications` with generated Info.plist, helper bundles with `CFBundleDocumentTypes` / `CFBundleURLTypes`, `~/Library/Fonts`, `~/Library/LaunchAgents/*.plist`. Same default fallbacks as Windows — no sandbox enforcement yet. |
 | `Windows/ShellLink.cs` | Hand-rolled COM interop (`IShellLinkW` + `IPersistFile`) using the `[CoClass]` idiom; AOT-compatible |
 
 ### Paths/
@@ -227,12 +228,40 @@ Per-OS shell integration. Pure interface + factory + three implementations.
 
 | Class | Purpose |
 |-------|---------|
-| `RegistryVerifier` | Reconciles the local registry against on-disk state. `Inspect` reports orphans (missing AppDir, dangling shell entries, dangling hook evidence); `RepairAsync` calls the platform `Unregister*` / `Remove*` and rewrites the registry. Used by `hina verify [--repair]`. |
-| `AppDiagnostic` / `AppRepairResult` | Plain data shapes for the verifier's output. |
+| `RegistryVerifier` | Reconciles the local registry against on-disk state. `Inspect` reports orphans (missing AppDir, dangling shell entries, dangling hook evidence) **plus a local integrity check** (reads the cached descriptor and confirms the declared exec + entry files exist on disk, reporting `DescriptorCacheMissing` / `MissingFiles`); `RepairAsync` calls the platform `Unregister*` / `Remove*` and rewrites the registry. `FindOrphanArtifacts` scans `IPlatformIntegration.EnumerateManagedArtifacts()` and subtracts every registry-referenced path to surface leftovers from a manual `registry.json` deletion; `RepairOrphanArtifactsAsync` deletes them (fail-soft, under the registry lock). Used by `hina verify [--repair] [--deep]`. |
+| `AppDiagnostic` / `AppRepairResult` | Plain data shapes for the verifier's output. `AppDiagnostic` carries `AppDirMissing`, `DescriptorCacheMissing`, `MissingFiles`, `DanglingShellEntries`, `DanglingHooks`, and an `IsHealthy` roll-up. |
 
 `InstallOptions` and `UpdateOptions` carry a `NetworkOptions` struct that
 threads `MaxRetries`, `MaxRetryDelayMs`, `ConnectTimeoutMs`, and
 `RequestTimeoutMs` into the `PatcherConfig` for the per-call `PatchClient`.
+
+### Io/
+
+| Class | Purpose |
+|-------|---------|
+| `AtomicFile` | Crash-safe small-file text write: serializes to a sibling `.tmp`, `Flush(flushToDisk: true)`, then `File.Move(..., overwrite: true)` — atomic for a same-volume rename on POSIX and Windows. A crash mid-write leaves the old file (or no file) intact, never a truncated one. The same pattern `RegistryStore` uses for `registry.json`, centralised so the descriptor cache and any future small-file writes share it. |
+
+### Sandbox/
+
+Optional Flatpak-style filesystem isolation. v1 enforces **filesystem scope only**, on **Linux/Landlock only**; declared non-filesystem capabilities are surfaced but not enforced, and there are no portals.
+
+The architecture mirrors `Platform/`: a per-OS interface (`ISandboxLauncher`) with a factory that selects one implementation. The pivot is that **Hina becomes the launcher for sandboxed apps** — their shell shortcut's launch command points at `hina run <app> <entry>` instead of the app binary, so `hina run` can build the filesystem plan and install the sandbox before the app starts. Non-sandboxed apps continue to launch their binary directly.
+
+| Class | Purpose |
+|-------|---------|
+| `SandboxPlanner` | `Build(spec, userGrants, appDir, env)` folds the descriptor's declared `FsRule`s and the user's runtime `FsGrant`s into a resolved `SandboxPlan`. The install dir is always granted read-only; a `host` rule short-circuits to `Unrestricted`; when the same concrete path appears twice, read-write wins. |
+| `SandboxPlan` / `ResolvedFsRule` | `SandboxPlan { bool Unrestricted, IReadOnlyList<ResolvedFsRule> Rules }`; each `ResolvedFsRule` is an absolute `Path` + `CanWrite` flag. |
+| `SandboxEnv` | Resolved user-directory roots (`Home`, `Documents`, `Download`, `Config`, `Tmp`) that abstract tokens map onto. `FromSystem()` reads the live XDG vars with home-relative fallbacks; constructed explicitly in tests for determinism. |
+| `SandboxPaths` | `Resolve(token, appDir, env)` maps a `SandboxTokens` value to an absolute path. Returns `null` for `host` (means "no restriction", not a path) and for unknown tokens (already rejected by `DescriptorValidator`). |
+| `ISandboxLauncher` | Per-OS launcher: `bool IsSupported` + `int Launch(execAbs, appArgs, plan, ct)`. A backend MAY replace the current process image (`execv`) rather than spawn a child — in that case `Launch` returns only on exec failure. |
+| `LinuxLandlockSandbox` | Linux backend (kernel 5.13+). Unprivileged P/Invoke into `landlock_create_ruleset` / `landlock_add_rule` / `landlock_restrict_self` plus `prctl(NO_NEW_PRIVS)`, then `execv`. Builds a ruleset that denies every filesystem access right the running ABI knows and grants back only the resolved paths; restrictions apply to `hina` itself and are inherited across `execv`, so the sandboxed app's PID is hina's. ABI-probed; any failure logs a warning and execs unsandboxed — it never blocks a launch. |
+| `NoOpSandbox` | Fallback for macOS, Windows, or a too-old Linux kernel. Spawns the app and waits; warns once if the plan asked for real scoping it cannot enforce. `IsSupported` is `false`. |
+| `SandboxLauncherFactory` | `Current(logger)` returns `LinuxLandlockSandbox` when on Linux and supported, otherwise `NoOpSandbox`. |
+| `AppPermissions` | Pure flat view of one app's permissions, folded from the cached descriptor (declared scope + capabilities) and the registry row (`UserGrants`). No I/O. Drives `hina perms`. |
+| `PermissionsFormatter` | Renders `AppPermissions` as the `hina perms` table (all apps) and detail (one app). Every non-filesystem capability is rendered with a "declared — not enforced" caveat. |
+| `SandboxDiff` | `Compute(oldSpec, newSpec)` → `{ Broadened, Added, Removed }`. A null/disabled sandbox means "unsandboxed = full access", so dropping or loosening a sandbox broadens (needs consent) while enabling or tightening it narrows (applies silently). Drives the update-flow permission-consent gate (a broadening update fails unless re-run with `--accept-new-permissions`). |
+
+The descriptor wire model for the sandbox lives in `Descriptor/`: `SandboxSpec` (`Enabled`, `List<FsRule> Filesystem`, `CapabilitySpec? Capabilities`), `FsRule` (`Path` token + `Access` `ro`/`rw`), `CapabilitySpec` (`Network`/`Audio`/`Microphone`/`Screen`/`Input`/`Devices` bools — **declared only**), and `SandboxTokens` (the closed token set: `app`, `home`, `xdg-documents`, `xdg-download`, `xdg-config`, `tmp`, `host`). Unknown tokens are rejected at validation — fail closed.
 
 ---
 
@@ -373,10 +402,13 @@ The client (`PatchClient`) downloads the manifest, matches local data, and appli
  [10] Sanity check: descriptor.Exec[os] exists on disk
         |
  [11] CreateMenuShortcut for each entry → record evidence
+      (sandboxed app → launchOverride "hina run <name> <entry>"; else direct binary)
         |
  [12] HookExecutor.ApplyAsync in declared order → record HookEvidence
         |
- [13] Write registry entry; cache descriptor
+ [13] Cache descriptor FIRST via AtomicFile.WriteAllText, THEN commit registry entry.
+      A crash between the two leaves a cache with no registry row (harmless) rather
+      than a registry row with no cache (would break run/perms/update).
         |
  [14] Release lock
 
@@ -407,6 +439,10 @@ The client (`PatchClient`) downloads the manifest, matches local data, and appli
         |
  [5] Snapshot pre-update registry entry
         |
+ [5a] SandboxDiff.Compute(oldDescriptor.sandbox, newDescriptor.sandbox)
+      If it BROADENS access (new paths, host, ro→rw, new capability, or sandbox
+      dropped) and not --accept-new-permissions → fail BEFORE touching disk
+        |
  [6] PatchClient.PatchAsync(appDir, Backup=true)
      On failure → PatchClient.RollbackAsync + restore registry snapshot
         |
@@ -436,6 +472,54 @@ The client (`PatchClient`) downloads the manifest, matches local data, and appli
  Critical: hook side-effects are read from the registry, NEVER from
  the live descriptor — a newer descriptor might list different hooks.
 ```
+
+### Run Flow (Hina.PackageManager)
+
+The launch chokepoint. A sandboxed app's shell shortcut runs `hina run` instead of
+the app binary, so the filesystem sandbox is installed before the app starts.
+
+```
+ hina run <app> [entryId] [-- appArgs...]
+        |
+ [1] Load registry; app missing → error
+ [2] AppDir missing → error (suggest reinstall)
+ [3] Read cached descriptor; missing/corrupt → error
+     (NEVER launch unsandboxed without the descriptor — that would silently drop isolation)
+        |
+ [4] Resolve the entry's exec (entryId → entries[]; else entries[0]; else Exec[os])
+     Resolved exec missing on disk → error
+        |
+ [5] Build the plan:
+        sandbox.Enabled → SandboxPlanner.Build(spec, app.UserGrants, appDir, SandboxEnv.FromSystem())
+        else            → SandboxPlan(Unrestricted: true)
+        |
+ [6] SandboxLauncherFactory.Current(logger).Launch(execAbs, appArgs, plan, ct)
+     Linux+supported → Landlock installs the ruleset then execv's the app (app PID = hina PID)
+     else            → spawn + wait (warns once if scoping was requested but unenforceable)
+```
+
+### Permissions Flow (Hina.PackageManager)
+
+```
+ hina perms                          → table of every app's permissions
+ hina perms <app>                    → detail for one app
+ hina perms <app> --grant <path>[:ro|:rw]   → add a runtime FsGrant   (takes the registry lock)
+ hina perms <app> --revoke <path>           → remove a runtime FsGrant (takes the registry lock)
+```
+
+`AppPermissions.From(cachedDescriptor, registryRow)` folds the declared sandbox scope
+and the registry `UserGrants` into a flat view; `PermissionsFormatter` renders it.
+Filesystem is the only enforced category; every other capability is shown "declared —
+not enforced".
+
+`hina verify [name] [--repair] [--deep]` extends the diagnostic: the default offline
+pass adds local integrity checks (descriptor cache + declared files present) and a global
+orphan-artifact scan; `--repair` (also reachable as `hina repair`) prunes orphan entries,
+dangling side-effects, and orphan artifacts; `--deep` re-fetches the manifest and hashes
+every file via `PatchClient.VerifyAsync`. `hina dev sandbox-run --app-dir <dir>
+[--allow <path>[:ro|:rw] ...] [--host] -- <exec> [args...]` applies a filesystem sandbox
+(Landlock on Linux) then execs — it drives the Landlock integration test and is handy for
+manual sandbox probing.
 
 ---
 

--- a/docs/CLI-Guide.md
+++ b/docs/CLI-Guide.md
@@ -19,7 +19,10 @@ Top-level (end-user package manager):
   which <name>              Print the install path of an app
   update [name]             Update one app or every installed app
   reinstall <name>          Reinstall an app
-  verify [name]             Reconcile registry against on-disk state
+  run <app> [entry]         Launch a sandboxed app through Hina
+  perms [app]               Show app permissions (aliases: permissions, permessi)
+  verify [name]             Reconcile registry + check local integrity (--deep)
+  repair [name]             Alias for `verify [name] --repair`
   version                   Print the installed Hina version
   check-update              Check whether a newer Hina release is available
 
@@ -30,6 +33,7 @@ hina dev <subcommand> (patcher engine + publisher helpers):
   rollback    --dir <path> --base <url>
   cleanup     --dir <path> --base <url>
   sign-descriptor --in <hina.app.json> --key <ed25519.priv.b64> [--out <path>]
+  sandbox-run --app-dir <dir> [--allow <path>[:ro|:rw]] [--host] -- <exec> [args]
 
 Global flags:
   -v, --verbose      Enable debug logging
@@ -100,6 +104,15 @@ hina update foo      # just one
 hina update --force  # run patcher even if version unchanged
 ```
 
+If a new version **broadens** the app's sandbox, the update is refused (nothing
+written to disk) and the new permissions are listed. Re-run with
+`--accept-new-permissions` to consent. Permission **narrowing** applies
+automatically.
+
+```shell
+hina update foo --accept-new-permissions
+```
+
 **Exit codes:** `0` all updated (or already up to date), `2` at least one failure.
 
 ### reinstall
@@ -113,21 +126,104 @@ hina reinstall foo --rotate-key   # accept a publisher key change
 
 Without `--rotate-key`, reinstall refuses to proceed if the new descriptor declares a different publisher key than the one pinned at original install time (silent key-rotation guard). The check happens before uninstall, so a refusal leaves the install intact.
 
-### verify
+### run
 
-Reconcile the local registry against on-disk state. Detects orphans created when
-the user manually deletes an app directory, breaks a symlink, or removes a
-shortcut. `--repair` cleans the orphans.
+Launch a sandboxed app's executable **through Hina**, so the filesystem sandbox
+is installed before the binary execs. Shell shortcuts for sandboxed apps point
+their launch command at `hina run <app> <entry>` instead of at the binary.
 
 ```shell
-hina verify                # report orphans across all apps
-hina verify foo            # one app
-hina verify --repair       # report + clean
+hina run foo                 # default entry / per-OS executable
+hina run foo editor          # a specific shell entry by id
+hina run foo -- --flag arg   # everything after -- is passed to the app
 ```
 
+The optional second positional is the entry id; everything after a bare `--` is
+forwarded to the app unchanged. If the app declares no sandbox, it runs
+unrestricted.
+
+`run` never falls back to an unsandboxed launch when it can't read the sandbox
+scope. It exits `1` (and suggests `hina reinstall`) if the app isn't installed,
+the install directory is missing, the cached descriptor is missing or corrupt,
+or the resolved executable is gone. Missing args exit `2`.
+
+### perms
+
+Show the declared and granted permissions of installed apps. Aliases:
+`permissions`, `permessi`.
+
+```shell
+hina perms                 # overview table of all apps
+hina perms list            # same as above
+hina perms foo             # full detail for one app
+```
+
+The overview table has columns `APP SANDBOX FS NET AUDIO MIC SCREEN INPUT DEV`.
+The `FS` column summarizes the filesystem scope: declared tokens, `host(!)` when
+the app requests unrestricted host access, and `+Ng` for N user grants. A legend
+notes that **only the filesystem (FS) is enforced** (Linux/Landlock); the other
+capability columns are declared by the app but not yet enforced.
+
+`hina perms <app>` prints the per-app detail: whether the sandbox is on or off;
+the **Filesystem (enforced)** section listing the install dir, each declared
+token with its access, and each user-granted absolute path; then Network, Audio,
+Microphone, Screen, Input and Devices, each shown as `declared (not enforced)`
+or `not declared`.
+
+Manage the user's extra runtime filesystem grants (persisted in the registry):
+
+```shell
+hina perms foo --grant ~/Documents          # default access: ro
+hina perms foo --grant ~/Projects:rw         # read-write
+hina perms foo --revoke ~/Documents
+```
+
+Paths support `~` and are stored absolute. A grant with no `:ro`/`:rw` suffix is
+read-only. Granting a path that already has a grant replaces it.
+
+### verify
+
+Reconcile the local registry against on-disk state **and** check local
+integrity. Detects orphans created when the user manually deletes an app
+directory, breaks a symlink, or removes a shortcut, and — always, offline —
+confirms that the per-OS executable and every `entries[].exec` exist under the
+install dir, flagging a missing or corrupt descriptor cache.
+
+```shell
+hina verify                # report problems across all apps
+hina verify foo            # one app
+hina verify --repair       # report + clean repairable problems
+hina verify --deep         # also re-fetch the manifest and hash every file
+```
+
+`--repair` cleans the repairable problems (orphan registry rows, dangling
+shortcuts/hooks, a missing app directory). The `hina repair` hint is only shown
+when such repairable problems exist. Missing **files** can't be restored by
+repair, so those instead suggest `hina reinstall`.
+
+`--deep` additionally re-fetches the manifest and hash-verifies every file,
+catching modified or truncated content the offline check can't see. It needs
+network; if the manifest is unreachable the app is reported as not deep-verified
+rather than crashing.
+
 Detection is read-only; only `--repair` mutates anything. Exit code `0` when all
-inspected apps are healthy or when `--repair` succeeds; `1` when orphans were
+inspected apps are healthy or when `--repair` succeeds; `1` when problems were
 found and not repaired; `2` on internal error.
+
+### repair
+
+Alias for `hina verify [name] --repair`.
+
+```shell
+hina repair                # repair all apps
+hina repair foo            # one app
+```
+
+Removes orphan registry rows (left when an app directory was deleted by hand),
+dangling shortcuts/hooks, and true-orphan artifacts left after a manual
+`registry.json` deletion — on Linux, `hina-*.desktop` files in the applications
+and autostart directories and `hina-*` fonts. Fail-soft: it cleans what it can
+and does not abort on a single failure.
 
 ### version
 
@@ -233,6 +329,22 @@ hina dev sign-descriptor --in hina.app.json --key ./keys/myapp.key.b64 --out sig
 
 Validates the descriptor against the schema, attaches `descriptorSignature`, writes back (in-place if `--out` is omitted). Generate the key pair with `Hina.Builder keygen`.
 
+### dev sandbox-run
+
+Apply a filesystem sandbox (Landlock on Linux) then exec a command. Drives the
+Landlock CI integration test and is handy for manual sandbox debugging.
+
+```shell
+hina dev sandbox-run --app-dir ./client -- ./client/foo
+hina dev sandbox-run --app-dir ./client --allow ~/data:rw -- ./client/foo
+hina dev sandbox-run --app-dir ./client --host -- ./client/foo
+```
+
+The app dir is added read-only; each `--allow <path>[:ro|:rw]` (default `ro`)
+grants an additional path; `--host` runs unrestricted. Everything after the bare
+`--` is the executable and its arguments. On success the process image is
+replaced, so the exec's own exit code is the result.
+
 ---
 
 ## Flags Reference
@@ -244,8 +356,12 @@ Validates the descriptor against the schema, attaches `descriptorSignature`, wri
 | `--allow-insecure` | `install` | Permit HTTP descriptor URLs (default: HTTPS only) |
 | `--rotate-key` | `reinstall` | Accept a publisher key change |
 | `--force` | `update` | Re-run patcher even if descriptor version unchanged |
+| `--accept-new-permissions` | `update` | Consent to an update that broadens the app's sandbox |
 | `--jobs N` | `update` | Update N apps concurrently (default 4) |
 | `--repair` | `verify` | Remove orphan registry entries + dangling side-effects |
+| `--deep` | `verify` | Re-fetch the manifest and hash-verify every file (needs network) |
+| `--grant <path>[:ro\|:rw]` | `perms` | Add a user filesystem grant (default `ro`); `~` expanded |
+| `--revoke <path>` | `perms` | Remove a user filesystem grant |
 | `--retries N` | `install`, `update` | Max retry attempts per HTTP request (default 8) |
 | `--connect-timeout SEC` | `install`, `update` | TCP connect timeout in seconds (default 10) |
 | `--request-timeout SEC` | `install`, `update` | Overall request timeout in seconds (default 60) |
@@ -299,6 +415,15 @@ Every long-running command honours Ctrl-C cooperatively:
 | `--key <path>` | Yes | Ed25519 private key file (base64) |
 | `--out <path>` | No | Output path (default: overwrite input) |
 
+### hina dev sandbox-run
+
+| Flag | Required | Description |
+|------|----------|-------------|
+| `--app-dir <path>` | Yes | Install dir, added read-only |
+| `--allow <path>[:ro\|:rw]` | No | Extra path to allow (default `ro`); repeatable |
+| `--host` | No | Run unrestricted (no filesystem isolation) |
+| `-- <exec> [args...]` | Yes | Command to exec after the sandbox is applied |
+
 ---
 
 ## Exit Codes (Summary)
@@ -310,6 +435,8 @@ Every long-running command honours Ctrl-C cooperatively:
 | `1` | `dev check` | Updates available |
 | `1` | `install` | User cancelled at TOFU prompt |
 | `1` | `info` / `which` | App not installed |
+| `1` | `run` | App / install dir / descriptor cache / executable missing or corrupt |
+| `1` | `verify` / `repair` | Problems found and not repaired |
 | `2` | any | Missing required args, invalid input, or operation failed |
 | `3` | `dev verify` | Verification failed (broken files detected) |
 
@@ -370,16 +497,21 @@ hina dev sign-descriptor --in hina.app.json --key ./keys/foo.key.b64
 #    hina install https://foo.example/hina.app.json
 ```
 
-### Verify and repair a corrupted install (advanced)
+### Verify and repair a corrupted install
 
-`hina` doesn't expose `verify` at the top level for installed apps — use the
-patcher engine directly with the app's recorded baseUrl from `hina info`:
+Use the top-level `verify` / `repair` commands:
 
 ```shell
-hina info foo                                  # note the BaseUrl
-hina dev verify --dir <install path> --base <BaseUrl>
-hina dev patch  --dir <install path> --base <BaseUrl>   # re-patch only broken chunks
+hina verify foo            # offline integrity + registry check
+hina verify foo --deep     # also re-fetch the manifest and hash every file
+hina repair foo            # clean orphans / dangling side-effects (= verify --repair)
+hina reinstall foo         # restore missing or modified files
 ```
+
+`verify` reports the problem and points you at the right fix: repairable
+problems (orphan registry rows, dangling shortcuts/hooks, a missing app dir) at
+`hina repair`; missing or corrupt files (which repair can't restore) at
+`hina reinstall`.
 
 ### Scripted update with error handling
 

--- a/docs/Changelog.md
+++ b/docs/Changelog.md
@@ -4,6 +4,61 @@ All notable changes to Hina are documented in this file.
 
 ---
 
+## Sandboxing, Permissions & Integrity
+
+Apps can now opt into filesystem isolation, users can inspect and grant
+permissions, and the install can be checked and repaired.
+
+### Sandbox (v1)
+
+- **Optional `sandbox` block** in the signed `hina.app.json`: a filesystem scope
+  (abstract tokens `app`, `home`, `xdg-documents`, `xdg-download`, `xdg-config`,
+  `tmp`, `host`, each `ro`/`rw`) plus declared capabilities (`network`, `audio`,
+  `microphone`, `screen`, `input`, `devices`).
+- **Filesystem enforcement on Linux only**, via Landlock (unprivileged, kernel
+  ≥ 5.13, no root / no bubblewrap). Old kernel / no Landlock → no-op with a
+  one-time warning, never blocks the launch. macOS/Windows: scope is **declared
+  but NOT enforced** — install warns the app runs with full user privileges.
+- **Capabilities are declared-only**, never enforced yet (no portals). `hina
+  perms` shows them as "declared — not enforced".
+- **`hina run <app> [entryId] [-- args]`**: the launch chokepoint. Sandboxed apps'
+  shortcuts route through it so the Landlock ruleset is installed before `execv`.
+- The `host` token grants unrestricted access and is surfaced loudly at install
+  and in `hina perms`.
+
+### Permissions
+
+- **`hina perms`** (aliases `permissions` / `permessi`): table of all apps'
+  permissions, per-app detail view, and `--grant <path>[:ro|:rw]` / `--revoke
+  <path>` to manage user filesystem grants (persisted in the registry, folded into
+  the Landlock ruleset at launch).
+- **Update permission consent**: an update that *broadens* an app's access (new
+  path, `host`, `ro → rw`, a new capability, or removing the sandbox) is refused
+  before any file is touched until `hina update --accept-new-permissions`.
+  Narrowing applies automatically.
+
+### Integrity & Repair
+
+- **`hina verify [name]`**: offline check that each per-OS exec, `entries[].exec`,
+  and the descriptor cache are present. Missing files point the user at `hina
+  reinstall`.
+- **`hina verify --deep`**: re-fetches the manifest and hash-verifies every
+  installed file against it (network required).
+- **`hina repair`** (= `hina verify --repair`): removes orphan registry rows,
+  dangling shortcuts/hooks, and true-orphan artifacts left after a manual
+  `registry.json` deletion. Idempotent.
+- **`hina uninstall <name>`** is now fail-soft — it works even when the install
+  directory is already gone.
+
+### Hardening
+
+- `entries[].id` is charset-validated against `^[A-Za-z0-9][A-Za-z0-9._-]{0,63}$`.
+  The id flows into the `.desktop` `Exec=` line (`hina run <app> "<id>"`), so this
+  closes a command-injection surface for a signed-but-hostile descriptor.
+- Descriptor-cache writes are atomic.
+- `Registry.InstalledApp` gained a `userGrants` list (schemaVersion still `1`;
+  older registries round-trip unchanged).
+
 ## Network Resilience (Round 3)
 
 Targeted at flaky / mobile / changing-IP connections.

--- a/docs/Home.md
+++ b/docs/Home.md
@@ -32,6 +32,11 @@ Hina is an open-source cross-platform package manager and rsync-like patcher for
 - Cross-platform package manager: `hina install <url>` / `update` / `uninstall` / `list` on Windows, Linux, macOS
 - Whitelisted declarative hooks (PATH symlink, MIME, URL scheme, font, autostart), all user-scope (no admin)
 - Ed25519 signed descriptors with TOFU on first install and pinned-key verification on update
+- Optional [filesystem sandboxing](Security.md) for apps that opt in — enforced on Linux via Landlock (`hina run`), declared-but-not-enforced on macOS/Windows
+- [`hina perms`](Security.md) to inspect declared scope/capabilities and grant or revoke filesystem paths per app
+- Update [permission consent](Security.md): an update that broadens an app's sandbox is refused until `--accept-new-permissions`
+- Integrity tooling: `hina verify` checks installed files against the descriptor, `verify --deep` hash-verifies every file against the manifest (see [Troubleshooting](Troubleshooting.md))
+- `hina repair` (`verify --repair`) cleans orphan registry rows and dangling shortcuts/hooks after a manual deletion (see [Troubleshooting](Troubleshooting.md))
 - rsync-like delta patching with rolling checksum matching reuses local chunks
 - Content-defined chunking (CDC) for superior deduplication
 - Brotli-compressed chunk storage

--- a/docs/Integration-Guide.md
+++ b/docs/Integration-Guide.md
@@ -528,6 +528,57 @@ public partial class UpdateForm : Form
 
 ---
 
+## Declaring a Sandbox (Publishers)
+
+If you ship your app through Hina's package manager (a `hina.app.json` descriptor),
+you can opt it into a Flatpak-style filesystem sandbox by adding an optional
+top-level `sandbox` block. It is part of the signed descriptor payload.
+
+```json
+"sandbox": {
+  "enabled": true,
+  "filesystem": [
+    { "path": "home",          "access": "ro" },
+    { "path": "xdg-documents", "access": "rw" }
+  ],
+  "capabilities": { "network": true, "audio": false, "microphone": false, "screen": false, "input": false, "devices": false }
+}
+```
+
+- `enabled` — opt-in. Absent or `false` ⇒ the app runs unsandboxed with full user
+  privileges (legacy behavior).
+- `filesystem[]` — each `{ "path": <token>, "access": "ro" | "rw" }` grants access to
+  an **abstract token**, never a raw host path. Valid tokens: `app` (the install
+  dir, always implicitly granted ro+exec), `home`, `xdg-documents`, `xdg-download`,
+  `xdg-config`, `tmp`, and `host` (no restriction — an escape hatch). Unknown tokens
+  fail validation.
+- `capabilities` — declared-only booleans (`network`, `audio`, `microphone`,
+  `screen`, `input`, `devices`).
+
+**Enforcement is narrow in v1:** filesystem scope is enforced only on Linux (via
+Landlock); macOS and Windows show the declared scope at install but do not yet
+enforce it; capabilities are surfaced to the user but not enforced anywhere. See
+[`docs/PackageManager-Guide.md`](PackageManager-Guide.md#sandboxing) for the full model.
+
+### Best practices
+
+- **Least privilege.** Declare the narrowest filesystem scope your app actually
+  needs (and prefer `ro` over `rw`). The install dir is always available, so you
+  rarely need to list `app`.
+- **Avoid `host`.** It disables filesystem isolation entirely and is flagged loudly
+  to the user at install. Reach for a specific `xdg-*` token instead whenever you can.
+- **Declare capabilities truthfully** even though they aren't enforced yet. They are
+  shown to users as declared intent, and they form the baseline Hina diffs against on
+  every update — under-declaring now means a later honest declaration registers as a
+  broadening change.
+- **Broadening permissions across versions requires user consent.** When a new
+  version widens access — a new path, `host`, a `ro → rw` change, a new capability,
+  or dropping the sandbox — the update is **refused** until the user re-runs with
+  `--accept-new-permissions`. Narrowing applies automatically. Plan your scope up
+  front so routine updates don't stall on a consent prompt.
+
+---
+
 ## Cleanup
 
 After a successful patch (or to recover from a failed one), use `PatchCleanup` to remove leftover temporary files:

--- a/docs/PackageManager-Guide.md
+++ b/docs/PackageManager-Guide.md
@@ -122,7 +122,10 @@ hina install <url-to-hina.app.json>
 | `hina which <name>` | Print the install path of an app |
 | `hina update [name]` | Update one app or all installed apps |
 | `hina reinstall <name>` | Reinstall (use `--rotate-key` to accept a new publisher key) |
-| `hina verify [name] [--repair]` | Reconcile registry against on-disk state; detect orphans (missing dirs, dangling shortcuts) and optionally clean them |
+| `hina run <app> [entryId] [-- args...]` | Launch a sandboxed app through Hina so its filesystem sandbox is installed before exec (the launch chokepoint a sandboxed app's shortcut points at) |
+| `hina perms` / `permissions` / `permessi` | Inspect each app's declared + granted permissions: `perms [list]` for a table, `perms <app>` for detail, `perms <app> --grant <path>[:ro\|:rw]` / `--revoke <path>` to manage runtime filesystem grants |
+| `hina verify [name] [--repair] [--deep]` | Reconcile registry against on-disk state; check local integrity (per-OS exec + every `entries[].exec` + descriptor cache present); detect orphans (missing dirs, dangling shortcuts) and optionally clean them. `--deep` re-fetches the manifest and hash-verifies every file |
+| `hina repair [name]` | Alias for `verify --repair`: remove orphan registry entries + dangling side-effects |
 | `hina dev <subcommand>` | Advanced patcher / publisher commands (`check`, `patch`, `verify`, `rollback`, `cleanup`, `sign-descriptor`) |
 
 Global flags:
@@ -141,6 +144,12 @@ Hina installs apps under user-scope OS-standard directories. No admin / sudo req
 | Windows | `%LOCALAPPDATA%\Hina\Apps\` | `%LOCALAPPDATA%\Hina\registry.json` | `%LOCALAPPDATA%\Hina\bin\` (auto-added to user PATH) |
 | Linux | `~/.local/share/hina/apps/` (or `$XDG_DATA_HOME/hina/apps`) | `~/.local/share/hina/registry.json` | `~/.local/bin/` |
 | macOS | `~/Library/Application Support/Hina/Apps/` | `~/Library/Application Support/Hina/registry.json` | `~/.local/bin/` |
+
+Each registry row also carries a `userGrants` list — the absolute filesystem paths
+the user has granted a sandboxed app via `hina perms --grant`, additive over the
+descriptor's declared scope and preserved across updates. The cached descriptor
+that backs `run`/`perms`/`verify` is written atomically, so a crash mid-write can
+never leave a half-written descriptor behind.
 
 Shortcut destinations:
 
@@ -189,6 +198,15 @@ Minimal example:
       "terminal": false }
   ],
 
+  "sandbox": {
+    "enabled": true,
+    "filesystem": [
+      { "path": "home",           "access": "ro" },
+      { "path": "xdg-documents",  "access": "rw" }
+    ],
+    "capabilities": { "network": true, "audio": false, "microphone": false, "screen": false, "input": false, "devices": false }
+  },
+
   "postInstall": [
     { "action": "addToPath",         "name": "fooedit", "target": "bin/fooedit" },
     { "action": "registerMimeType",  "mimeType": "application/x-fooedit", "extensions": [".foo"], "entryId": "main" },
@@ -205,6 +223,39 @@ Minimal example:
 }
 ```
 
+### The optional `sandbox` block
+
+`sandbox` is an optional top-level object and is part of the signed payload. Absent
+or `"enabled": false` ⇒ the app runs **unsandboxed** (legacy behavior, full user
+privileges). Set `"enabled": true` to opt in.
+
+**`filesystem[]`** — each entry is `{ "path": <token>, "access": "ro" | "rw" }`. The
+`path` is an **abstract token**, never a raw host path, so the same descriptor
+resolves correctly across machines and users:
+
+| Token | Resolves to |
+|-------|-------------|
+| `app` | the install directory — **always implicitly granted** (read-only + exec); listing it is harmless |
+| `home` | the user's home directory |
+| `xdg-documents` | the user's Documents directory |
+| `xdg-download` | the user's Downloads directory |
+| `xdg-config` | the user's config directory |
+| `tmp` | the temp directory |
+| `host` | **no filesystem restriction** — an escape hatch, flagged loudly at install. Use it only as a last resort |
+
+Any token outside this set is rejected at validation (fail closed — Hina never
+silently grants an unknown path).
+
+**`capabilities`** — declared-only booleans: `network`, `audio`, `microphone`,
+`screen`, `input`, `devices`. **None of these are enforced in v1.** They are
+surfaced to the user (by `hina perms`) as *"declared — not enforced"* so the
+display never implies isolation Hina does not provide.
+
+**What is enforced where** — only the **filesystem** scope is enforced, and only on
+**Linux** (via Landlock). On macOS and Windows the declared scope is shown at
+install time with a warning that it is *not* applied. See the [Sandboxing](#sandboxing)
+section for the full model.
+
 ### Validation rules
 
 - `name` matches `^[a-z][a-z0-9-]{1,63}$`
@@ -213,7 +264,10 @@ Minimal example:
 - `publicKey` is a valid base64 32-byte Ed25519 key
 - Hook paths (`target`, `exec`, `icon`, `files`) are relative — no `..`, no absolute paths
 - Every hook `entryId` must match an `entries[].id`
+- `entries[].id` matches `^[A-Za-z0-9][A-Za-z0-9._-]{0,63}$` (it flows into the `.desktop` Exec via the `hina run` launch command)
 - `exec` must define at least one platform
+- `sandbox.filesystem[].path` must be a known token (`app`, `home`, `xdg-documents`, `xdg-download`, `xdg-config`, `tmp`, `host`); unknown tokens are rejected
+- `sandbox.filesystem[].access` is `ro` or `rw`
 
 ### `baseUrl` content
 
@@ -272,6 +326,48 @@ idempotent — repeated runs converge to "clean".
 
 ---
 
+## Sandboxing
+
+A publisher can opt an app into a Flatpak-style filesystem sandbox via the
+[`sandbox` block](#the-optional-sandbox-block). The enforcement model in v1 is
+deliberately narrow:
+
+- **Filesystem scope is the only enforced category**, and **only on Linux** (via
+  Landlock — kernel ≥ 5.13, unprivileged, no root or bubblewrap). `hina run`
+  installs the Landlock ruleset, then `execv`s the app; the restrictions are
+  inherited across the exec, so the app's process is the restricted one.
+- **macOS and Windows do not enforce the sandbox yet** (those backends are
+  deferred). Installing a sandboxed app there warns that it runs with full user
+  privileges, and its shortcut launches the binary directly — it does **not**
+  route through `hina run` (which would gain nothing).
+- **Old kernel / no Landlock** → a no-op plus a one-time warning. A missing or
+  too-old sandbox backend never blocks a launch.
+- **Capabilities are declared-only.** `network`, `audio`, `microphone`, `screen`,
+  `input`, and `devices` are surfaced to the user as *"declared — not enforced"*;
+  nothing restricts them in v1.
+- **No portals.** There are no dynamic file-picker grants. Scope is the static set
+  of declared paths plus any paths the user grants manually.
+
+The app dir is always granted read-only + exec, even when the descriptor doesn't
+list `app`.
+
+### Inspecting and granting permissions
+
+`hina perms` shows what each app declared and what the user has granted:
+
+```shell
+hina perms               # table of all installed apps
+hina perms <app>         # full detail for one app
+hina perms <app> --grant <path>[:ro|:rw]   # add a runtime filesystem grant (defaults to ro)
+hina perms <app> --revoke <path>           # remove a grant
+```
+
+User grants are stored as absolute resolved paths in the registry's `userGrants`
+and are **kept across updates** — they are the only way to widen a sandboxed app's
+filesystem reach beyond its declared scope.
+
+---
+
 ## Update Flow
 
 `hina update [name]` re-fetches the descriptor for one or all installed apps:
@@ -281,10 +377,19 @@ idempotent — repeated runs converge to "clean".
    up-to-date (use `--force` to re-run the patcher anyway).
 3. Diff hook identity and entry id between the old registry record and the new
    descriptor.
-4. Call `PatchClient.PatchAsync` for a delta download (rsync rolling checksums
+4. **Diff the sandbox permissions** of the old (cached) descriptor against the new
+   one. A **broadening** change — a new filesystem path, `host` added, a `ro → rw`
+   widening, a newly-declared capability, or the sandbox being removed/disabled —
+   is **refused** before anything touches disk, unless the user re-runs with
+   `--accept-new-permissions`. A **narrowing** change — a removed path, `rw → ro`,
+   a capability turned off, or an app becoming newly/more-tightly sandboxed —
+   applies automatically.
+5. Call `PatchClient.PatchAsync` for a delta download (rsync rolling checksums
    reuse local chunks).
-5. Remove obsolete hooks and entries; add new ones.
-6. Update the registry.
+6. Remove obsolete hooks and entries; add new ones.
+7. Update the registry.
+8. Refresh the cached descriptor (atomic write) so `run`/`perms` reflect the new
+   declared scope. The user's `userGrants` persist across the update untouched.
 
 On any post-patch failure: `PatchClient.RollbackAsync` restores files from backups,
 and the registry is reverted to the pre-update snapshot.
@@ -331,18 +436,37 @@ Hina's data dir, the registry will still reference the missing app. `hina list`
 flags the row with `[missing]` and points at:
 
 ```shell
-hina verify            # report orphans across all installed apps
-hina verify --repair   # remove orphan registry entries + dangling shortcuts/symlinks
+hina verify            # report problems across all installed apps
+hina verify --deep     # also re-fetch the manifest and hash-verify every file
+hina repair            # the primary recovery command: prune orphans + dangling side-effects
 ```
+
+`hina repair` is the equivalent of `hina verify --repair`.
 
 The verifier checks each installed app's:
 
 - Install directory presence
+- **Local integrity**: the per-OS executable, every `entries[].exec`, and the
+  cached descriptor are present. A missing exec or file means the install is
+  incomplete (deleted by hand, botched patch) — the fix is `hina reinstall`, not
+  repair. `verify --deep` goes further and hash-verifies every file against the
+  manifest.
 - Each recorded shell entry's evidence (symlink target, .lnk, .app bundle, .desktop)
 - Each recorded hook's evidence (`addToPath` symlink targets, `installFont` files, MIME/URL/autostart artifacts)
 
-`--repair` is fail-soft: it logs and continues on individual failures. Safe to
-run from cron.
+`hina repair` removes orphan registry rows (whose install dir is gone) along with
+their symlinks/`.desktop` entries and dangling evidence, and sweeps up
+**true-orphan artifacts** left after a manual `registry.json` deletion (on Linux,
+stray `hina-*.desktop` entries and installed fonts). Repair is fail-soft: it logs
+and continues on individual failures. Safe to run from cron.
+
+**Manual-deletion matrix.** What to run after a hand edit Hina didn't make:
+
+| You deleted… | `hina verify` reports | Fix |
+|--------------|-----------------------|-----|
+| the app's install directory | "app directory missing" | `hina repair`, or `hina uninstall <name>` (fail-soft on the missing dir) |
+| `registry.json` | nothing per-app (the rows are gone) | `hina repair` runs the orphan-artifact scan and cleans the leftovers |
+| files inside the install dir | missing file(s) | `hina reinstall <name>` |
 
 ---
 

--- a/docs/Security.md
+++ b/docs/Security.md
@@ -264,6 +264,124 @@ For each file in manifest:
 
 ---
 
+## Sandboxing / App Isolation
+
+Hina's primary trust model is **signing-based**: a descriptor and its manifest are
+signed by a pinned publisher key (see the sections above), and whitelisted hooks
+mean a compromised publisher cannot run arbitrary code at install time. On top of
+that, an app may now opt into **filesystem isolation** so that even a fully-trusted
+but over-reaching app sees only the paths it declares.
+
+### What Is and Isn't Enforced
+
+| Surface | Status |
+|---------|--------|
+| **Filesystem scope** | Enforced **on Linux only**, via Landlock (unprivileged, kernel ≥ 5.13, no root / no bubblewrap). On macOS and Windows it is **declared but NOT enforced** — the app runs with full user privileges (warned at install time). |
+| **Capabilities** (`network`, `audio`, `microphone`, `screen`, `input`, `devices`) | **Declared-only, never enforced yet.** `hina perms` shows them as "declared — not enforced". No portals (PipeWire / Wayland / per-OS device policy) are wired up. |
+
+When a descriptor carries no `sandbox` block (or `sandbox.enabled` is `false`), the
+app launches unsandboxed exactly as before — full user privileges.
+
+### The Sandbox Block
+
+The optional `sandbox` block lives in the signed `hina.app.json`, so its scope is
+covered by the descriptor signature and cannot be tampered with in transit:
+
+```json
+{
+  "sandbox": {
+    "enabled": true,
+    "filesystem": [
+      { "path": "xdg-documents", "access": "ro" },
+      { "path": "xdg-config", "access": "rw" }
+    ],
+    "capabilities": { "network": true }
+  }
+}
+```
+
+`filesystem[].path` is an abstract token, never a raw host path, so the same
+descriptor resolves correctly across machines and users. The closed token set is:
+
+| Token | Meaning |
+|-------|---------|
+| `app` | The install directory. Always implicitly granted read-only + exec; listing it is harmless. |
+| `home` | The user's home directory. |
+| `xdg-documents` | The Documents folder. |
+| `xdg-download` | The Downloads folder. |
+| `xdg-config` | The user config folder. |
+| `tmp` | The temp directory. |
+| `host` | **Escape hatch — no filesystem restriction at all.** |
+
+Unknown tokens are rejected at descriptor validation (fail closed). `access` is
+`ro` (read-only) or `rw` (read-write); exec is implied for the app dir only.
+
+The `host` token grants **unrestricted** filesystem access — an app that requests
+it is effectively not isolated. Hina surfaces it loudly: the install-time
+disclosure prints it as an explicit `UNRESTRICTED filesystem access` warning, and
+`hina perms` renders it as `host(!)` / `host — UNRESTRICTED, no isolation`.
+
+### How Enforcement Works (`hina run`)
+
+For a sandboxed app on Linux, the shell shortcuts Hina creates do **not** point at
+the app binary — they route through `hina run <app> "<entryId>"`. `hina run`
+resolves the declared scope plus any user grants into a Landlock ruleset, applies
+it to itself (`landlock_restrict_self`), and then `execv`s the app, which inherits
+the restrictions (the app's PID is Hina's). On macOS/Windows the shortcut launches
+the app directly (routing through `hina run` would gain nothing there).
+
+If the kernel is too old for Landlock (or Landlock setup fails for any reason),
+enforcement degrades to a **no-op with a one-time warning** and the launch is never
+blocked.
+
+### Install-Time Disclosure
+
+When a sandboxed app is installed, Hina discloses the declared scope. On a host
+where the sandbox cannot be enforced (macOS/Windows), it warns plainly that the
+app **runs with FULL user privileges (no isolation)** before listing the declared
+scope, so the user is never misled into thinking isolation is in effect.
+
+### User-Granted Paths (`hina perms`)
+
+There are no portals, so a sandboxed app cannot prompt for additional paths at
+runtime. Instead the user grants them explicitly and out-of-band:
+
+```shell
+hina perms <app> --grant ~/Projects:rw
+hina perms <app> --revoke ~/Projects
+```
+
+Grants are persisted in the local registry (`InstalledApp.userGrants`) and folded
+into the Landlock ruleset alongside the descriptor-declared scope at launch. `hina
+perms` (aliases `permissions` / `permessi`) also prints a per-app table and a
+per-app detail view of declared scope, user grants, and capabilities.
+
+### Update Permission Consent
+
+A signed descriptor's sandbox scope can change between versions. Hina diffs the
+old (cached) descriptor against the new one and classifies the change:
+
+- **Narrowing** (tighter scope, `rw → ro`, a dropped capability, or newly enabling
+  the sandbox) applies automatically.
+- **Broadening** — a new path, the `host` token, `ro → rw`, a new capability, or
+  **removing the sandbox entirely** (which regains full filesystem access) — is
+  **refused before any file is touched** until the user re-runs with
+  `hina update --accept-new-permissions`.
+
+This stops a previously-narrow app from silently widening its own reach through a
+routine update.
+
+### Descriptor `entries[].id` Hardening
+
+Each `entries[].id` is charset-validated against `^[A-Za-z0-9][A-Za-z0-9._-]{0,63}$`
+at descriptor validation. The id flows into the generated `.desktop` file (both its
+filename and, for sandboxed apps, the `Exec=` line as `hina run <app> "<id>"`).
+Restricting it to a safe token closes a command-injection surface: even a
+**signed-but-hostile** descriptor cannot smuggle shell metacharacters or path
+separators into the launch command.
+
+---
+
 ## Threat Model
 
 ### Attacks Hina Protects Against

--- a/docs/Troubleshooting.md
+++ b/docs/Troubleshooting.md
@@ -576,6 +576,179 @@ If you re-built the app without bumping the version, no update is performed.
 
 ---
 
+### PM8. App Declares a Sandbox but Isn't Isolated on macOS/Windows
+
+**Symptom:**
+
+The app's `hina.app.json` declares a `sandbox` block, but on macOS or Windows the
+app can still read and write anywhere. At install time you saw:
+
+```
+warn: This app DECLARES a filesystem sandbox, but Hina does not enforce sandboxing
+      on this OS yet. The app will run with FULL user privileges (no isolation).
+```
+
+**Cause:**
+
+Filesystem sandboxing is enforced **only on Linux** (via Landlock). On macOS and
+Windows the declared scope is shown but **not applied** — the app runs with full
+user privileges. This is expected, not a bug.
+
+**Solutions:**
+
+- Treat the declared scope as advisory on macOS/Windows.
+- Run `hina perms <app>` to see what the app declares; the table footer and the
+  detail view both state which surfaces are actually enforced.
+
+---
+
+### PM9. Update Fails Asking for `--accept-new-permissions`
+
+**Error:**
+
+```
+'demo' 2.0.0 requests broader permissions (home (rw), capability: network).
+Re-run with `--accept-new-permissions` to allow it.
+```
+
+**Cause:**
+
+The new version of the descriptor *broadens* the app's sandbox: a new path, the
+`host` token, a `ro → rw` upgrade, a new capability, or removing the sandbox
+entirely. Hina refuses to silently widen an installed app's reach, so it stops
+before touching any files.
+
+**Solutions:**
+
+- Review the listed `+` permission changes. If you trust them, re-run:
+
+  ```shell
+  hina update demo --accept-new-permissions
+  ```
+
+- If the new scope looks wrong, verify with the publisher before accepting.
+  *Narrowing* changes never require this flag — they apply automatically.
+
+---
+
+### PM10. `hina verify` Reports a Missing File / App Corrupt
+
+**Symptom:**
+
+```
+demo (1.2.0)
+  install path: ...
+  - descriptor cache missing
+  - missing file: bin/demo
+
+Some apps are missing files — run `hina reinstall <app>` to restore them.
+```
+
+`hina run` may also refuse to launch with a "descriptor is missing/corrupt;
+cannot launch safely" message. Or `hina verify --deep` reports
+`N file(s) corrupt or missing (hash check)`.
+
+**Cause:**
+
+A declared executable, an `entries[].exec`, or the cached descriptor is missing,
+or (with `--deep`) a file's content no longer matches the manifest hash — i.e. the
+install is incomplete or has been tampered with.
+
+**Solutions:**
+
+```shell
+hina verify <app>          # offline: missing exec / entries / descriptor cache
+hina verify <app> --deep   # network: hash every file against the manifest
+hina reinstall <app>       # re-run the full install to restore the files
+```
+
+`hina reinstall` is the recovery path Hina points you at for any "missing file" /
+"descriptor cache missing" condition.
+
+---
+
+### PM11. I Deleted an App Folder or `registry.json` by Hand — Now There Are Leftovers
+
+**Symptom:**
+
+`hina list` shows an app with `[missing]`, or shortcuts / PATH symlinks / MIME and
+URL-scheme registrations point at a directory that no longer exists. After deleting
+`registry.json` itself, the app directories and their side-effects are still on
+disk with no registry to track them.
+
+**Cause:**
+
+The registry row and the on-disk side-effects (shortcuts, hooks) outlived the app
+directory, or the whole registry was removed leaving "orphan" artifacts with no
+backing entry.
+
+**Solutions:**
+
+```shell
+hina verify          # show every dangling entry / shortcut / hook / orphan
+hina repair          # = `hina verify --repair`: remove them all (idempotent)
+hina uninstall <app> # also works even when the app directory is already gone
+```
+
+`hina repair` prunes orphan registry rows, dangling shortcuts/hooks, and
+true-orphan artifacts left after a manual `registry.json` deletion. It is safe to
+re-run (e.g. from cron).
+
+---
+
+### PM12. Sandboxed App Won't Start / Landlock
+
+**Symptom:**
+
+Launching a sandboxed app on Linux, the log shows one of:
+
+```
+warn: Landlock ruleset creation failed; running unsandboxed.
+warn: This app requested filesystem sandboxing, but this platform cannot enforce
+      it. Running unsandboxed.
+```
+
+The app still starts.
+
+**Cause:**
+
+The kernel is older than 5.13 (or lacks Landlock), so Hina cannot build the
+ruleset. Enforcement degrades to a **no-op with a one-time warning** — by design,
+Hina never blocks a launch over an unenforceable sandbox.
+
+**Solutions:**
+
+- If you want enforcement, run on a kernel ≥ 5.13 with Landlock available
+  (unprivileged Landlock; no root or bubblewrap needed).
+- Otherwise the app runs unsandboxed; this is safe to ignore if you trust the
+  publisher (the descriptor is still signature-verified).
+
+---
+
+### PM13. `hina perms` Shows ✓ but the App Still Can't Access X
+
+**Symptom:**
+
+`hina perms <app>` shows a capability (e.g. `Network`, `Audio`, `Microphone`) as
+`✓` / "declared (not enforced)", but the app behaves as if it has — or lacks —
+that access regardless.
+
+**Cause:**
+
+Non-filesystem **capabilities are declared intent only**. Hina does not enforce
+`network` / `audio` / `microphone` / `screen` / `input` / `devices` yet (no
+portals). The `✓` records what the app *asked for*, not a grant Hina is policing.
+Only the filesystem column (`FS`) is actually enforced, and only on Linux.
+
+**Solutions:**
+
+- For filesystem access, use `hina perms <app> --grant <path>[:rw]` — that is the
+  one surface Hina enforces (Linux/Landlock).
+- For capabilities, the OS itself governs access; treat the `hina perms` marker as
+  a disclosure of the app's declared intent, not a Hina-applied control.
+
+---
+
 ## Reporting Bugs
 
 If you encounter an issue not covered here:

--- a/scripts/landlock-probe.sh
+++ b/scripts/landlock-probe.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+#
+# Landlock filesystem-sandbox integration probe.
+#
+# Runs a child (/bin/sh) under a Hina sandbox that grants:
+#   - the system dirs the interpreter needs (read-only)
+#   - a "documents" dir (read-write)
+# but deliberately does NOT grant a "secret" dir. Under real Landlock
+# enforcement the child must be DENIED reading the secret and ALLOWED writing
+# the document. On a host without Landlock (old kernel / disabled), Hina logs
+# "cannot enforce" and runs unsandboxed — the probe then skips with success so
+# the CI job stays green on non-Landlock runners (e.g. macOS).
+#
+# Usage: landlock-probe.sh <hina-exec> [hina-exec-args...]
+#   e.g. landlock-probe.sh ./Hina.CLI
+#        landlock-probe.sh dotnet bin/.../Hina.CLI.dll
+set -u
+
+if [ "$#" -lt 1 ]; then
+  echo "usage: $0 <hina-exec> [args...]" >&2
+  exit 2
+fi
+HINA=( "$@" )
+
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+APP="$WORK/app"; DOCS="$WORK/docs"; SECRET="$WORK/secret"
+mkdir -p "$APP" "$DOCS" "$SECRET"
+echo "topsecret" > "$SECRET/key"
+
+STDERR="$WORK/stderr"
+
+# The inner command interpolates absolute paths (the sandboxed shell does not
+# inherit our shell variables reliably across the exec boundary).
+INNER="r=0; w=0
+cat '$SECRET/key' >/dev/null 2>&1 && r=1
+echo data > '$DOCS/out' 2>/dev/null && w=1
+echo \"READ=\$r WRITE=\$w\""
+
+OUT="$(
+  "${HINA[@]}" dev sandbox-run \
+    --app-dir "$APP" \
+    --allow /usr:ro --allow /lib:ro --allow /lib64:ro --allow /bin:ro \
+    --allow /etc:ro --allow /dev:rw \
+    --allow "$DOCS:rw" \
+    -- /bin/sh -c "$INNER" 2>"$STDERR"
+)"
+
+echo "---- probe stdout ----"; echo "$OUT"
+echo "---- probe stderr ----"; cat "$STDERR"
+echo "---- kernel: $(uname -r) ----"
+
+if grep -q "cannot enforce" "$STDERR" || echo "$OUT" | grep -q "cannot enforce"; then
+  echo "SKIP: Landlock not supported on this host (kernel $(uname -r)); passing."
+  exit 0
+fi
+
+if echo "$OUT" | grep -q "READ=0 WRITE=1"; then
+  echo "PASS: secret read denied, document write allowed under Landlock."
+  exit 0
+fi
+
+echo "FAIL: expected 'READ=0 WRITE=1' (secret denied, docs writable)." >&2
+exit 1


### PR DESCRIPTION
## What

Adds opt-in, Flatpak-style **filesystem isolation** to Hina, plus the user-facing tooling around it. Until now an installed app ran with full user privileges and zero sandbox; a signed descriptor meant trusting the publisher with the whole home directory.

Six commits:

1. **feat(sandbox)** — Linux/Landlock v1 engine + `hina run` launcher pivot. Sandboxed apps' shortcuts route through `hina run <app> <entry>`, which installs a Landlock ruleset (unprivileged, kernel ≥5.13, no root/bubblewrap) then execs the app. macOS/Windows fall back to a no-op launcher behind the same `ISandboxLauncher` interface (deferred backends). Descriptor gains a signed `sandbox` block (filesystem path tokens + ro/rw, declared capabilities).
2. **test(sandbox)** — Landlock enforcement integration probe (`scripts/landlock-probe.sh` + `hina dev sandbox-run`), wired into CI. Skip-passes on non-Landlock hosts.
3. **feat(perms)** — `hina perms` / `permissions` / `permessi`: overview table of all apps + per-app detail; `--grant`/`--revoke` user filesystem grants.
4. **fix(audit)** — security + lifecycle hardening: `entries[].id` charset validation (closes a `.desktop` Exec injection surface), OS-aware sandbox disclosure (macOS/Windows warn "not enforced"), atomic descriptor cache written before the registry commit, guards for manually-deleted install dirs, and `hina repair` (orphan registry rows + dangling evidence + true-orphan artifact scan).
5. **feat(verify+update)** — `hina verify` integrity (missing exec/files + `--deep` manifest hash) and update permission consent (`hina update --accept-new-permissions` blocks broadening updates; narrowing auto-applies).
6. **docs** — full docs/* coverage.

## Enforcement scope

- Filesystem scope is the **only enforced** category, and **only on Linux** (Landlock). macOS/Windows: declared but not enforced (warned at install). Capabilities (network/audio/mic/screen/input/devices) are **declared-only**, never enforced yet. No portals.

## Verification

- **382 tests green** (was 322; +60). AOT publish clean (no IL/trim warnings).
- Manual e2e on the AOT binary: perms table/detail, repair after manual deletion, verify integrity, update consent gate.
- ⚠️ **Landlock enforcement could not be verified on the dev host (macOS, no Docker).** The CI probe job on this PR is the real gate — it runs the sandbox on an Ubuntu runner and asserts a secret read is denied while a granted write succeeds.

## Deferred (follow-ups)

macOS `sandbox-exec` + Windows AppContainer backends; capability enforcement; portals (dynamic grants).

🤖 Generated with [Claude Code](https://claude.com/claude-code)