### PR TITLE
Phase 6 tech debt: CLI coverage, platform dedup, registry migration framework

### DIFF
--- a/.claude/scheduled_tasks.lock
+++ b/.claude/scheduled_tasks.lock
@@ -1,0 +1,1 @@
+{"sessionId":"6364bd6e-4d1a-41dd-abcc-0f3b3a6c54ef","pid":92183,"procStart":"Mon Jun  8 15:21:55 2026","acquiredAt":1780934428533}

--- a/Hina.CLI.Tests/CommandRouterTests.cs
+++ b/Hina.CLI.Tests/CommandRouterTests.cs
@@ -114,6 +114,72 @@ namespace Hina.CLI.Tests
             Assert.Equal(0, await Dispatch("version"));
         }
 
+        // ---- sandbox-era verbs (run / perms / repair / dev sandbox-run) ----
+
+        [Fact]
+        public async Task Run_NoApp_ReturnsUsageError()
+        {
+            Assert.Equal(2, await Dispatch("run"));
+        }
+
+        [Fact]
+        public async Task Run_UnknownApp_ReturnsNotFound()
+        {
+            Assert.Equal(1, await Dispatch("run", "ghost"));
+        }
+
+        [Fact]
+        public async Task Perms_EmptyRegistry_PrintsTableReturnsZero()
+        {
+            Assert.Equal(0, await Dispatch("perms"));
+        }
+
+        [Fact]
+        public async Task Perms_ListKeyword_ReturnsZero()
+        {
+            Assert.Equal(0, await Dispatch("perms", "list"));
+        }
+
+        [Theory]
+        [InlineData("permissions")]
+        [InlineData("permessi")]
+        public async Task Perms_Aliases_RouteToPerms(string alias)
+        {
+            Assert.Equal(0, await Dispatch(alias));
+        }
+
+        [Fact]
+        public async Task Perms_UnknownApp_ReturnsNotFound()
+        {
+            Assert.Equal(1, await Dispatch("perms", "ghost"));
+        }
+
+        [Fact]
+        public async Task Repair_Alias_RoutesToVerify_EmptyRegistryReturnsZero()
+        {
+            Assert.Equal(0, await Dispatch("repair"));
+        }
+
+        [Fact]
+        public async Task Check_UnknownSubword_ReturnsUsageError()
+        {
+            // `hina check <not-update>` is the two-word router branch's failure path —
+            // deterministic and offline (the `check update` form would hit the network).
+            Assert.Equal(2, await Dispatch("check", "frobnicate"));
+        }
+
+        [Fact]
+        public async Task DevSandboxRun_MissingAppDir_ReturnsUsageError()
+        {
+            Assert.Equal(2, await Dispatch("dev", "sandbox-run", "--", "/bin/true"));
+        }
+
+        [Fact]
+        public async Task DevSandboxRun_MissingCommandSeparator_ReturnsUsageError()
+        {
+            Assert.Equal(2, await Dispatch("dev", "sandbox-run", "--app-dir", _root));
+        }
+
         [Fact]
         public async Task ReadOnly_FutureSchemaRegistry_ReturnsErrorCodeNotCrash()
         {

--- a/Hina.PackageManager.Tests/PlatformTextTests.cs
+++ b/Hina.PackageManager.Tests/PlatformTextTests.cs
@@ -1,0 +1,23 @@
+using Hina.PackageManager.Platform;
+using Xunit;
+
+namespace Hina.PackageManager.Tests
+{
+    public class PlatformTextTests
+    {
+        [Fact]
+        public void StripControl_RemovesNewlinesAndControlChars()
+        {
+            // Control chars (newline especially) must go so a value can't inject extra
+            // .desktop Exec lines / shell-script lines at a write site.
+            Assert.Equal("abc", PlatformText.StripControl("a\nb\tc"));
+            Assert.Equal("hinarun", PlatformText.StripControl("hina\r\nrun"));
+        }
+
+        [Fact]
+        public void StripControl_NoControlChars_ReturnsSameContent()
+        {
+            Assert.Equal("/usr/bin/app --flag", PlatformText.StripControl("/usr/bin/app --flag"));
+        }
+    }
+}

--- a/Hina.PackageManager.Tests/RegistryMigratorTests.cs
+++ b/Hina.PackageManager.Tests/RegistryMigratorTests.cs
@@ -1,0 +1,76 @@
+using System.Collections.Generic;
+using System.Text.Json.Nodes;
+using Hina.PackageManager.Registry;
+using Xunit;
+
+namespace Hina.PackageManager.Tests
+{
+    public class RegistryMigratorTests
+    {
+        private static JsonObject Doc(int version) => new JsonObject
+        {
+            ["schemaVersion"] = version,
+            ["apps"] = new JsonObject(),
+        };
+
+        [Fact]
+        public void Migrate_AlreadyAtTarget_LeavesDocUnchanged()
+        {
+            JsonObject root = Doc(1);
+            JsonObject result = RegistryMigrator.Migrate(root, targetVersion: 1, new List<RegistryMigration>());
+            Assert.Equal(1, (int)result["schemaVersion"]!);
+        }
+
+        [Fact]
+        public void Migrate_AppliesOrderedMigrations_AndStampsTargetVersion()
+        {
+            JsonObject root = Doc(1);
+            List<RegistryMigration> migrations = new List<RegistryMigration>
+            {
+                new RegistryMigration(1, o => o["foo"] = "added-by-1to2"),
+                new RegistryMigration(2, o => o["bar"] = "added-by-2to3"),
+            };
+
+            JsonObject result = RegistryMigrator.Migrate(root, targetVersion: 3, migrations);
+
+            Assert.Equal(3, (int)result["schemaVersion"]!);
+            Assert.Equal("added-by-1to2", (string)result["foo"]!);
+            Assert.Equal("added-by-2to3", (string)result["bar"]!);
+        }
+
+        [Fact]
+        public void Migrate_MissingStepInChain_Throws()
+        {
+            JsonObject root = Doc(1);
+            // Only a 2->3 migration; nothing to take v1 to v2.
+            List<RegistryMigration> migrations = new List<RegistryMigration>
+            {
+                new RegistryMigration(2, o => o["bar"] = "x"),
+            };
+
+            Assert.Throws<RegistrySchemaException>(
+                () => RegistryMigrator.Migrate(root, targetVersion: 3, migrations));
+        }
+
+        [Fact]
+        public void Migrate_MissingSchemaVersion_TreatedAsOne()
+        {
+            JsonObject root = new JsonObject { ["apps"] = new JsonObject() };
+            List<RegistryMigration> migrations = new List<RegistryMigration>
+            {
+                new RegistryMigration(1, o => o["foo"] = "y"),
+            };
+            JsonObject result = RegistryMigrator.Migrate(root, targetVersion: 2, migrations);
+            Assert.Equal(2, (int)result["schemaVersion"]!);
+            Assert.Equal("y", (string)result["foo"]!);
+        }
+
+        [Fact]
+        public void Default_HasNoMigrations_WhileSchemaIsStillOne()
+        {
+            // Schema is still version 1, so there is nothing to migrate yet — the
+            // framework is the scaffold for the first non-additive bump.
+            Assert.Empty(RegistryMigrator.Default);
+        }
+    }
+}

--- a/Hina.PackageManager.Tests/RegistryStoreMigrationTests.cs
+++ b/Hina.PackageManager.Tests/RegistryStoreMigrationTests.cs
@@ -1,0 +1,46 @@
+using System.Collections.Generic;
+using System.Text.Json.Nodes;
+using Hina.PackageManager.Registry;
+using Microsoft.Extensions.Logging.Abstractions;
+using Xunit;
+
+namespace Hina.PackageManager.Tests
+{
+    // Exercises the RegistryStore load path's integration with RegistryMigrator. The
+    // production target is still schema 1 (no migrations), so this drives the internal
+    // seam with a synthetic target+migration to prove the wiring upgrades forward.
+    public class RegistryStoreMigrationTests
+    {
+        [Fact]
+        public void LoadFromJson_OlderSchema_IsMigratedForwardThenDeserialized()
+        {
+            string json = "{\"schemaVersion\":1,\"apps\":{}}";
+            List<RegistryMigration> migrations = new List<RegistryMigration>
+            {
+                new RegistryMigration(1, root => root["apps"]!.AsObject()["demo"] = new JsonObject()),
+            };
+
+            var r = RegistryStore.LoadFromJson(json, targetVersion: 2, migrations, NullLogger.Instance, "/x");
+
+            Assert.Equal(2, r.SchemaVersion);
+            Assert.True(r.Apps.ContainsKey("demo"));
+        }
+
+        [Fact]
+        public void LoadFromJson_NewerSchema_StillRefused()
+        {
+            string json = "{\"schemaVersion\":2,\"apps\":{}}";
+            Assert.Throws<RegistrySchemaException>(
+                () => RegistryStore.LoadFromJson(json, targetVersion: 1, new List<RegistryMigration>(), NullLogger.Instance, "/x"));
+        }
+
+        [Fact]
+        public void LoadFromJson_CurrentSchema_LoadsUnchanged()
+        {
+            string json = "{\"schemaVersion\":1,\"apps\":{}}";
+            var r = RegistryStore.LoadFromJson(json, targetVersion: 1, new List<RegistryMigration>(), NullLogger.Instance, "/x");
+            Assert.Equal(1, r.SchemaVersion);
+            Assert.Empty(r.Apps);
+        }
+    }
+}

--- a/Hina.PackageManager/Install/UpdateService.cs
+++ b/Hina.PackageManager/Install/UpdateService.cs
@@ -288,51 +288,10 @@ namespace Hina.PackageManager.Install
             {
                 _logger.LogError(addEx, "Hook/entry add failed for {Name}; rolling back update.", name);
 
-                for (int i = addedHooks.Count - 1; i >= 0; i--)
-                {
-                    try { await hooks.UndoAsync(addedHooks[i], CancellationToken.None); }
-                    catch (Exception ex) { _logger.LogDebug(ex, "Rollback-undo of added hook {Action} failed for {Name} (fail-soft).", addedHooks[i].Action, name); }
-                }
-                for (int i = addedEntries.Count - 1; i >= 0; i--)
-                {
-                    try { await _platform.RemoveMenuShortcut(addedEntries[i].Evidence, CancellationToken.None); }
-                    catch (Exception ex) { _logger.LogDebug(ex, "Rollback-removal of added shell entry {Id} failed for {Name} (fail-soft).", addedEntries[i].Id, name); }
-                }
-                // Best-effort: re-apply the hooks/entries we removed at step [7] so the app
-                // comes back to its pre-update side-effect set. These are sourced from the
-                // PREVIOUS descriptor (the new one no longer lists them). May silently fail
-                // (e.g. target re-exists, race) — we proceed regardless.
-                if (previousDescriptor != null)
-                {
-                    foreach (ShellEntryRecord r in entriesToRemove)
-                    {
-                        foreach (ShellEntry orig in previousDescriptor.Entries)
-                        {
-                            if (orig.Id != r.Id) continue;
-                            try { await _platform.CreateMenuShortcut(orig, app.InstallPath, CancellationToken.None); }
-                            catch (Exception ex) { _logger.LogDebug(ex, "Re-create of shell entry {Id} during rollback failed for {Name} (fail-soft).", r.Id, name); }
-                            break;
-                        }
-                    }
-                    foreach (HookEvidence removed in hooksToRemove)
-                    {
-                        string removedId = UpdateDiff.ResolveIdentity(removed);
-                        foreach (HookAction origHook in previousDescriptor.PostInstall)
-                        {
-                            if (HookIdentity.For(origHook) != removedId) continue;
-                            try { await hooks.ApplyAsync(origHook, app.InstallPath, app.Name, previousDescriptor.Entries, CancellationToken.None); }
-                            catch (Exception ex) { _logger.LogDebug(ex, "Re-apply of hook {Id} during rollback failed for {Name} (fail-soft).", removedId, name); }
-                            break;
-                        }
-                    }
-                }
-                // Patch on disk also needs to roll back; PatchClient already journaled
-                // backups when Backup=true so RollbackAsync restores them.
-                try { await patcher.RollbackAsync(app.InstallPath, CancellationToken.None); }
-                catch (Exception ex) { _logger.LogDebug(ex, "Patch rollback during add-failure recovery failed for {Name} (fail-soft).", name); }
-
-                try { await SaveAppRowLockedAsync(locks, store, name, previousSnapshot, CancellationToken.None); }
-                catch (Exception ex) { _logger.LogWarning(ex, "Restoring pre-update registry snapshot for {Name} failed (fail-soft); run `hina verify`.", name); }
+                await RollbackFailedAddAsync(
+                    name, app, hooks, patcher, previousDescriptor,
+                    addedHooks, addedEntries, entriesToRemove, hooksToRemove,
+                    locks, store, previousSnapshot);
 
                 return new UpdateResult
                 {
@@ -384,17 +343,8 @@ namespace Hina.PackageManager.Install
                 };
             }
 
-            // [8] Refresh descriptor cache (atomic). Not fatal if it fails — a cache from the
-            // previous version already exists, so the worst case is `run`/`perms` showing stale
-            // scope until the next update/reinstall — but log it rather than swallow silently.
-            try
-            {
-                AtomicFile.WriteAllText(_paths.DescriptorCache(name), DescriptorParser.Serialize(descriptor));
-            }
-            catch (Exception cacheEx)
-            {
-                _logger.LogWarning(cacheEx, "Updated {Name} but could not refresh its descriptor cache; run/perms may show stale scope until the next update.", name);
-            }
+            // [8] Refresh descriptor cache (atomic, best-effort).
+            RefreshDescriptorCacheBestEffort(name, descriptor);
 
             return new UpdateResult
             {
@@ -403,6 +353,80 @@ namespace Hina.PackageManager.Install
                 ToVersion = descriptor.Version,
                 Status = UpdateStatus.Updated
             };
+        }
+
+        // Rewrite the cached descriptor so run/perms see the new version's scope. Not fatal
+        // if it fails — the previous version's cache already exists, so the worst case is
+        // run/perms showing stale scope until the next update/reinstall — but log it rather
+        // than swallow silently.
+        private void RefreshDescriptorCacheBestEffort(string name, AppDescriptor descriptor)
+        {
+            try
+            {
+                AtomicFile.WriteAllText(_paths.DescriptorCache(name), DescriptorParser.Serialize(descriptor));
+            }
+            catch (Exception cacheEx)
+            {
+                _logger.LogWarning(cacheEx, "Updated {Name} but could not refresh its descriptor cache; run/perms may show stale scope until the next update.", name);
+            }
+        }
+
+        // Recover from a mid-flight failure while applying the new version's hooks/entries:
+        // undo what we just added (reverse order), best-effort re-restore the hooks/entries we
+        // removed at step [7] from the PREVIOUS descriptor, roll back the on-disk patch, and
+        // restore the pre-update registry snapshot — so the user sees a clean rollback. Every
+        // step is fail-soft; recovery must not throw.
+        private async Task RollbackFailedAddAsync(
+            string name, InstalledApp app, HookExecutor hooks, IPatchClient patcher, AppDescriptor? previousDescriptor,
+            List<HookEvidence> addedHooks, List<ShellEntryRecord> addedEntries,
+            List<ShellEntryRecord> entriesToRemove, List<HookEvidence> hooksToRemove,
+            LockManager locks, RegistryStore store, InstalledApp previousSnapshot)
+        {
+            for (int i = addedHooks.Count - 1; i >= 0; i--)
+            {
+                try { await hooks.UndoAsync(addedHooks[i], CancellationToken.None); }
+                catch (Exception ex) { _logger.LogDebug(ex, "Rollback-undo of added hook {Action} failed for {Name} (fail-soft).", addedHooks[i].Action, name); }
+            }
+            for (int i = addedEntries.Count - 1; i >= 0; i--)
+            {
+                try { await _platform.RemoveMenuShortcut(addedEntries[i].Evidence, CancellationToken.None); }
+                catch (Exception ex) { _logger.LogDebug(ex, "Rollback-removal of added shell entry {Id} failed for {Name} (fail-soft).", addedEntries[i].Id, name); }
+            }
+            // Best-effort: re-apply the hooks/entries we removed at step [7] so the app
+            // comes back to its pre-update side-effect set. These are sourced from the
+            // PREVIOUS descriptor (the new one no longer lists them). May silently fail
+            // (e.g. target re-exists, race) — we proceed regardless.
+            if (previousDescriptor != null)
+            {
+                foreach (ShellEntryRecord r in entriesToRemove)
+                {
+                    foreach (ShellEntry orig in previousDescriptor.Entries)
+                    {
+                        if (orig.Id != r.Id) continue;
+                        try { await _platform.CreateMenuShortcut(orig, app.InstallPath, CancellationToken.None); }
+                        catch (Exception ex) { _logger.LogDebug(ex, "Re-create of shell entry {Id} during rollback failed for {Name} (fail-soft).", r.Id, name); }
+                        break;
+                    }
+                }
+                foreach (HookEvidence removed in hooksToRemove)
+                {
+                    string removedId = UpdateDiff.ResolveIdentity(removed);
+                    foreach (HookAction origHook in previousDescriptor.PostInstall)
+                    {
+                        if (HookIdentity.For(origHook) != removedId) continue;
+                        try { await hooks.ApplyAsync(origHook, app.InstallPath, app.Name, previousDescriptor.Entries, CancellationToken.None); }
+                        catch (Exception ex) { _logger.LogDebug(ex, "Re-apply of hook {Id} during rollback failed for {Name} (fail-soft).", removedId, name); }
+                        break;
+                    }
+                }
+            }
+            // Patch on disk also needs to roll back; PatchClient already journaled
+            // backups when Backup=true so RollbackAsync restores them.
+            try { await patcher.RollbackAsync(app.InstallPath, CancellationToken.None); }
+            catch (Exception ex) { _logger.LogDebug(ex, "Patch rollback during add-failure recovery failed for {Name} (fail-soft).", name); }
+
+            try { await SaveAppRowLockedAsync(locks, store, name, previousSnapshot, CancellationToken.None); }
+            catch (Exception ex) { _logger.LogWarning(ex, "Restoring pre-update registry snapshot for {Name} failed (fail-soft); run `hina verify`.", name); }
         }
 
         // Write a single app row under the exclusive lock, re-reading the on-disk registry first so

--- a/Hina.PackageManager/Platform/Linux/LinuxPlatformIntegration.cs
+++ b/Hina.PackageManager/Platform/Linux/LinuxPlatformIntegration.cs
@@ -305,25 +305,6 @@ namespace Hina.PackageManager.Platform.Linux
         }
 
         // Remove any control character so an interpolated value can't break out of its key line.
-        // The descriptor validator already rejects these, but stripping here keeps every write site
-        // safe even if a new field is added without a validator rule.
-        private static string StripControl(string value)
-        {
-            StringBuilder? sb = null;
-            for (int i = 0; i < value.Length; i++)
-            {
-                if (char.IsControl(value[i]))
-                {
-                    sb ??= new StringBuilder(value.Length).Append(value, 0, i);
-                }
-                else
-                {
-                    sb?.Append(value[i]);
-                }
-            }
-            return sb?.ToString() ?? value;
-        }
-
         // Quote a single Exec token per the freedesktop Desktop Entry spec. Reserved characters
         // require the token to be double-quoted; inside double quotes the characters
         // backslash, backtick, dollar and double-quote must each be escaped with a backslash.

--- a/Hina.PackageManager/Platform/MacOS/MacOSPlatformIntegration.cs
+++ b/Hina.PackageManager/Platform/MacOS/MacOSPlatformIntegration.cs
@@ -300,18 +300,6 @@ $@"<?xml version=""1.0"" encoding=""UTF-8""?>
             catch (Exception ex) { _logger.LogDebug(ex, "Best-effort: could not set exec mode on {Path}", execPath); }
         }
 
-        // Drop control characters (newlines especially) so a launch override can't
-        // inject extra script lines into the bundle exec.
-        private static string StripControl(string s)
-        {
-            StringBuilder sb = new StringBuilder(s.Length);
-            foreach (char c in s)
-            {
-                if (!char.IsControl(c)) sb.Append(c);
-            }
-            return sb.ToString();
-        }
-
         private static string BuildInfoPlist(string bundleName, string bundleId, string execName, string? documentTypes, string? urlTypes)
         {
             StringBuilder sb = new StringBuilder();

--- a/Hina.PackageManager/Platform/PlatformText.cs
+++ b/Hina.PackageManager/Platform/PlatformText.cs
@@ -44,6 +44,27 @@ namespace Hina.PackageManager.Platform
             return sb.Length == 0 ? "entry" : sb.ToString();
         }
 
+        // Drop control characters (newlines especially) so a value can't inject extra lines at a
+        // write site — a .desktop Exec=, a macOS bundle shell stub, etc. The descriptor validator
+        // already rejects these, but stripping here keeps every write site safe even if a new
+        // field is added without a validator rule. Allocates only when a control char is present.
+        public static string StripControl(string value)
+        {
+            StringBuilder? sb = null;
+            for (int i = 0; i < value.Length; i++)
+            {
+                if (char.IsControl(value[i]))
+                {
+                    sb ??= new StringBuilder(value.Length).Append(value, 0, i);
+                }
+                else
+                {
+                    sb?.Append(value[i]);
+                }
+            }
+            return sb?.ToString() ?? value;
+        }
+
         // Sanitize an arbitrary string into a filesystem-safe file name: OS-invalid chars become
         // '_'. Empty/whitespace-only input falls back to "Hina".
         public static string SanitizeFileName(string value)

--- a/Hina.PackageManager/Registry/RegistryMigrator.cs
+++ b/Hina.PackageManager/Registry/RegistryMigrator.cs
@@ -1,0 +1,71 @@
+using System;
+using System.Collections.Generic;
+using System.Text.Json.Nodes;
+
+namespace Hina.PackageManager.Registry
+{
+    // One step that upgrades a registry JSON document from schema FromVersion to
+    // FromVersion+1, mutating the raw JsonObject in place. Migrations work on the raw
+    // JSON (not a deserialized Registry) because the source-generated serializer
+    // silently drops fields it doesn't know — by the time you have a Registry object
+    // the older/newer data a migration needs may already be gone.
+    public sealed class RegistryMigration
+    {
+        public int FromVersion { get; }
+        public Action<JsonObject> Apply { get; }
+
+        public RegistryMigration(int fromVersion, Action<JsonObject> apply)
+        {
+            FromVersion = fromVersion;
+            Apply = apply;
+        }
+    }
+
+    // Upgrades an on-disk registry document to the current schema by applying ordered
+    // migrations. This is the upgrade path that replaces "refuse any non-current
+    // schema": a registry written by an OLDER Hina is migrated forward; one written by
+    // a NEWER Hina is still refused by RegistryStore (we can't know its future fields).
+    //
+    // Default is empty while the schema is still version 1 — it is the scaffold for the
+    // first non-additive bump. To add a migration: bump Registry.CurrentSchemaVersion
+    // and append a RegistryMigration(oldVersion, transform) to Default.
+    public static class RegistryMigrator
+    {
+        public static readonly IReadOnlyList<RegistryMigration> Default = Array.Empty<RegistryMigration>();
+
+        public static JsonObject Migrate(JsonObject root, int targetVersion, IReadOnlyList<RegistryMigration> migrations)
+        {
+            int version = ReadVersion(root);
+            while (version < targetVersion)
+            {
+                RegistryMigration? step = null;
+                foreach (RegistryMigration m in migrations)
+                {
+                    if (m.FromVersion == version) { step = m; break; }
+                }
+                if (step == null)
+                {
+                    throw new RegistrySchemaException(
+                        $"No registry migration from schema version {version} to {version + 1}; cannot upgrade to {targetVersion}.");
+                }
+
+                step.Apply(root);
+                version++;
+                root["schemaVersion"] = version;
+            }
+            return root;
+        }
+
+        // A registry that predates the schemaVersion field is treated as the first
+        // version (1) — the oldest format that could lack it.
+        private static int ReadVersion(JsonObject root)
+        {
+            if (root.TryGetPropertyValue("schemaVersion", out JsonNode? node) && node is not null)
+            {
+                try { return node.GetValue<int>(); }
+                catch (Exception) { return 1; }
+            }
+            return 1;
+        }
+    }
+}

--- a/Hina.PackageManager/Registry/RegistryStore.cs
+++ b/Hina.PackageManager/Registry/RegistryStore.cs
@@ -1,6 +1,8 @@
 using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Text.Json;
+using System.Text.Json.Nodes;
 using System.Threading;
 using System.Threading.Tasks;
 using Hina.PackageManager.Json;
@@ -63,22 +65,55 @@ namespace Hina.PackageManager.Registry
                 return new Registry();
             }
 
-            Registry? r = JsonSerializer.Deserialize(json, PackageManagerJsonContext.Default.Registry);
-            r ??= new Registry();
+            return LoadFromJson(json, Registry.CurrentSchemaVersion, RegistryMigrator.Default, _logger, _path);
+        }
 
-            // Schema gate: a registry stamped with a higher schema than this build understands
-            // was written by a newer Hina. Source-gen JSON silently drops fields it doesn't
-            // know, so loading-then-saving here would truncate the newer data. Refuse instead
-            // so the user upgrades Hina rather than losing install state.
-            if (r.SchemaVersion > Registry.CurrentSchemaVersion)
+        // Deserialize a registry document, upgrading an OLDER schema forward through the
+        // migration chain first. A NEWER schema is still refused (source-gen silently drops
+        // fields it doesn't know, so loading-then-saving would truncate the newer data — the
+        // user must upgrade Hina). Internal so tests can drive the migration path with a
+        // synthetic target+migrations while the production schema is still version 1.
+        internal static Registry LoadFromJson(string json, int targetVersion, IReadOnlyList<RegistryMigration> migrations, ILogger logger, string path)
+        {
+            JsonNode? node = JsonNode.Parse(json);
+            if (node is JsonObject root)
             {
-                throw new RegistrySchemaException(
-                    $"Registry at '{_path}' has schema version {r.SchemaVersion}, but this Hina only understands up to {Registry.CurrentSchemaVersion}. " +
-                    "Upgrade Hina to manage this registry; an older Hina would corrupt it.");
+                int version = ReadSchemaVersion(root);
+                if (version > targetVersion)
+                {
+                    throw NewerSchema(path, version, targetVersion);
+                }
+                if (version < targetVersion)
+                {
+                    RegistryMigrator.Migrate(root, targetVersion, migrations);
+                }
+                return root.Deserialize(PackageManagerJsonContext.Default.Registry) ?? new Registry();
             }
 
+            // Non-object / "null" JSON: defer to the source-gen deserializer (preserves the
+            // prior behavior, including the higher-schema gate).
+            Registry r = JsonSerializer.Deserialize(json, PackageManagerJsonContext.Default.Registry) ?? new Registry();
+            if (r.SchemaVersion > targetVersion)
+            {
+                throw NewerSchema(path, r.SchemaVersion, targetVersion);
+            }
             return r;
         }
+
+        private static int ReadSchemaVersion(JsonObject root)
+        {
+            if (root.TryGetPropertyValue("schemaVersion", out JsonNode? node) && node is not null)
+            {
+                try { return node.GetValue<int>(); }
+                catch (Exception) { return 1; }
+            }
+            return 1;
+        }
+
+        private static RegistrySchemaException NewerSchema(string path, int found, int max) =>
+            new RegistrySchemaException(
+                $"Registry at '{path}' has schema version {found}, but this Hina only understands up to {max}. " +
+                "Upgrade Hina to manage this registry; an older Hina would corrupt it.");
 
         public async Task SaveAsync(Registry registry, CancellationToken ct = default)
         {


### PR DESCRIPTION
Tech-debt items from the architecture review (sandbox v2 follow-up). No user-facing behavior change.

- **#12 CLI test coverage** — CommandRouterTests now cover the sandbox-era verbs: `run`, `perms` (+`permissions`/`permessi` aliases + `list`), the `repair`→`verify` alias, the `check <bad>` two-word router path, and `dev sandbox-run` arg validation. (20→31 CLI tests.)
- **#4 platform dedup** — hoisted the duplicated `StripControl` (Linux + macOS) into shared `PlatformText`; both sites already `using static` it. New `PlatformTextTests`.
- **#8 registry schema migration framework** — `RegistryMigrator`/`RegistryMigration` upgrade an older registry forward on load (operating on raw `JsonObject` so source-gen doesn't drop fields), wired into `RegistryStore.LoadFromJson`. Newer-schema refusal preserved. Empty migration list while schema is still v1 — scaffold for the first non-additive bump. AOT-safe.
- **#5 UpdateService refactor** — extracted `RollbackFailedAddAsync` (add-failure recovery) and `RefreshDescriptorCacheBestEffort` from the ~340-line `UpdateAsync`. Pure, behavior-identical; the 13 UpdateService tests + rollback coverage stay green.

436 tests green. AOT publish clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)