### PR TITLE
Sandbox v2: system-runtime grants + network enforcement + macOS backend

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -50,3 +50,21 @@ jobs:
         echo "Using hina: $HINA (kernel $(uname -r))"
         chmod +x scripts/landlock-net-probe.sh
         bash scripts/landlock-net-probe.sh "$HINA"
+
+  macos-sandbox:
+    runs-on: macos-latest
+    steps:
+    - uses: actions/checkout@v3
+    - name: Setup .NET
+      uses: actions/setup-dotnet@v3
+      with:
+        dotnet-version: 10.0.x
+    - name: Restore dependencies
+      run: dotnet restore
+    - name: Build
+      run: dotnet build --no-restore -c Release
+    # The macOS sandbox-exec backend is enforced here: MacOsSandboxTests runs a real
+    # sandbox-exec child and asserts an ungranted read is denied + a granted write
+    # allowed. It is a no-op assert off macOS, so this job is its real proof.
+    - name: Test (incl. sandbox-exec enforcement)
+      run: dotnet test --no-build -c Release --verbosity normal

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -43,3 +43,10 @@ jobs:
         echo "Using hina: $HINA (kernel $(uname -r))"
         chmod +x scripts/landlock-probe.sh
         bash scripts/landlock-probe.sh "$HINA"
+    - name: Landlock network sandbox probe
+      run: |
+        HINA="$(find Hina.CLI/bin/Release -type f -name Hina.CLI | head -1)"
+        if [ -z "$HINA" ]; then echo "hina binary not found" >&2; exit 1; fi
+        echo "Using hina: $HINA (kernel $(uname -r))"
+        chmod +x scripts/landlock-net-probe.sh
+        bash scripts/landlock-net-probe.sh "$HINA"

--- a/Hina.CLI/Commands/DevCommand.cs
+++ b/Hina.CLI/Commands/DevCommand.cs
@@ -126,8 +126,9 @@ namespace Hina.CLI.Commands
             Console.WriteLine("                       Attach an Ed25519 signature to a descriptor file.");
             Console.WriteLine();
             Console.WriteLine("Sandbox subcommand:");
-            Console.WriteLine("  sandbox-run --app-dir <dir> [--allow <path>[:ro|:rw] ...] [--host] -- <exec> [args...]");
+            Console.WriteLine("  sandbox-run --app-dir <dir> [--allow <path>[:ro|:rw] ...] [--host] [--deny-network] -- <exec> [args...]");
             Console.WriteLine("                       Apply a filesystem sandbox (Landlock on Linux) then exec.");
+            Console.WriteLine("                       --deny-network blocks TCP bind/connect (Landlock ABI >= 4 / kernel 6.7+).");
         }
 
         // `hina dev sandbox-run --app-dir <dir> [--allow <path>[:ro|:rw] ...] [--host] -- <exec> [args...]`
@@ -160,9 +161,11 @@ namespace Hina.CLI.Commands
                 new ResolvedFsRule(Path.GetFullPath(appDir), canWrite: false),
             };
             bool unrestricted = false;
+            bool denyNetwork = false;
             for (int i = 0; i < sep; i++)
             {
                 if (args[i] == "--host") { unrestricted = true; continue; }
+                if (args[i] == "--deny-network") { denyNetwork = true; continue; }
                 if (args[i] != "--allow" || i + 1 >= sep) continue;
                 string spec = args[++i];
                 bool rw = spec.EndsWith(":rw", StringComparison.Ordinal);
@@ -171,7 +174,7 @@ namespace Hina.CLI.Commands
                 rules.Add(new ResolvedFsRule(Path.GetFullPath(p), rw));
             }
 
-            SandboxPlan plan = new SandboxPlan(unrestricted, rules);
+            SandboxPlan plan = new SandboxPlan(unrestricted, rules, restrictNetwork: denyNetwork);
             ISandboxLauncher launcher = SandboxLauncherFactory.Current(logger);
             logger.LogDebug("Sandbox backend supported: {Supported}", launcher.IsSupported);
             return launcher.Launch(Path.GetFullPath(exec), execArgs, plan, CancellationToken.None);

--- a/Hina.CLI/Commands/InfoCommand.cs
+++ b/Hina.CLI/Commands/InfoCommand.cs
@@ -1,8 +1,10 @@
 using System;
 using System.IO;
 using System.Threading.Tasks;
+using Hina.PackageManager.Descriptor;
 using Hina.PackageManager.Install;
 using Hina.PackageManager.Registry;
+using Hina.PackageManager.Sandbox;
 using Microsoft.Extensions.Logging;
 
 namespace Hina.CLI.Commands
@@ -49,6 +51,23 @@ namespace Hina.CLI.Commands
                 Console.WriteLine("Hooks:");
                 foreach (HookEvidence h in app.ExecutedHooks) Console.WriteLine($"  - {h.Action}: {h.Evidence}");
             }
+            // Sandbox / permission summary, from the cached descriptor (best-effort:
+            // a missing or corrupt cache just omits the block — info must not fail).
+            string descPath = ctx.Paths.DescriptorCache(name);
+            if (File.Exists(descPath))
+            {
+                try
+                {
+                    AppDescriptor desc = DescriptorParser.Parse(await File.ReadAllTextAsync(descPath, ctx.Ct));
+                    AppPermissions perms = AppPermissions.From(desc, app);
+                    Console.Write(PermissionsFormatter.Compact(perms));
+                }
+                catch (Exception ex)
+                {
+                    ctx.Logger.LogDebug(ex, "Could not render sandbox summary for {Name}", name);
+                }
+            }
+
             if (!string.IsNullOrEmpty(installSuffix))
             {
                 Console.WriteLine();

--- a/Hina.PackageManager.Tests/LinuxSystemRuntimePathsTests.cs
+++ b/Hina.PackageManager.Tests/LinuxSystemRuntimePathsTests.cs
@@ -1,0 +1,60 @@
+using System.Collections.Generic;
+using System.Linq;
+using Hina.PackageManager.Sandbox;
+using Xunit;
+
+namespace Hina.PackageManager.Tests
+{
+    // Guards the curated list of implicit system-runtime paths that a Linux
+    // Landlock sandbox must grant so dynamically-linked apps can load their
+    // loader + libc + system libs. Without these, only fully self-contained
+    // (static/AOT) binaries run; everything else EACCES at startup.
+    public class LinuxSystemRuntimePathsTests
+    {
+        private static IReadOnlyList<ResolvedFsRule> Paths => LinuxLandlockSandbox.SystemRuntimePaths;
+
+        [Theory]
+        [InlineData("/usr")]
+        [InlineData("/lib")]
+        [InlineData("/lib64")]
+        [InlineData("/bin")]
+        [InlineData("/sbin")]
+        [InlineData("/etc")]
+        public void GrantsReadOnSystemLibraryDirs(string path)
+        {
+            ResolvedFsRule? rule = Paths.FirstOrDefault(r => r.Path == path);
+            Assert.NotNull(rule);
+            Assert.False(rule!.CanWrite); // loader/libs are read+exec only, never writable.
+        }
+
+        [Theory]
+        [InlineData("/dev/null")]
+        [InlineData("/dev/zero")]
+        [InlineData("/dev/full")]
+        [InlineData("/dev/random")]
+        [InlineData("/dev/urandom")]
+        [InlineData("/dev/tty")]
+        public void GrantsReadWriteOnCommonDeviceNodes(string path)
+        {
+            ResolvedFsRule? rule = Paths.FirstOrDefault(r => r.Path == path);
+            Assert.NotNull(rule);
+            Assert.True(rule!.CanWrite); // device nodes are written to (e.g. /dev/null).
+        }
+
+        [Fact]
+        public void DoesNotGrantAllOfDev()
+        {
+            // Granting all of /dev would expose block devices, /dev/mem, etc.
+            // Only the specific safe nodes above are granted.
+            Assert.DoesNotContain(Paths, r => r.Path == "/dev");
+        }
+
+        [Fact]
+        public void DoesNotGrantSensitiveSecretDirs()
+        {
+            // DAC still protects /etc/shadow as non-root, but the curated list
+            // must never broaden to whole-home or root.
+            Assert.DoesNotContain(Paths, r => r.Path == "/" || r.Path == "/root" || r.Path == "/home");
+        }
+    }
+}

--- a/Hina.PackageManager.Tests/MacOSPlatformIntegrationTests.cs
+++ b/Hina.PackageManager.Tests/MacOSPlatformIntegrationTests.cs
@@ -69,6 +69,30 @@ namespace Hina.PackageManager.Tests
         }
 
         [Fact]
+        public async Task CreateMenuShortcut_WithLaunchOverride_WritesScriptStubNotSymlink()
+        {
+            if (!_supportsSymlinks) return;
+
+            string appDir = Path.Combine(_tempDir, "sandboxed");
+            string execAbs = Path.Combine(appDir, "bin", "demo");
+            Directory.CreateDirectory(Path.GetDirectoryName(execAbs)!);
+            File.WriteAllText(execAbs, "#!/bin/sh\necho hi\n");
+
+            ShellEntry entry = new ShellEntry { Id = "main", Name = "Boxed App", Exec = "bin/demo" };
+            string launchOverride = "\"/usr/local/bin/hina\" run boxed \"main\"";
+            string bundlePath = await _platform.CreateMenuShortcut(entry, appDir, launchOverride, CancellationToken.None);
+
+            string bundleExec = Path.Combine(bundlePath, "Contents", "MacOS", "Boxed App");
+            // A sandboxed app must launch via `hina run`, so the bundle exec is a
+            // script that invokes the override — NOT a symlink to the raw binary
+            // (which would bypass the sandbox).
+            Assert.Null(new FileInfo(bundleExec).LinkTarget);
+            string stub = File.ReadAllText(bundleExec);
+            Assert.Contains("hina", stub);
+            Assert.Contains("run boxed", stub);
+        }
+
+        [Fact]
         public async Task RemoveMenuShortcut_DeletesBundleRecursively_AndIsIdempotent()
         {
             if (!_supportsSymlinks) return;

--- a/Hina.PackageManager.Tests/MacOsSandboxTests.cs
+++ b/Hina.PackageManager.Tests/MacOsSandboxTests.cs
@@ -1,0 +1,59 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Threading;
+using Hina.PackageManager.Sandbox;
+using Microsoft.Extensions.Logging.Abstractions;
+using Xunit;
+
+namespace Hina.PackageManager.Tests
+{
+    // Real sandbox-exec enforcement test. Unlike the Linux/Landlock path, the macOS
+    // dev host CAN run this, so it is the local proof that the Seatbelt profile
+    // actually isolates: a granted dir is writable, an ungranted dir is not readable.
+    public class MacOsSandboxTests
+    {
+        [Fact]
+        public void Launch_AllowsGrantedWrite_DeniesUngrantedRead()
+        {
+            if (!OperatingSystem.IsMacOS())
+            {
+                return; // sandbox-exec enforcement is macOS-only.
+            }
+
+            string work = Directory.CreateTempSubdirectory("hina-sbx-").FullName;
+            try
+            {
+                string docs = Path.Combine(work, "docs");
+                string secret = Path.Combine(work, "secret");
+                Directory.CreateDirectory(docs);
+                Directory.CreateDirectory(secret);
+                File.WriteAllText(Path.Combine(secret, "key"), "topsecret");
+
+                // docs is granted rw; secret is NOT granted. /bin (sh, cat) is in the
+                // system baseline so the interpreter can run.
+                SandboxPlan plan = new SandboxPlan(
+                    unrestricted: false,
+                    new List<ResolvedFsRule> { new ResolvedFsRule(docs, canWrite: true) },
+                    restrictNetwork: false);
+
+                string inner =
+                    $"r=0; w=0; " +
+                    $"cat '{secret}/key' >/dev/null 2>&1 && r=1; " +
+                    $"echo data > '{docs}/out' 2>/dev/null && w=1; " +
+                    $"echo \"$r$w\" > '{docs}/result'";
+
+                MacOsSandbox sandbox = new MacOsSandbox(NullLogger.Instance);
+                Assert.True(sandbox.IsSupported);
+                sandbox.Launch("/bin/sh", new[] { "-c", inner }, plan, CancellationToken.None);
+
+                string result = File.ReadAllText(Path.Combine(docs, "result")).Trim();
+                Assert.Equal("01", result); // read denied (0), write allowed (1)
+            }
+            finally
+            {
+                try { Directory.Delete(work, recursive: true); } catch { /* best-effort */ }
+            }
+        }
+    }
+}

--- a/Hina.PackageManager.Tests/MacOsSeatbeltProfileTests.cs
+++ b/Hina.PackageManager.Tests/MacOsSeatbeltProfileTests.cs
@@ -1,0 +1,78 @@
+using System.Collections.Generic;
+using Hina.PackageManager.Sandbox;
+using Xunit;
+
+namespace Hina.PackageManager.Tests
+{
+    // The Seatbelt (.sb) profile is the testable, pure core of the macOS sandbox
+    // backend. sandbox-exec enforcement itself is exercised by an integration test
+    // / CI probe; here we lock down the generated policy text.
+    public class MacOsSeatbeltProfileTests
+    {
+        private static SandboxPlan Plan(bool restrictNetwork, params ResolvedFsRule[] rules)
+            => new SandboxPlan(unrestricted: false, rules, restrictNetwork);
+
+        [Fact]
+        public void StartsWithVersionAndDeniesByDefault()
+        {
+            string p = MacOsSeatbeltProfile.Build(Plan(false, new ResolvedFsRule("/apps/demo", false)));
+            Assert.StartsWith("(version 1)", p);
+            Assert.Contains("(deny default)", p);
+        }
+
+        [Fact]
+        public void AllowsProcessExec()
+        {
+            string p = MacOsSeatbeltProfile.Build(Plan(false, new ResolvedFsRule("/apps/demo", false)));
+            Assert.Contains("(allow process-exec", p);
+            Assert.Contains("(allow process-fork)", p);
+        }
+
+        [Fact]
+        public void ReadOnlyRule_GrantsReadNotWrite()
+        {
+            string p = MacOsSeatbeltProfile.Build(Plan(false, new ResolvedFsRule("/data/docs", false)));
+            Assert.Contains("(allow file-read* (subpath \"/data/docs\"))", p);
+            Assert.DoesNotContain("(allow file-write* (subpath \"/data/docs\"))", p);
+        }
+
+        [Fact]
+        public void ReadWriteRule_GrantsReadAndWrite()
+        {
+            string p = MacOsSeatbeltProfile.Build(Plan(false, new ResolvedFsRule("/data/docs", true)));
+            Assert.Contains("(allow file-read* (subpath \"/data/docs\"))", p);
+            Assert.Contains("(allow file-write* (subpath \"/data/docs\"))", p);
+        }
+
+        [Fact]
+        public void IncludesSystemBaselineReads()
+        {
+            // A GUI/CLI app must read the dyld cache + system frameworks to start.
+            string p = MacOsSeatbeltProfile.Build(Plan(false, new ResolvedFsRule("/apps/demo", false)));
+            Assert.Contains("(subpath \"/usr/lib\")", p);
+            Assert.Contains("(subpath \"/System\")", p);
+        }
+
+        [Fact]
+        public void NetworkRestricted_OmitsNetworkAllow()
+        {
+            string p = MacOsSeatbeltProfile.Build(Plan(restrictNetwork: true, new ResolvedFsRule("/apps/demo", false)));
+            Assert.DoesNotContain("(allow network", p);
+        }
+
+        [Fact]
+        public void NetworkAllowed_GrantsNetwork()
+        {
+            string p = MacOsSeatbeltProfile.Build(Plan(restrictNetwork: false, new ResolvedFsRule("/apps/demo", false)));
+            Assert.Contains("(allow network*)", p);
+        }
+
+        [Fact]
+        public void EscapesQuotesInPaths()
+        {
+            // A path containing a double quote must not break out of the string literal.
+            string p = MacOsSeatbeltProfile.Build(Plan(false, new ResolvedFsRule("/weird/\"x\"", false)));
+            Assert.Contains("\\\"x\\\"", p);
+        }
+    }
+}

--- a/Hina.PackageManager.Tests/PermissionsFormatterTests.cs
+++ b/Hina.PackageManager.Tests/PermissionsFormatterTests.cs
@@ -104,6 +104,45 @@ namespace Hina.PackageManager.Tests
         }
 
         [Fact]
+        public void CapabilityDisclosure_NetworkDeniedAndDeclaredExtras()
+        {
+            // network not declared -> denied & enforced; audio declared -> not enforced.
+            CapabilitySpec caps = new CapabilitySpec { Network = false, Audio = true };
+            string text = string.Join("\n", PermissionsFormatter.CapabilityDisclosure(caps)).ToLowerInvariant();
+            Assert.Contains("network", text);
+            Assert.Contains("denied", text);
+            Assert.Contains("audio", text);
+            Assert.Contains("not enforced", text);
+        }
+
+        [Fact]
+        public void CapabilityDisclosure_NetworkAllowed_OmitsUndeclaredCaps()
+        {
+            CapabilitySpec caps = new CapabilitySpec { Network = true };
+            var lines = PermissionsFormatter.CapabilityDisclosure(caps);
+            string text = string.Join("\n", lines).ToLowerInvariant();
+            Assert.Contains("network", text);
+            Assert.Contains("allowed", text);
+            // Undeclared caps are not listed (keep disclosure terse).
+            Assert.DoesNotContain("microphone", text);
+        }
+
+        [Fact]
+        public void Compact_SandboxedApp_ShowsScopeAndNetwork()
+        {
+            string c = PermissionsFormatter.Compact(Sample()).ToLowerInvariant();
+            Assert.Contains("sandbox", c);
+            Assert.Contains("network", c);
+        }
+
+        [Fact]
+        public void Compact_UnsandboxedApp_SaysNoIsolation()
+        {
+            string c = PermissionsFormatter.Compact(new AppPermissions { Name = "oldapp", SandboxEnabled = false }).ToLowerInvariant();
+            Assert.Contains("no isolation", c);
+        }
+
+        [Fact]
         public void Detail_DisabledSandboxWarnsNoIsolation()
         {
             string d = PermissionsFormatter.Detail(new AppPermissions { Name = "oldapp", SandboxEnabled = false });

--- a/Hina.PackageManager.Tests/PermissionsFormatterTests.cs
+++ b/Hina.PackageManager.Tests/PermissionsFormatterTests.cs
@@ -28,8 +28,24 @@ namespace Hina.PackageManager.Tests
             Assert.Contains("APP", t);
             Assert.Contains("NET", t);
             Assert.Contains("DEV", t);
-            // Legend must state only filesystem is enforced.
-            Assert.Contains("only filesystem", t.ToLowerInvariant());
+            // Legend must say filesystem AND network are enforced now (no longer
+            // "only filesystem"), and that the remaining caps are not enforced.
+            string lower = t.ToLowerInvariant();
+            Assert.DoesNotContain("only filesystem", lower);
+            Assert.Contains("network", lower);
+            Assert.Contains("enforced", lower);
+        }
+
+        [Fact]
+        public void Detail_NetworkDenied_ShownAsEnforced()
+        {
+            // A sandboxed app that did not declare network has it DENIED — and that
+            // denial is enforced (Linux 6.7+/macOS), not merely declared.
+            AppPermissions p = new AppPermissions { Name = "boxed", SandboxEnabled = true, Network = false };
+            string d = PermissionsFormatter.Detail(p).ToLowerInvariant();
+            Assert.Contains("network", d);
+            Assert.Contains("denied", d);
+            Assert.DoesNotContain("network:      declared (not enforced)", d);
         }
 
         [Fact]

--- a/Hina.PackageManager.Tests/SandboxPlannerTests.cs
+++ b/Hina.PackageManager.Tests/SandboxPlannerTests.cs
@@ -81,6 +81,55 @@ namespace Hina.PackageManager.Tests
         }
 
         [Fact]
+        public void Build_NoCapabilities_RestrictsNetwork()
+        {
+            // A sandbox that declares no capability block grants no network — the
+            // secure default is to deny it (enforced on Landlock ABI >= 4).
+            SandboxSpec spec = new SandboxSpec { Enabled = true };
+            SandboxPlan plan = SandboxPlanner.Build(spec, new List<FsGrant>(), AppDir, Env);
+            Assert.True(plan.RestrictNetwork);
+        }
+
+        [Fact]
+        public void Build_NetworkCapabilityFalse_RestrictsNetwork()
+        {
+            SandboxSpec spec = new SandboxSpec
+            {
+                Enabled = true,
+                Capabilities = new CapabilitySpec { Network = false },
+            };
+            SandboxPlan plan = SandboxPlanner.Build(spec, new List<FsGrant>(), AppDir, Env);
+            Assert.True(plan.RestrictNetwork);
+        }
+
+        [Fact]
+        public void Build_NetworkCapabilityTrue_AllowsNetwork()
+        {
+            SandboxSpec spec = new SandboxSpec
+            {
+                Enabled = true,
+                Capabilities = new CapabilitySpec { Network = true },
+            };
+            SandboxPlan plan = SandboxPlanner.Build(spec, new List<FsGrant>(), AppDir, Env);
+            Assert.False(plan.RestrictNetwork);
+        }
+
+        [Fact]
+        public void Build_HostRule_DoesNotRestrictNetwork()
+        {
+            // host = unrestricted filesystem; there is nothing to scope, and the
+            // app explicitly opted out of isolation — don't restrict its network.
+            SandboxSpec spec = new SandboxSpec
+            {
+                Enabled = true,
+                Capabilities = new CapabilitySpec { Network = false },
+                Filesystem = new List<FsRule> { new FsRule { Path = SandboxTokens.Host, Access = "rw" } },
+            };
+            SandboxPlan plan = SandboxPlanner.Build(spec, new List<FsGrant>(), AppDir, Env);
+            Assert.False(plan.RestrictNetwork);
+        }
+
+        [Fact]
         public void Build_DuplicatePath_RwWins()
         {
             SandboxSpec spec = new SandboxSpec

--- a/Hina.PackageManager/Install/InstallService.cs
+++ b/Hina.PackageManager/Install/InstallService.cs
@@ -177,12 +177,13 @@ namespace Hina.PackageManager.Install
                 }
 
                 // [12] Shell entries. Sandboxed apps launch via `hina run` so the
-                // filesystem sandbox is installed before the app process starts — but only Linux
-                // enforces it today. On other OSes the launchOverride is ignored (the app launches
-                // directly), so we must NOT route through `hina run` (it would gain nothing) and we
-                // must tell the user the sandbox is not actually enforced here.
+                // filesystem sandbox is installed before the app process starts — enforced on
+                // Linux (Landlock) and macOS (sandbox-exec). On Windows the launchOverride is
+                // ignored (the app launches directly), so we must NOT route through `hina run`
+                // (it would gain nothing) and we must tell the user the sandbox is not enforced.
                 bool sandboxRequested = descriptor.Sandbox?.Enabled == true;
-                bool sandboxEnforceable = RuntimeInformation.IsOSPlatform(OSPlatform.Linux);
+                bool sandboxEnforceable = RuntimeInformation.IsOSPlatform(OSPlatform.Linux)
+                    || RuntimeInformation.IsOSPlatform(OSPlatform.OSX);
                 if (sandboxRequested)
                 {
                     DiscloseSandbox(descriptor.Sandbox!, sandboxEnforceable);

--- a/Hina.PackageManager/Install/InstallService.cs
+++ b/Hina.PackageManager/Install/InstallService.cs
@@ -15,6 +15,7 @@ using Hina.PackageManager.Hooks;
 using Hina.PackageManager.Paths;
 using Hina.PackageManager.Platform;
 using Hina.PackageManager.Registry;
+using Hina.PackageManager.Sandbox;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 
@@ -259,6 +260,10 @@ namespace Hina.PackageManager.Install
                 {
                     _logger.LogInformation("  - {Path} ({Access})", rule.Path, rule.Access);
                 }
+            }
+            foreach (string line in PermissionsFormatter.CapabilityDisclosure(sandbox.Capabilities))
+            {
+                _logger.LogInformation("  - {Capability}", line);
             }
             if (enforceable)
             {

--- a/Hina.PackageManager/Platform/MacOS/MacOSPlatformIntegration.cs
+++ b/Hina.PackageManager/Platform/MacOS/MacOSPlatformIntegration.cs
@@ -48,6 +48,13 @@ namespace Hina.PackageManager.Platform.MacOS
         // ---- Menu shortcut: minimal .app bundle ----
 
         public Task<string> CreateMenuShortcut(ShellEntry entry, string appDir, CancellationToken ct)
+            => CreateMenuShortcut(entry, appDir, launchOverride: null, ct);
+
+        // A sandboxed app routes through `hina run` (launchOverride) so the Seatbelt
+        // sandbox is installed before the app process starts. The bundle exec then
+        // becomes a tiny script that execs the override command — symlinking straight
+        // to the binary would bypass the sandbox.
+        public Task<string> CreateMenuShortcut(ShellEntry entry, string appDir, string? launchOverride, CancellationToken ct)
         {
             string bundlePath = WriteAppBundle(
                 bundleName: entry.Name,
@@ -55,7 +62,8 @@ namespace Hina.PackageManager.Platform.MacOS
                 execTarget: Path.Combine(appDir, entry.Exec),
                 iconRelative: entry.Icon != null ? Path.Combine(appDir, entry.Icon) : null,
                 documentTypes: null,
-                urlTypes: null);
+                urlTypes: null,
+                launchOverride: launchOverride);
             return Task.FromResult(bundlePath);
         }
 
@@ -234,7 +242,7 @@ $@"<?xml version=""1.0"" encoding=""UTF-8""?>
 
         // ---- App bundle writer ----
 
-        private string WriteAppBundle(string bundleName, string bundleId, string? execTarget, string? iconRelative, string? documentTypes, string? urlTypes)
+        private string WriteAppBundle(string bundleName, string bundleId, string? execTarget, string? iconRelative, string? documentTypes, string? urlTypes, string? launchOverride = null)
         {
             Directory.CreateDirectory(_userAppsDir);
 
@@ -246,7 +254,18 @@ $@"<?xml version=""1.0"" encoding=""UTF-8""?>
             // Stub or symlinked executable so Launch Services treats the bundle as launchable.
             string execName = SanitizeFileName(bundleName);
             string execPath = Path.Combine(macosDir, execName);
-            if (execTarget != null)
+            if (launchOverride != null)
+            {
+                // Sandboxed app: the bundle exec is a script that routes through
+                // `hina run` so the sandbox is applied before the real binary starts.
+                if (File.Exists(execPath) || new FileInfo(execPath).LinkTarget != null)
+                {
+                    TryDeleteFile(execPath, _logger);
+                }
+                File.WriteAllText(execPath, "#!/bin/sh\nexec " + StripControl(launchOverride) + " \"$@\"\n");
+                TrySetExecutable(execPath);
+            }
+            else if (execTarget != null)
             {
                 if (File.Exists(execPath) || new FileInfo(execPath).LinkTarget != null)
                 {
@@ -259,14 +278,7 @@ $@"<?xml version=""1.0"" encoding=""UTF-8""?>
                 // Helper bundles (MIME/URL) don't launch anything; tiny no-op stub keeps Launch
                 // Services happy by giving the bundle a valid CFBundleExecutable target.
                 File.WriteAllText(execPath, "#!/bin/sh\nexit 0\n");
-                try
-                {
-                    // 0755 — owner rwx, group/others rx. Best-effort: ignore on platforms that don't support it.
-                    File.SetUnixFileMode(execPath, UnixFileMode.UserRead | UnixFileMode.UserWrite | UnixFileMode.UserExecute
-                        | UnixFileMode.GroupRead | UnixFileMode.GroupExecute
-                        | UnixFileMode.OtherRead | UnixFileMode.OtherExecute);
-                }
-                catch (Exception ex) { _logger.LogDebug(ex, "Best-effort: could not set exec mode on {Path}", execPath); }
+                TrySetExecutable(execPath);
             }
 
             string plistPath = Path.Combine(contentsDir, "Info.plist");
@@ -274,6 +286,30 @@ $@"<?xml version=""1.0"" encoding=""UTF-8""?>
             File.WriteAllText(plistPath, plist);
 
             return bundlePath;
+        }
+
+        private void TrySetExecutable(string execPath)
+        {
+            try
+            {
+                // 0755 — owner rwx, group/others rx. Best-effort: ignore on platforms that don't support it.
+                File.SetUnixFileMode(execPath, UnixFileMode.UserRead | UnixFileMode.UserWrite | UnixFileMode.UserExecute
+                    | UnixFileMode.GroupRead | UnixFileMode.GroupExecute
+                    | UnixFileMode.OtherRead | UnixFileMode.OtherExecute);
+            }
+            catch (Exception ex) { _logger.LogDebug(ex, "Best-effort: could not set exec mode on {Path}", execPath); }
+        }
+
+        // Drop control characters (newlines especially) so a launch override can't
+        // inject extra script lines into the bundle exec.
+        private static string StripControl(string s)
+        {
+            StringBuilder sb = new StringBuilder(s.Length);
+            foreach (char c in s)
+            {
+                if (!char.IsControl(c)) sb.Append(c);
+            }
+            return sb.ToString();
         }
 
         private static string BuildInfoPlist(string bundleName, string bundleId, string execName, string? documentTypes, string? urlTypes)

--- a/Hina.PackageManager/Sandbox/LinuxLandlockSandbox.cs
+++ b/Hina.PackageManager/Sandbox/LinuxLandlockSandbox.cs
@@ -47,6 +47,12 @@ namespace Hina.PackageManager.Sandbox
         private const ulong FS_REFER = 1ul << 13;      // ABI v2
         private const ulong FS_TRUNCATE = 1ul << 14;   // ABI v3
 
+        // Network access-right bits (ABI v4 / kernel 6.7+). Scoping TCP bind/connect
+        // lets us actually ENFORCE the declared `network` capability.
+        private const int NET_ABI = 4;
+        private const ulong NET_BIND_TCP = 1ul << 0;
+        private const ulong NET_CONNECT_TCP = 1ul << 1;
+
         // Implicit system-runtime grants. A dynamically-linked Linux app must read
         // the loader (/lib64/ld-linux-*), libc, and system libraries to even start;
         // it also reads /etc/ld.so.cache + /etc/ld.so.conf.d. Without these grants
@@ -122,8 +128,32 @@ namespace Hina.PackageManager.Sandbox
 
             ulong handled = HandledMask(_abi);
 
-            RulesetAttr attr = new RulesetAttr { handled_access_fs = handled };
-            long rulesetFd = syscall(SYS_landlock_create_ruleset, ref attr, (UIntPtr)Marshal.SizeOf<RulesetAttr>(), 0u);
+            // Enforce the network capability when the plan denies it AND the kernel
+            // is new enough (ABI >= 4). We "handle" TCP bind+connect but add NO
+            // net-port allow rules, so every TCP bind/connect is denied. On older
+            // kernels we cannot enforce — log it so the app/operator knows the
+            // declared denial is not actually applied here.
+            ulong netHandled = 0;
+            if (plan.RestrictNetwork)
+            {
+                if (_abi >= NET_ABI)
+                {
+                    netHandled = NET_BIND_TCP | NET_CONNECT_TCP;
+                }
+                else
+                {
+                    _logger.LogInformation(
+                        "Sandbox requested network denial but Landlock ABI {Abi} < {NetAbi} (kernel < 6.7); network not enforced.",
+                        _abi, NET_ABI);
+                }
+            }
+
+            RulesetAttr attr = new RulesetAttr { handled_access_fs = handled, handled_access_net = netHandled };
+            // Pass only the fs field's size on pre-net kernels so an old Landlock
+            // doesn't reject a struct it doesn't understand; include the net field
+            // only when we actually use it.
+            UIntPtr attrSize = (UIntPtr)(netHandled != 0 ? Marshal.SizeOf<RulesetAttr>() : sizeof(ulong));
+            long rulesetFd = syscall(SYS_landlock_create_ruleset, ref attr, attrSize, 0u);
             if (rulesetFd < 0)
             {
                 _logger.LogWarning("Landlock ruleset creation failed; running unsandboxed.");
@@ -252,6 +282,7 @@ namespace Hina.PackageManager.Sandbox
         private struct RulesetAttr
         {
             public ulong handled_access_fs;
+            public ulong handled_access_net; // ABI v4+; passed only when used (see attrSize).
         }
 
         [StructLayout(LayoutKind.Sequential, Pack = 1)]

--- a/Hina.PackageManager/Sandbox/LinuxLandlockSandbox.cs
+++ b/Hina.PackageManager/Sandbox/LinuxLandlockSandbox.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Runtime.InteropServices;
 using System.Threading;
 using Microsoft.Extensions.Logging;
@@ -176,12 +177,31 @@ namespace Hina.PackageManager.Sandbox
             }
             try
             {
-                ulong allowed = (FS_READ_FILE | FS_READ_DIR | FS_EXECUTE);
-                if (rule.CanWrite)
+                // Landlock rejects (EINVAL) a path_beneath rule that carries
+                // directory-only rights (READ_DIR, MAKE_*, REMOVE_*, REFER) when the
+                // target is NOT a directory — e.g. a device node like /dev/null or a
+                // single granted file. Such a rule fails wholesale and the path ends
+                // up ungranted. So scope the access mask to what the object type
+                // supports: dirs get the full set, files/devices get file rights only.
+                bool isDir = Directory.Exists(rule.Path);
+                ulong allowed;
+                if (isDir)
                 {
-                    allowed |= FS_WRITE_FILE | FS_REMOVE_DIR | FS_REMOVE_FILE
-                             | FS_MAKE_CHAR | FS_MAKE_DIR | FS_MAKE_REG | FS_MAKE_SOCK
-                             | FS_MAKE_FIFO | FS_MAKE_BLOCK | FS_MAKE_SYM | FS_REFER | FS_TRUNCATE;
+                    allowed = FS_READ_FILE | FS_READ_DIR | FS_EXECUTE;
+                    if (rule.CanWrite)
+                    {
+                        allowed |= FS_WRITE_FILE | FS_REMOVE_DIR | FS_REMOVE_FILE
+                                 | FS_MAKE_CHAR | FS_MAKE_DIR | FS_MAKE_REG | FS_MAKE_SOCK
+                                 | FS_MAKE_FIFO | FS_MAKE_BLOCK | FS_MAKE_SYM | FS_REFER | FS_TRUNCATE;
+                    }
+                }
+                else
+                {
+                    allowed = FS_READ_FILE | FS_EXECUTE;
+                    if (rule.CanWrite)
+                    {
+                        allowed |= FS_WRITE_FILE | FS_TRUNCATE;
+                    }
                 }
                 allowed &= handled;
 

--- a/Hina.PackageManager/Sandbox/LinuxLandlockSandbox.cs
+++ b/Hina.PackageManager/Sandbox/LinuxLandlockSandbox.cs
@@ -46,6 +46,39 @@ namespace Hina.PackageManager.Sandbox
         private const ulong FS_REFER = 1ul << 13;      // ABI v2
         private const ulong FS_TRUNCATE = 1ul << 14;   // ABI v3
 
+        // Implicit system-runtime grants. A dynamically-linked Linux app must read
+        // the loader (/lib64/ld-linux-*), libc, and system libraries to even start;
+        // it also reads /etc/ld.so.cache + /etc/ld.so.conf.d. Without these grants
+        // Landlock denies them and the app EACCESs at startup — only fully
+        // self-contained (static/AOT) binaries would run. So when a sandbox IS
+        // enforced we grant read+exec on the standard system dirs and read+write on
+        // the handful of device nodes apps commonly need.
+        //
+        // Landlock is layered ON TOP OF normal DAC: granting read+exec on /etc does
+        // NOT make /etc/shadow readable to a non-root user — the kernel still checks
+        // file permissions first. These grants only relax the Landlock layer, never
+        // the underlying ownership/mode checks. Paths that don't exist are skipped
+        // (AddPath's open() fails harmlessly).
+        internal static readonly IReadOnlyList<ResolvedFsRule> SystemRuntimePaths = new[]
+        {
+            // Loader + system libraries + binaries (read + execute, never writable).
+            new ResolvedFsRule("/usr", false),
+            new ResolvedFsRule("/lib", false),
+            new ResolvedFsRule("/lib64", false),
+            new ResolvedFsRule("/bin", false),
+            new ResolvedFsRule("/sbin", false),
+            new ResolvedFsRule("/etc", false),   // ld.so.cache, ld.so.conf.d, resolv.conf, …
+            // Common device nodes apps open (and write to, e.g. /dev/null). Granted
+            // individually — NOT all of /dev, which would expose block devices,
+            // /dev/mem, etc.
+            new ResolvedFsRule("/dev/null", true),
+            new ResolvedFsRule("/dev/zero", true),
+            new ResolvedFsRule("/dev/full", true),
+            new ResolvedFsRule("/dev/random", true),
+            new ResolvedFsRule("/dev/urandom", true),
+            new ResolvedFsRule("/dev/tty", true),
+        };
+
         private readonly ILogger _logger;
         private readonly int _abi;
 
@@ -98,6 +131,14 @@ namespace Hina.PackageManager.Sandbox
 
             try
             {
+                // Grant the implicit system runtime FIRST so dynamically-linked apps
+                // can load their loader + libc. DAC still applies on top (see
+                // SystemRuntimePaths docs), so this does not expose /etc/shadow etc.
+                foreach (ResolvedFsRule rule in SystemRuntimePaths)
+                {
+                    AddPath(rulesetFd, rule, handled);
+                }
+
                 foreach (ResolvedFsRule rule in plan.Rules)
                 {
                     AddPath(rulesetFd, rule, handled);

--- a/Hina.PackageManager/Sandbox/MacOsSandbox.cs
+++ b/Hina.PackageManager/Sandbox/MacOsSandbox.cs
@@ -1,0 +1,130 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Runtime.InteropServices;
+using System.Threading;
+using Microsoft.Extensions.Logging;
+
+namespace Hina.PackageManager.Sandbox
+{
+    // macOS filesystem (and network) sandbox backend. Generates a Seatbelt profile
+    // from the plan (see MacOsSeatbeltProfile) and launches the app under
+    // `sandbox-exec -f <profile>`.
+    //
+    // sandbox-exec is deprecated by Apple but still present and functional on every
+    // supported macOS; it is far simpler than the private libsandbox API and needs
+    // no entitlements. We spawn it as a child (rather than execve) so we can delete
+    // the temporary profile file once the app exits. Fail-soft: any setup failure
+    // logs a warning and runs the app unsandboxed — a sandbox problem never blocks a
+    // launch.
+    public sealed class MacOsSandbox : ISandboxLauncher
+    {
+        private const string SandboxExec = "/usr/bin/sandbox-exec";
+
+        private readonly ILogger _logger;
+
+        public MacOsSandbox(ILogger logger)
+        {
+            _logger = logger;
+        }
+
+        public bool IsSupported => OperatingSystem.IsMacOS() && File.Exists(SandboxExec);
+
+        public int Launch(string execAbs, IReadOnlyList<string> appArgs, SandboxPlan plan, CancellationToken ct)
+        {
+            if (plan.Unrestricted || !IsSupported)
+            {
+                // Nothing to enforce (host opt-out) or no sandbox-exec — run directly.
+                return Spawn(execAbs, appArgs, profile: null, ct);
+            }
+
+            string? profilePath = null;
+            try
+            {
+                // Seatbelt matches CANONICAL paths, but macOS scatters symlinks across
+                // the standard tree (/tmp, /var, /etc → /private/...). Resolve each
+                // granted path to its real location so the rule actually matches, or a
+                // write to /tmp/... (really /private/tmp/...) would be silently denied.
+                SandboxPlan resolved = Canonicalize(plan);
+                profilePath = Path.Combine(Path.GetTempPath(), "hina-sandbox-" + Guid.NewGuid().ToString("N") + ".sb");
+                File.WriteAllText(profilePath, MacOsSeatbeltProfile.Build(resolved));
+            }
+            catch (Exception ex)
+            {
+                _logger.LogWarning("Could not write sandbox profile ({Message}); running unsandboxed.", ex.Message);
+                return Spawn(execAbs, appArgs, profile: null, ct);
+            }
+
+            try
+            {
+                return Spawn(execAbs, appArgs, profilePath, ct);
+            }
+            finally
+            {
+                try { File.Delete(profilePath); }
+                catch (Exception ex) { _logger.LogDebug(ex, "Best-effort: could not delete sandbox profile {Path}", profilePath); }
+            }
+        }
+
+        // Resolve every rule path to its canonical (symlink-free) location so Seatbelt
+        // subpath rules match. A path that doesn't resolve (missing / permission) is
+        // kept verbatim — the grant simply won't match anything, which is fail-safe.
+        private static SandboxPlan Canonicalize(SandboxPlan plan)
+        {
+            List<ResolvedFsRule> resolved = new List<ResolvedFsRule>(plan.Rules.Count);
+            foreach (ResolvedFsRule rule in plan.Rules)
+            {
+                resolved.Add(new ResolvedFsRule(RealPath(rule.Path), rule.CanWrite));
+            }
+            return new SandboxPlan(plan.Unrestricted, resolved, plan.RestrictNetwork);
+        }
+
+        private static string RealPath(string path)
+        {
+            IntPtr p = realpath(path, IntPtr.Zero);
+            if (p == IntPtr.Zero)
+            {
+                return path;
+            }
+            try { return Marshal.PtrToStringUTF8(p) ?? path; }
+            finally { free(p); }
+        }
+
+        [DllImport("libc", SetLastError = true)]
+        private static extern IntPtr realpath([MarshalAs(UnmanagedType.LPUTF8Str)] string path, IntPtr resolved);
+
+        [DllImport("libc")]
+        private static extern void free(IntPtr ptr);
+
+        private int Spawn(string execAbs, IReadOnlyList<string> appArgs, string? profile, CancellationToken ct)
+        {
+            ProcessStartInfo psi = new ProcessStartInfo { UseShellExecute = false };
+            if (profile != null)
+            {
+                psi.FileName = SandboxExec;
+                psi.ArgumentList.Add("-f");
+                psi.ArgumentList.Add(profile);
+                psi.ArgumentList.Add(execAbs);
+            }
+            else
+            {
+                psi.FileName = execAbs;
+            }
+            foreach (string a in appArgs)
+            {
+                psi.ArgumentList.Add(a);
+            }
+
+            using Process proc = Process.Start(psi)!;
+            // Forward a cancellation to the child so the sandbox launch honours ct.
+            using CancellationTokenRegistration reg = ct.Register(() =>
+            {
+                try { if (!proc.HasExited) proc.Kill(entireProcessTree: true); }
+                catch { /* race: already gone */ }
+            });
+            proc.WaitForExit();
+            return proc.ExitCode;
+        }
+    }
+}

--- a/Hina.PackageManager/Sandbox/MacOsSeatbeltProfile.cs
+++ b/Hina.PackageManager/Sandbox/MacOsSeatbeltProfile.cs
@@ -1,0 +1,88 @@
+using System.Collections.Generic;
+using System.Text;
+
+namespace Hina.PackageManager.Sandbox
+{
+    // Generates a Seatbelt (.sb) sandbox profile from a SandboxPlan, for use with
+    // macOS `sandbox-exec -f <profile>`. Pure/string-only so it is unit-testable;
+    // the actual enforcement lives in MacOsSandbox.
+    //
+    // Policy shape: deny everything by default, then allow back exactly what the
+    // app needs — process exec/fork, a system read baseline (dyld cache + system
+    // frameworks, without which nothing launches), the plan's resolved filesystem
+    // rules (read for ro, read+write for rw), and network unless the plan denies it.
+    public static class MacOsSeatbeltProfile
+    {
+        // Apple-shipped base sandbox profile, stable across macOS releases. Imported
+        // so dyld and the mach bootstrap work; it does not grant broad file access.
+        public const string BsdBaseProfile = "/System/Library/Sandbox/Profiles/bsd.sb";
+
+        // System paths every macOS process must read to start (dyld, libs, frameworks,
+        // ICU/locale data, timezone). Read-only — analogous to the Linux implicit
+        // SystemRuntimePaths. These only relax the sandbox layer; POSIX perms still apply.
+        public static readonly IReadOnlyList<string> SystemReadPaths = new[]
+        {
+            "/usr/lib",
+            "/usr/bin",
+            "/bin",
+            "/usr/share",
+            "/System",
+            "/Library",
+            "/private/var/db/dyld",
+            "/dev/null",
+            "/dev/random",
+            "/dev/urandom",
+        };
+
+        public static string Build(SandboxPlan plan)
+        {
+            StringBuilder sb = new StringBuilder();
+            sb.AppendLine("(version 1)");
+            // The BSD base profile grants the low-level operations (dyld shared-cache
+            // reads, mach bootstrap, sysctl) without which dyld aborts the process
+            // before main() — but it does NOT open up arbitrary file read/write, so
+            // our deny-default + explicit subpath grants still isolate the app.
+            sb.AppendLine("(import \"" + BsdBaseProfile + "\")");
+            sb.AppendLine("(deny default)");
+
+            // Let the app spawn/replace itself and read its own metadata.
+            sb.AppendLine("(allow process-exec*)");
+            sb.AppendLine("(allow process-fork)");
+            sb.AppendLine("(allow sysctl-read)");
+            sb.AppendLine("(allow mach-lookup)");
+            sb.AppendLine("(allow signal (target self))");
+
+            // System read baseline.
+            foreach (string path in SystemReadPaths)
+            {
+                sb.AppendLine($"(allow file-read* (subpath {Quote(path)}))");
+            }
+
+            // Plan filesystem rules. ro → read; rw → read + write.
+            foreach (ResolvedFsRule rule in plan.Rules)
+            {
+                sb.AppendLine($"(allow file-read* (subpath {Quote(rule.Path)}))");
+                if (rule.CanWrite)
+                {
+                    sb.AppendLine($"(allow file-write* (subpath {Quote(rule.Path)}))");
+                }
+            }
+
+            // Network: denied by default; allowed back only when the plan grants it.
+            if (!plan.RestrictNetwork)
+            {
+                sb.AppendLine("(allow network*)");
+            }
+
+            return sb.ToString();
+        }
+
+        // Seatbelt string literal: escape backslash and double-quote so a path can
+        // never break out of the literal (defense in depth — tokens are curated).
+        private static string Quote(string path)
+        {
+            string escaped = path.Replace("\\", "\\\\").Replace("\"", "\\\"");
+            return "\"" + escaped + "\"";
+        }
+    }
+}

--- a/Hina.PackageManager/Sandbox/PermissionsFormatter.cs
+++ b/Hina.PackageManager/Sandbox/PermissionsFormatter.cs
@@ -107,6 +107,61 @@ namespace Hina.PackageManager.Sandbox
             return sb.ToString();
         }
 
+        // Human-readable capability lines for install-time disclosure. Network is
+        // always shown (enforced); the other capabilities are listed only when the
+        // app declares them, each marked NOT enforced so the user is never misled.
+        public static IReadOnlyList<string> CapabilityDisclosure(CapabilitySpec? caps)
+        {
+            CapabilitySpec c = caps ?? new CapabilitySpec();
+            List<string> lines = new List<string>
+            {
+                c.Network
+                    ? "network: ALLOWED (declared by the app)"
+                    : "network: denied (enforced on Linux 6.7+/macOS)",
+            };
+            foreach ((string name, bool on) in DeclaredExtras(c))
+            {
+                if (on) lines.Add($"{name}: declared — NOT enforced (no portal/policy yet)");
+            }
+            return lines;
+        }
+
+        // A compact one-block permission summary for `hina info`.
+        public static string Compact(AppPermissions p)
+        {
+            StringBuilder sb = new StringBuilder();
+            if (!p.SandboxEnabled)
+            {
+                sb.Append("Sandbox:        disabled — full user privileges (no isolation)\n");
+                return sb.ToString();
+            }
+            sb.Append("Sandbox:        enabled\n");
+            sb.Append("  Filesystem:   ").Append(FsSummary(p)).Append("  (enforced: Linux/macOS)\n");
+            sb.Append("  Network:      ").Append(p.Network ? "allowed (enforced)" : "denied (enforced)").Append('\n');
+            List<string> extras = new List<string>();
+            foreach ((string name, bool on) in DeclaredExtras(new CapabilitySpec
+            {
+                Audio = p.Audio, Microphone = p.Microphone, Screen = p.Screen, Input = p.Input, Devices = p.Devices,
+            }))
+            {
+                if (on) extras.Add(name.ToLowerInvariant());
+            }
+            if (extras.Count > 0)
+            {
+                sb.Append("  Declared:     ").Append(string.Join(", ", extras)).Append("  (NOT enforced)\n");
+            }
+            return sb.ToString();
+        }
+
+        private static IEnumerable<(string, bool)> DeclaredExtras(CapabilitySpec c)
+        {
+            yield return ("Audio", c.Audio);
+            yield return ("Microphone", c.Microphone);
+            yield return ("Screen", c.Screen);
+            yield return ("Input", c.Input);
+            yield return ("Devices", c.Devices);
+        }
+
         private static void Capability(StringBuilder sb, string name, bool declared)
         {
             sb.Append("  ").Append(PadRight(name + ":", 12)).Append(' ');

--- a/Hina.PackageManager/Sandbox/PermissionsFormatter.cs
+++ b/Hina.PackageManager/Sandbox/PermissionsFormatter.cs
@@ -7,9 +7,9 @@ using Hina.PackageManager.Descriptor;
 namespace Hina.PackageManager.Sandbox
 {
     // Renders AppPermissions as the `hina perms` table (all apps) and detail
-    // (one app). Pure string output. Every non-filesystem capability is rendered
-    // with a "not enforced" caveat so the display never implies isolation Hina
-    // does not provide.
+    // (one app). Pure string output. Filesystem and network are enforced; the other
+    // capabilities are rendered with a "not enforced" caveat so the display never
+    // implies isolation Hina does not provide.
     public static class PermissionsFormatter
     {
         private const string Yes = "✓";
@@ -58,8 +58,9 @@ namespace Hina.PackageManager.Sandbox
             }
 
             sb.Append('\n');
-            sb.Append("Only filesystem (FS) is enforced — Linux/Landlock. NET/AUDIO/MIC/SCREEN/INPUT/DEV are\n");
-            sb.Append("declared by the app but NOT yet enforced. Run `hina perms <app>` for details.\n");
+            sb.Append("Filesystem (FS) and network (NET) are enforced — Linux/Landlock + macOS/sandbox-exec\n");
+            sb.Append("(NET needs Linux 6.7+). AUDIO/MIC/SCREEN/INPUT/DEV are declared but NOT enforced.\n");
+            sb.Append("Run `hina perms <app>` for details.\n");
             return sb.ToString();
         }
 
@@ -91,7 +92,13 @@ namespace Hina.PackageManager.Sandbox
                 sb.Append("    (nothing beyond the install dir)\n");
             }
 
-            Capability(sb, "Network", p.Network);
+            // Network is enforced (Linux 6.7+/macOS), so it reads differently from the
+            // declared-only capabilities: granted vs actively denied, both enforced.
+            sb.Append("  ").Append(PadRight("Network:", 12)).Append(' ');
+            sb.Append(p.Network
+                ? "allowed (enforced)\n"
+                : "denied (enforced on Linux 6.7+/macOS)\n");
+
             Capability(sb, "Audio", p.Audio);
             Capability(sb, "Microphone", p.Microphone);
             Capability(sb, "Screen", p.Screen);

--- a/Hina.PackageManager/Sandbox/SandboxLauncherFactory.cs
+++ b/Hina.PackageManager/Sandbox/SandboxLauncherFactory.cs
@@ -4,7 +4,9 @@ using Microsoft.Extensions.Logging;
 namespace Hina.PackageManager.Sandbox
 {
     // Selects the sandbox backend for this OS. Linux → Landlock when the kernel
-    // supports it, otherwise NoOp. macOS/Windows → NoOp until their backends land.
+    // supports it; macOS → sandbox-exec (Seatbelt); otherwise NoOp. Windows → NoOp
+    // until its backend lands. A backend that reports IsSupported=false falls back
+    // to NoOp so a launch is never blocked.
     public static class SandboxLauncherFactory
     {
         public static ISandboxLauncher Current(ILogger logger)
@@ -15,6 +17,14 @@ namespace Hina.PackageManager.Sandbox
                 if (landlock.IsSupported)
                 {
                     return landlock;
+                }
+            }
+            else if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+            {
+                MacOsSandbox macos = new MacOsSandbox(logger);
+                if (macos.IsSupported)
+                {
+                    return macos;
                 }
             }
             return new NoOpSandbox(logger);

--- a/Hina.PackageManager/Sandbox/SandboxPlan.cs
+++ b/Hina.PackageManager/Sandbox/SandboxPlan.cs
@@ -12,10 +12,16 @@ namespace Hina.PackageManager.Sandbox
 
         public IReadOnlyList<ResolvedFsRule> Rules { get; }
 
-        public SandboxPlan(bool unrestricted, IReadOnlyList<ResolvedFsRule> rules)
+        // True if the app's network access should be denied. Enforced on Linux via
+        // Landlock net rules (ABI >= 4 / kernel 6.7+); declared-only on older
+        // kernels and other OSes. Never set when Unrestricted (host opt-out).
+        public bool RestrictNetwork { get; }
+
+        public SandboxPlan(bool unrestricted, IReadOnlyList<ResolvedFsRule> rules, bool restrictNetwork = false)
         {
             Unrestricted = unrestricted;
             Rules = rules;
+            RestrictNetwork = restrictNetwork;
         }
     }
 

--- a/Hina.PackageManager/Sandbox/SandboxPlanner.cs
+++ b/Hina.PackageManager/Sandbox/SandboxPlanner.cs
@@ -48,7 +48,12 @@ namespace Hina.PackageManager.Sandbox
                 rules.Add(new ResolvedFsRule(kv.Key, kv.Value));
             }
 
-            return new SandboxPlan(unrestricted, rules);
+            // Network is denied unless the app explicitly declares the capability.
+            // A "host" rule opts out of all isolation, so don't restrict it there.
+            // A missing capability block means nothing is granted (secure default).
+            bool restrictNetwork = !unrestricted && spec.Capabilities?.Network != true;
+
+            return new SandboxPlan(unrestricted, rules, restrictNetwork);
         }
     }
 }

--- a/docs/CLI-Guide.md
+++ b/docs/CLI-Guide.md
@@ -80,7 +80,7 @@ hina list
 
 ### info
 
-Show detailed info for one installed app: install path, channel, pinned key fingerprint, hooks executed, shell entries created, timestamps.
+Show detailed info for one installed app: install path, channel, pinned key fingerprint, hooks executed, shell entries created, timestamps, and — when the app is sandboxed — a compact **sandbox summary** (filesystem scope, network allowed/denied, and any declared-but-not-enforced capabilities). Run `hina perms <app>` for the full per-app breakdown.
 
 ```shell
 hina info foo

--- a/docs/CLI-Guide.md
+++ b/docs/CLI-Guide.md
@@ -161,14 +161,15 @@ hina perms foo             # full detail for one app
 The overview table has columns `APP SANDBOX FS NET AUDIO MIC SCREEN INPUT DEV`.
 The `FS` column summarizes the filesystem scope: declared tokens, `host(!)` when
 the app requests unrestricted host access, and `+Ng` for N user grants. A legend
-notes that **only the filesystem (FS) is enforced** (Linux/Landlock); the other
-capability columns are declared by the app but not yet enforced.
+notes that **the filesystem (FS) and network (NET) are enforced** (Linux/Landlock +
+macOS/sandbox-exec; NET needs Linux 6.7+); the other capability columns are
+declared by the app but not yet enforced.
 
 `hina perms <app>` prints the per-app detail: whether the sandbox is on or off;
 the **Filesystem (enforced)** section listing the install dir, each declared
-token with its access, and each user-granted absolute path; then Network, Audio,
-Microphone, Screen, Input and Devices, each shown as `declared (not enforced)`
-or `not declared`.
+token with its access, and each user-granted absolute path; then **Network**
+(`allowed (enforced)` or `denied (enforced …)`); then Audio, Microphone, Screen,
+Input and Devices, each shown as `declared (not enforced)` or `not declared`.
 
 Manage the user's extra runtime filesystem grants (persisted in the registry):
 

--- a/docs/PackageManager-Guide.md
+++ b/docs/PackageManager-Guide.md
@@ -246,13 +246,17 @@ resolves correctly across machines and users:
 Any token outside this set is rejected at validation (fail closed — Hina never
 silently grants an unknown path).
 
-**`capabilities`** — declared-only booleans: `network`, `audio`, `microphone`,
-`screen`, `input`, `devices`. **None of these are enforced in v1.** They are
-surfaced to the user (by `hina perms`) as *"declared — not enforced"* so the
-display never implies isolation Hina does not provide.
+**`capabilities`** — booleans: `network`, `audio`, `microphone`, `screen`,
+`input`, `devices`. **`network` is enforced on Linux 6.7+** (Landlock ABI ≥ 4): a
+sandboxed app that does not declare `network: true` has all TCP bind/connect
+denied. On older kernels and other OSes `network` is declared-only. The remaining
+capabilities are **not enforced** — surfaced to the user (by `hina perms`) as
+*"declared — not enforced"* so the display never implies isolation Hina does not
+provide.
 
-**What is enforced where** — only the **filesystem** scope is enforced, and only on
-**Linux** (via Landlock). On macOS and Windows the declared scope is shown at
+**What is enforced where** — the **filesystem** scope and the **`network`**
+capability are enforced on **Linux** (via Landlock; network needs kernel 6.7+).
+On macOS and Windows the declared scope is shown at
 install time with a warning that it is *not* applied. See the [Sandboxing](#sandboxing)
 section for the full model.
 
@@ -342,9 +346,11 @@ deliberately narrow:
   route through `hina run` (which would gain nothing).
 - **Old kernel / no Landlock** → a no-op plus a one-time warning. A missing or
   too-old sandbox backend never blocks a launch.
-- **Capabilities are declared-only.** `network`, `audio`, `microphone`, `screen`,
-  `input`, and `devices` are surfaced to the user as *"declared — not enforced"*;
-  nothing restricts them in v1.
+- **`network` is enforced on Linux 6.7+.** A sandboxed app that doesn't declare
+  `network: true` has all TCP bind/connect denied (Landlock ABI ≥ 4); on older
+  kernels and other OSes it falls back to declared-only. `audio`, `microphone`,
+  `screen`, `input`, and `devices` remain declared-only — surfaced to the user as
+  *"declared — not enforced"*; nothing restricts them yet.
 - **No portals.** There are no dynamic file-picker grants. Scope is the static set
   of declared paths plus any paths the user grants manually.
 

--- a/docs/PackageManager-Guide.md
+++ b/docs/PackageManager-Guide.md
@@ -255,8 +255,8 @@ capabilities are **not enforced** — surfaced to the user (by `hina perms`) as
 provide.
 
 **What is enforced where** — the **filesystem** scope and the **`network`**
-capability are enforced on **Linux** (via Landlock; network needs kernel 6.7+).
-On macOS and Windows the declared scope is shown at
+capability are enforced on **Linux** (via Landlock; network needs kernel 6.7+) and
+on **macOS** (via `sandbox-exec`). On Windows the declared scope is shown at
 install time with a warning that it is *not* applied. See the [Sandboxing](#sandboxing)
 section for the full model.
 
@@ -340,11 +340,14 @@ deliberately narrow:
   Landlock — kernel ≥ 5.13, unprivileged, no root or bubblewrap). `hina run`
   installs the Landlock ruleset, then `execv`s the app; the restrictions are
   inherited across the exec, so the app's process is the restricted one.
-- **macOS and Windows do not enforce the sandbox yet** (those backends are
-  deferred). Installing a sandboxed app there warns that it runs with full user
-  privileges, and its shortcut launches the binary directly — it does **not**
-  route through `hina run` (which would gain nothing).
-- **Old kernel / no Landlock** → a no-op plus a one-time warning. A missing or
+- **macOS** enforces via `sandbox-exec` (Seatbelt): `hina run` generates a profile
+  from the declared scope and launches the app under `sandbox-exec -f <profile>`,
+  so its shortcut routes through `hina run` just like Linux.
+- **Windows does not enforce the sandbox yet** (that backend is deferred).
+  Installing a sandboxed app there warns that it runs with full user privileges,
+  and its shortcut launches the binary directly — it does **not** route through
+  `hina run` (which would gain nothing).
+- **Old kernel / no Landlock / no sandbox-exec** → a no-op plus a one-time warning. A missing or
   too-old sandbox backend never blocks a launch.
 - **`network` is enforced on Linux 6.7+.** A sandboxed app that doesn't declare
   `network: true` has all TCP bind/connect denied (Landlock ABI ≥ 4); on older

--- a/docs/Security.md
+++ b/docs/Security.md
@@ -277,7 +277,8 @@ but over-reaching app sees only the paths it declares.
 | Surface | Status |
 |---------|--------|
 | **Filesystem scope** | Enforced **on Linux only**, via Landlock (unprivileged, kernel ≥ 5.13, no root / no bubblewrap). On macOS and Windows it is **declared but NOT enforced** — the app runs with full user privileges (warned at install time). |
-| **Capabilities** (`network`, `audio`, `microphone`, `screen`, `input`, `devices`) | **Declared-only, never enforced yet.** `hina perms` shows them as "declared — not enforced". No portals (PipeWire / Wayland / per-OS device policy) are wired up. |
+| **`network` capability** | **Enforced on Linux 6.7+** (Landlock ABI ≥ 4): when a sandboxed app does not declare `network: true`, all TCP bind/connect is denied via Landlock net rules. On older kernels (ABI < 4) and other OSes it is declared-only (a log line notes it is not enforced). |
+| **Other capabilities** (`audio`, `microphone`, `screen`, `input`, `devices`) | **Declared-only, never enforced yet.** `hina perms` shows them as "declared — not enforced". No portals (PipeWire / Wayland / per-OS device policy) are wired up. |
 
 When a descriptor carries no `sandbox` block (or `sandbox.enabled` is `false`), the
 app launches unsandboxed exactly as before — full user privileges.

--- a/docs/Security.md
+++ b/docs/Security.md
@@ -276,8 +276,8 @@ but over-reaching app sees only the paths it declares.
 
 | Surface | Status |
 |---------|--------|
-| **Filesystem scope** | Enforced **on Linux only**, via Landlock (unprivileged, kernel ≥ 5.13, no root / no bubblewrap). On macOS and Windows it is **declared but NOT enforced** — the app runs with full user privileges (warned at install time). |
-| **`network` capability** | **Enforced on Linux 6.7+** (Landlock ABI ≥ 4): when a sandboxed app does not declare `network: true`, all TCP bind/connect is denied via Landlock net rules. On older kernels (ABI < 4) and other OSes it is declared-only (a log line notes it is not enforced). |
+| **Filesystem scope** | Enforced on **Linux** via Landlock (unprivileged, kernel ≥ 5.13, no root / no bubblewrap) and on **macOS** via `sandbox-exec` (Seatbelt). On **Windows** it is **declared but NOT enforced** — the app runs with full user privileges (warned at install time). |
+| **`network` capability** | Enforced on **Linux 6.7+** (Landlock ABI ≥ 4) and **macOS** (Seatbelt `deny default` network): when a sandboxed app does not declare `network: true`, TCP bind/connect is denied. On older Linux kernels (ABI < 4) and Windows it is declared-only (a log line notes it is not enforced). |
 | **Other capabilities** (`audio`, `microphone`, `screen`, `input`, `devices`) | **Declared-only, never enforced yet.** `hina perms` shows them as "declared — not enforced". No portals (PipeWire / Wayland / per-OS device policy) are wired up. |
 
 When a descriptor carries no `sandbox` block (or `sandbox.enabled` is `false`), the
@@ -324,22 +324,26 @@ disclosure prints it as an explicit `UNRESTRICTED filesystem access` warning, an
 
 ### How Enforcement Works (`hina run`)
 
-For a sandboxed app on Linux, the shell shortcuts Hina creates do **not** point at
-the app binary — they route through `hina run <app> "<entryId>"`. `hina run`
-resolves the declared scope plus any user grants into a Landlock ruleset, applies
-it to itself (`landlock_restrict_self`), and then `execv`s the app, which inherits
-the restrictions (the app's PID is Hina's). On macOS/Windows the shortcut launches
-the app directly (routing through `hina run` would gain nothing there).
+For a sandboxed app on Linux **and macOS**, the shell shortcuts Hina creates do
+**not** point at the app binary — they route through `hina run <app> "<entryId>"`.
+`hina run` resolves the declared scope plus any user grants into a backend ruleset
+and applies it before the app starts:
+- **Linux**: builds a Landlock ruleset, applies it to itself
+  (`landlock_restrict_self`), then `execv`s the app, which inherits the
+  restrictions (the app's PID is Hina's).
+- **macOS**: generates a Seatbelt profile and launches the app under
+  `sandbox-exec -f <profile>`.
 
-If the kernel is too old for Landlock (or Landlock setup fails for any reason),
-enforcement degrades to a **no-op with a one-time warning** and the launch is never
-blocked.
+On **Windows** the shortcut launches the app directly (no backend yet). If the
+Linux kernel is too old for Landlock, or `sandbox-exec` is unavailable, or backend
+setup fails for any reason, enforcement degrades to a **no-op with a one-time
+warning** and the launch is never blocked.
 
 ### Install-Time Disclosure
 
 When a sandboxed app is installed, Hina discloses the declared scope. On a host
-where the sandbox cannot be enforced (macOS/Windows), it warns plainly that the
-app **runs with FULL user privileges (no isolation)** before listing the declared
+where the sandbox cannot be enforced (Windows), it warns plainly that the app
+**runs with FULL user privileges (no isolation)** before listing the declared
 scope, so the user is never misled into thinking isolation is in effect.
 
 ### User-Granted Paths (`hina perms`)

--- a/docs/Windows-Sandbox-Design.md
+++ b/docs/Windows-Sandbox-Design.md
@@ -1,0 +1,53 @@
+# Windows sandbox backend — design note (deferred)
+
+Status: **not implemented.** On Windows a sandboxed app currently falls back to
+`NoOpSandbox` (runs unsandboxed, warns once at install). This note records the
+intended design so the work can be picked up without re-deriving it.
+
+Why deferred: the AppContainer path is large and easy to get subtly wrong (ACL
+inheritance, profile lifecycle, the app needing read on system DLLs), and it cannot
+be verified on the macOS/Linux dev host. Per the project rule "do not ship a
+half-enforcing backend that *looks* like it isolates but doesn't", it is better to
+keep the honest NoOp + warning than to ship an unverified AppContainer.
+
+## Intended approach: low-privilege AppContainer
+
+Implement `WindowsSandbox : ISandboxLauncher`:
+
+1. **Create / derive an AppContainer profile** for the app
+   (`CreateAppContainerProfile`, or `DeriveAppContainerSidFromAppContainerName` if it
+   already exists). Use a stable per-app container name (e.g. `Hina.<appName>`).
+2. **Grant explicit ACEs** for the container SID on the app dir + each declared
+   `ro`/`rw` path and each user grant (`SetEntriesInAcl` / `SetNamedSecurityInfo`),
+   plus read+execute on the system DLL directories the app needs to load
+   (`C:\Windows\System32`, the app's own dir). Without these the process can't start
+   — the Windows analogue of the Linux `SystemRuntimePaths` / macOS system baseline.
+3. **Launch** with `CreateProcess` using `STARTUPINFOEX` +
+   `PROC_THREAD_ATTRIBUTE_SECURITY_CAPABILITIES` pointing at a
+   `SECURITY_CAPABILITIES` built from the container SID (and any capability SIDs).
+   All via AOT-safe `[LibraryImport]`/`[DllImport]` P/Invoke — no reflection.
+4. **`IsSupported`** = AppContainer APIs available (Windows 8+). Fail-soft: any
+   failure logs a warning and runs the app, never blocks the launch.
+
+Network: AppContainer denies network unless the `internetClient` /
+`internetClientServer` capability SID is added — so `capabilities.network` maps
+naturally (omit the SID to deny, add it to allow), mirroring Landlock/Seatbelt.
+
+## Shortcut routing
+
+Wire `WindowsPlatformIntegration`'s 4-arg `CreateMenuShortcut(launchOverride)` so a
+sandboxed app's `.lnk` invokes `hina run <app> <entry>` (like Linux/macOS). Then
+flip `InstallService.sandboxEnforceable` to include Windows. Until the backend
+exists, leave the `.lnk` pointing at the binary and keep the not-enforced warning.
+
+## Verification (when implemented)
+
+Add a `windows-latest` CI job analogous to `macos-sandbox`: a probe that runs a
+child under the AppContainer, asserts an ungranted read is denied and a granted
+write allowed, and skip-passes if the AppContainer APIs are unavailable.
+
+## Scope guard
+
+If time-boxed, ship a **correct minimal** version (deny-by-default AppContainer +
+app dir + declared paths + system DLL dirs) and clearly log/doc the limitations —
+never a backend that appears to isolate but leaks.

--- a/scripts/landlock-net-probe.sh
+++ b/scripts/landlock-net-probe.sh
@@ -22,7 +22,8 @@ if [ "$#" -lt 1 ]; then
 fi
 HINA=( "$@" )
 
-if ! command -v python3 >/dev/null 2>&1; then
+PY="$(command -v python3 || true)"
+if [ -z "$PY" ]; then
   echo "SKIP: python3 not available; passing."
   exit 0
 fi
@@ -63,11 +64,11 @@ except Exception as e:
 DENY_ERR="$WORK/deny.err"
 DENY_OUT="$(
   "${HINA[@]}" dev sandbox-run --app-dir "$APP" --allow /proc:ro --deny-network \
-    -- python3 -c "$CONNECT" 2>"$DENY_ERR"
+    -- "$PY" -c "$CONNECT" 2>"$DENY_ERR"
 )"
 ALLOW_OUT="$(
   "${HINA[@]}" dev sandbox-run --app-dir "$APP" --allow /proc:ro \
-    -- python3 -c "$CONNECT" 2>/dev/null
+    -- "$PY" -c "$CONNECT" 2>/dev/null
 )"
 
 echo "---- deny-network stdout ----"; echo "$DENY_OUT"

--- a/scripts/landlock-net-probe.sh
+++ b/scripts/landlock-net-probe.sh
@@ -1,0 +1,89 @@
+#!/usr/bin/env bash
+#
+# Landlock network-sandbox integration probe.
+#
+# Proves that Hina ENFORCES the `network` capability via Landlock net rules
+# (ABI >= 4 / kernel 6.7+). It starts a local TCP listener, then runs a
+# sandboxed python3 twice:
+#   1. with --deny-network  -> the connect() must be DENIED (EACCES).
+#   2. without --deny-network -> the connect() must SUCCEED (control: proves we
+#      don't break networking when the capability is granted).
+#
+# On a kernel older than 6.7 (Landlock ABI < 4) Hina cannot enforce net scoping
+# and logs "network not enforced"; the probe then SKIP-passes so the CI job stays
+# green on older runners. Also skip-passes if python3 is unavailable.
+#
+# Usage: landlock-net-probe.sh <hina-exec> [hina-exec-args...]
+set -u
+
+if [ "$#" -lt 1 ]; then
+  echo "usage: $0 <hina-exec> [args...]" >&2
+  exit 2
+fi
+HINA=( "$@" )
+
+if ! command -v python3 >/dev/null 2>&1; then
+  echo "SKIP: python3 not available; passing."
+  exit 0
+fi
+
+PORT=19099
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"; [ -n "${LISTENER_PID:-}" ] && kill "$LISTENER_PID" 2>/dev/null' EXIT
+APP="$WORK/app"; mkdir -p "$APP"
+READY="$WORK/ready"
+
+# Local TCP listener (NOT sandboxed). Writes a ready marker once bound.
+python3 - "$PORT" "$READY" <<'PY' &
+import socket, sys, time
+port = int(sys.argv[1]); ready = sys.argv[2]
+s = socket.socket()
+s.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+s.bind(("127.0.0.1", port)); s.listen()
+open(ready, "w").write("ready")
+time.sleep(60)
+PY
+LISTENER_PID=$!
+
+# Wait for the listener to bind (up to ~3s).
+for _ in $(seq 1 30); do [ -f "$READY" ] && break; sleep 0.1; done
+if [ ! -f "$READY" ]; then
+  echo "SKIP: listener failed to bind; passing."
+  exit 0
+fi
+
+CONNECT="import socket
+try:
+    s = socket.socket(); s.settimeout(3); s.connect(('127.0.0.1', $PORT)); print('RESULT=OK')
+except PermissionError:
+    print('RESULT=BLOCKED')
+except Exception as e:
+    print('RESULT=ERR:%s' % e)"
+
+DENY_ERR="$WORK/deny.err"
+DENY_OUT="$(
+  "${HINA[@]}" dev sandbox-run --app-dir "$APP" --allow /proc:ro --deny-network \
+    -- python3 -c "$CONNECT" 2>"$DENY_ERR"
+)"
+ALLOW_OUT="$(
+  "${HINA[@]}" dev sandbox-run --app-dir "$APP" --allow /proc:ro \
+    -- python3 -c "$CONNECT" 2>/dev/null
+)"
+
+echo "---- deny-network stdout ----"; echo "$DENY_OUT"
+echo "---- deny-network stderr ----"; cat "$DENY_ERR"
+echo "---- allow-network stdout ----"; echo "$ALLOW_OUT"
+echo "---- kernel: $(uname -r) ----"
+
+if grep -q "network not enforced" "$DENY_ERR" || echo "$DENY_OUT" | grep -q "network not enforced"; then
+  echo "SKIP: Landlock net scoping unsupported (kernel $(uname -r), ABI < 4); passing."
+  exit 0
+fi
+
+if echo "$DENY_OUT" | grep -q "RESULT=BLOCKED" && echo "$ALLOW_OUT" | grep -q "RESULT=OK"; then
+  echo "PASS: TCP connect denied under --deny-network, allowed without it."
+  exit 0
+fi
+
+echo "FAIL: expected deny=BLOCKED + allow=OK (got deny='$DENY_OUT' allow='$ALLOW_OUT')." >&2
+exit 1

--- a/scripts/landlock-probe.sh
+++ b/scripts/landlock-probe.sh
@@ -2,12 +2,15 @@
 #
 # Landlock filesystem-sandbox integration probe.
 #
-# Runs a child (/bin/sh) under a Hina sandbox that grants:
-#   - the system dirs the interpreter needs (read-only)
+# Runs a child (/bin/sh) under a Hina sandbox that grants ONLY:
 #   - a "documents" dir (read-write)
-# but deliberately does NOT grant a "secret" dir. Under real Landlock
-# enforcement the child must be DENIED reading the secret and ALLOWED writing
-# the document. On a host without Landlock (old kernel / disabled), Hina logs
+# and NOTHING else. The system dirs the interpreter needs (loader, libc, /bin)
+# are granted IMPLICITLY by LinuxLandlockSandbox.SystemRuntimePaths — this probe
+# is the end-to-end proof of that: if implicit grants were missing, /bin/sh +
+# cat would EACCES at startup and the probe would FAIL. It deliberately does NOT
+# grant a "secret" dir. Under real Landlock enforcement the child must be DENIED
+# reading the secret and ALLOWED writing the document (proving isolation still
+# holds). On a host without Landlock (old kernel / disabled), Hina logs
 # "cannot enforce" and runs unsandboxed — the probe then skips with success so
 # the CI job stays green on non-Landlock runners (e.g. macOS).
 #
@@ -40,8 +43,6 @@ echo \"READ=\$r WRITE=\$w\""
 OUT="$(
   "${HINA[@]}" dev sandbox-run \
     --app-dir "$APP" \
-    --allow /usr:ro --allow /lib:ro --allow /lib64:ro --allow /bin:ro \
-    --allow /etc:ro --allow /dev:rw \
     --allow "$DOCS:rw" \
     -- /bin/sh -c "$INNER" 2>"$STDERR"
 )"


### PR DESCRIPTION
Continues the sandbox feature (v1 shipped Linux/Landlock filesystem isolation in v1.2.0). Each phase is verified on a real CI runner.

## Phase 1 — implicit system-runtime grants (Linux) ✅ verified
Dynamically-linked apps couldn't start under Landlock (loader/libc denied). `LinuxLandlockSandbox.SystemRuntimePaths` now implicitly grants read+exec on `/usr`,`/lib`,`/lib64`,`/bin`,`/sbin`,`/etc` and rw on `/dev/{null,zero,full,random,urandom,tty}` before the plan's rules. Device-node grants carry file-only access rights (Landlock rejects dir rights on non-dirs). DAC still applies on top.
CI probe (Ubuntu 6.17, no manual lib grants): `READ=0 WRITE=1` → **PASS**.

## Phase 2 — network capability enforcement (Linux 6.7+) ✅ verified
Landlock ABI ≥ 4 net rules turn the declared `network` capability into a real one: a sandboxed app not declaring `network: true` has all TCP bind/connect denied. `SandboxPlan.RestrictNetwork` threads through the planner.
CI net probe: deny→`RESULT=BLOCKED`, allow→`RESULT=OK` → **PASS**.

## Phase 3 — macOS sandbox-exec backend ✅ verified
`MacOsSeatbeltProfile` + `MacOsSandbox` enforce filesystem + network via `sandbox-exec` (imports `bsd.sb`, deny-default, realpath-canonicalised grants). Sandboxed `.app` bundles route through `hina run` via a script stub (not a symlink that would bypass the sandbox). `InstallService` treats macOS as enforceable.
New `macos-latest` CI job runs the real enforcement test (ungranted read denied, granted write allowed) → **PASS**.

## Phase 5 (partial) — honesty
`hina perms` + docs updated: filesystem AND network are enforced (Linux/macOS); audio/mic/screen/input/devices remain declared-only.

## Status
411 tests green (+29). AOT publish clean. Windows AppContainer backend (Phase 4) and remaining UX polish are deferred — see commit history / design note.

🤖 Generated with [Claude Code](https://claude.com/claude-code)