### PR TITLE
Windows sandbox: AppContainer backend investigated — kept NoOp (unverified), honest docs + scaffold

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -68,3 +68,29 @@ jobs:
     # allowed. It is a no-op assert off macOS, so this job is its real proof.
     - name: Test (incl. sandbox-exec enforcement)
       run: dotnet test --no-build -c Release --verbosity normal
+
+  windows-sandbox:
+    runs-on: windows-latest
+    steps:
+    - uses: actions/checkout@v3
+    - name: Setup .NET
+      uses: actions/setup-dotnet@v3
+      with:
+        dotnet-version: 10.0.x
+    - name: Restore dependencies
+      run: dotnet restore
+    - name: Build
+      run: dotnet build --no-restore -c Release
+    - name: Test
+      run: dotnet test --no-build -c Release --verbosity normal
+    # The Windows AppContainer backend can only be PROVEN on a real Windows runner.
+    # windows-sandbox-probe.ps1 runs a child under an AppContainer granting only a
+    # docs:rw dir (not a secret dir) and asserts the secret read is denied + the docs
+    # write allowed. It skip-passes if AppContainer is unavailable.
+    - name: Windows AppContainer sandbox probe
+      shell: pwsh
+      run: |
+        $hina = Get-ChildItem -Path Hina.CLI/bin/Release -Recurse -Filter Hina.CLI.exe | Select-Object -First 1
+        if (-not $hina) { Write-Error "hina binary not found"; exit 1 }
+        Write-Host "Using hina: $($hina.FullName)"
+        ./scripts/windows-sandbox-probe.ps1 -HinaExe $hina.FullName

--- a/Hina.PackageManager.Tests/LinuxPlatformIntegrationTests.cs
+++ b/Hina.PackageManager.Tests/LinuxPlatformIntegrationTests.cs
@@ -40,6 +40,9 @@ namespace Hina.PackageManager.Tests
         [Fact]
         public async Task CreateMenuShortcut_WritesValidDesktopEntry()
         {
+            // Path.Combine produces a backslash separator on Windows, breaking the Unix Exec=
+            // path assertion; the Linux integration only runs on Unix in practice.
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows)) return;
             ShellEntry entry = new ShellEntry
             {
                 Id = "main",

--- a/Hina.PackageManager.Tests/LinuxSandboxShortcutTests.cs
+++ b/Hina.PackageManager.Tests/LinuxSandboxShortcutTests.cs
@@ -1,6 +1,7 @@
 using System;
 using System.IO;
 using System.Linq;
+using System.Runtime.InteropServices;
 using System.Threading;
 using System.Threading.Tasks;
 using Hina.PackageManager.Descriptor;
@@ -53,6 +54,9 @@ namespace Hina.PackageManager.Tests
         [Fact]
         public async Task NullOverride_PointsAtAppBinary()
         {
+            // Path.Combine yields a backslash separator on Windows, breaking the Unix path
+            // assertion; the Linux integration only runs on Unix in practice.
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows)) return;
             string path = await _platform.CreateMenuShortcut(Entry(), "/apps/demo", null, CancellationToken.None);
             string exec = await ExecLine(path);
             Assert.Contains("/apps/demo/bin/demo", exec);

--- a/Hina.PackageManager.Tests/NoOpSandboxTests.cs
+++ b/Hina.PackageManager.Tests/NoOpSandboxTests.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using System.Runtime.InteropServices;
 using Hina.PackageManager.Sandbox;
 using Microsoft.Extensions.Logging.Abstractions;
 
@@ -7,6 +8,8 @@ namespace Hina.PackageManager.Tests
     public class NoOpSandboxTests
     {
         private static readonly SandboxPlan EmptyPlan = new SandboxPlan(false, new List<ResolvedFsRule>());
+
+        private static bool IsWindows => RuntimeInformation.IsOSPlatform(OSPlatform.Windows);
 
         [Fact]
         public void IsSupported_IsFalse()
@@ -17,6 +20,7 @@ namespace Hina.PackageManager.Tests
         [Fact]
         public void Launch_RunsProcess_ReturnsExitCode()
         {
+            if (IsWindows) return; // /bin/sh is Unix-only; NoOp's spawn is the same code path on every OS.
             NoOpSandbox sandbox = new NoOpSandbox(NullLogger.Instance);
             int code = sandbox.Launch("/bin/sh", new List<string> { "-c", "exit 7" }, EmptyPlan, default);
             Assert.Equal(7, code);
@@ -25,6 +29,7 @@ namespace Hina.PackageManager.Tests
         [Fact]
         public void Launch_PassesArgs()
         {
+            if (IsWindows) return; // /bin/sh is Unix-only.
             NoOpSandbox sandbox = new NoOpSandbox(NullLogger.Instance);
             // sh -c 'exit $#' arg0 a b c  -> exit code = number of extra args after the -c command name
             int code = sandbox.Launch("/bin/sh", new List<string> { "-c", "exit $#", "x", "a", "b" }, EmptyPlan, default);

--- a/Hina.PackageManager.Tests/WindowsAppContainerPolicyTests.cs
+++ b/Hina.PackageManager.Tests/WindowsAppContainerPolicyTests.cs
@@ -1,0 +1,108 @@
+using System.Collections.Generic;
+using System.Linq;
+using Hina.PackageManager.Sandbox;
+using Xunit;
+
+namespace Hina.PackageManager.Tests
+{
+    // The AppContainer POLICY (which paths get which ACEs, which capability SIDs to
+    // attach, the container moniker) is the testable, pure core of the Windows sandbox
+    // backend — the analogue of MacOsSeatbeltProfile. The raw CreateProcess / ACL
+    // P/Invoke that consumes this policy is exercised by the windows-latest CI probe,
+    // not here (it cannot run on the macOS/Linux dev host).
+    public class WindowsAppContainerPolicyTests
+    {
+        private static SandboxPlan Plan(bool restrictNetwork, params ResolvedFsRule[] rules)
+            => new SandboxPlan(unrestricted: false, rules, restrictNetwork);
+
+        [Fact]
+        public void ContainerName_PrefixesHinaAndIsDeterministic()
+        {
+            string a = WindowsAppContainerPolicy.ContainerName("signal");
+            string b = WindowsAppContainerPolicy.ContainerName("signal");
+            Assert.Equal(a, b);
+            Assert.StartsWith("Hina.", a);
+            Assert.Contains("signal", a);
+        }
+
+        [Fact]
+        public void ContainerName_SanitizesIllegalCharsAndCapsAt64()
+        {
+            // AppContainer monikers are limited to 64 chars and a constrained charset;
+            // spaces / slashes must not leak into the name.
+            string name = WindowsAppContainerPolicy.ContainerName("My App/../weird name!");
+            Assert.DoesNotContain(" ", name);
+            Assert.DoesNotContain("/", name);
+            Assert.DoesNotContain("\\", name);
+            Assert.True(name.Length <= 64, $"name too long: {name.Length}");
+        }
+
+        [Fact]
+        public void ContainerName_LongAppNameStillCapsAt64()
+        {
+            string name = WindowsAppContainerPolicy.ContainerName(new string('x', 200));
+            Assert.True(name.Length <= 64, $"name too long: {name.Length}");
+        }
+
+        [Fact]
+        public void BuildAceList_ReadOnlyRule_GrantsReadExecuteNotWrite()
+        {
+            IReadOnlyList<AppContainerAce> aces =
+                WindowsAppContainerPolicy.BuildAceList(Plan(false, new ResolvedFsRule(@"C:\data\docs", false)));
+            AppContainerAce ace = Assert.Single(aces);
+            Assert.Equal(@"C:\data\docs", ace.Path);
+            Assert.Equal(AppContainerAccess.ReadExecute, ace.Access);
+        }
+
+        [Fact]
+        public void BuildAceList_ReadWriteRule_GrantsReadWriteExecute()
+        {
+            IReadOnlyList<AppContainerAce> aces =
+                WindowsAppContainerPolicy.BuildAceList(Plan(false, new ResolvedFsRule(@"C:\data\docs", true)));
+            AppContainerAce ace = Assert.Single(aces);
+            Assert.Equal(AppContainerAccess.ReadWriteExecute, ace.Access);
+        }
+
+        [Fact]
+        public void BuildAceList_PreservesEveryRuleInOrder()
+        {
+            // rules[0] is conventionally the app dir (ro) — it must get an ACE too, or
+            // the AppContainer can't read its own binary and the process won't start.
+            IReadOnlyList<AppContainerAce> aces = WindowsAppContainerPolicy.BuildAceList(Plan(false,
+                new ResolvedFsRule(@"C:\apps\demo", false),
+                new ResolvedFsRule(@"C:\data\docs", true)));
+            Assert.Equal(2, aces.Count);
+            Assert.Equal(@"C:\apps\demo", aces[0].Path);
+            Assert.Equal(@"C:\data\docs", aces[1].Path);
+        }
+
+        [Fact]
+        public void BuildAceList_Unrestricted_GrantsNothing()
+        {
+            // Host opt-out: the backend spawns directly with no container, so there is
+            // no SID to grant and the list must be empty.
+            SandboxPlan host = new SandboxPlan(unrestricted: true,
+                new[] { new ResolvedFsRule(@"C:\apps\demo", false) });
+            Assert.Empty(WindowsAppContainerPolicy.BuildAceList(host));
+        }
+
+        [Fact]
+        public void BuildCapabilitySids_NetworkAllowed_IncludesInternetClient()
+        {
+            IReadOnlyList<string> caps =
+                WindowsAppContainerPolicy.BuildCapabilitySids(Plan(restrictNetwork: false,
+                    new ResolvedFsRule(@"C:\apps\demo", false)));
+            Assert.Contains(WindowsAppContainerPolicy.InternetClientCapabilitySid, caps);
+        }
+
+        [Fact]
+        public void BuildCapabilitySids_NetworkRestricted_IsEmpty()
+        {
+            // Mirror Landlock/Seatbelt: omit the capability SID to deny network.
+            IReadOnlyList<string> caps =
+                WindowsAppContainerPolicy.BuildCapabilitySids(Plan(restrictNetwork: true,
+                    new ResolvedFsRule(@"C:\apps\demo", false)));
+            Assert.Empty(caps);
+        }
+    }
+}

--- a/Hina.PackageManager.Tests/WindowsLaunchOverrideTests.cs
+++ b/Hina.PackageManager.Tests/WindowsLaunchOverrideTests.cs
@@ -1,0 +1,37 @@
+using Hina.PackageManager.Platform.Windows;
+using Xunit;
+
+namespace Hina.PackageManager.Tests
+{
+    // A .lnk shortcut stores its launch command as a separate target path + argument
+    // string, but InstallService hands every backend ONE opaque override string
+    // (`"<hinaExe>" run <app> "<entry>"`). Splitting that back into (exe, args) for the
+    // .lnk is pure string logic, so it is unit-tested here on every host; the COM .lnk
+    // write itself is Windows-only (WindowsPlatformIntegrationTests, gated to Windows CI).
+    public class WindowsLaunchOverrideTests
+    {
+        [Fact]
+        public void Parse_QuotedExeWithSpaces_SplitsExeFromArgs()
+        {
+            WindowsLaunchOverride parsed = WindowsLaunchOverride.Parse("\"C:\\Program Files\\hina.exe\" run demo \"main\"");
+            Assert.Equal("C:\\Program Files\\hina.exe", parsed.Exe);
+            Assert.Equal("run demo \"main\"", parsed.Arguments);
+        }
+
+        [Fact]
+        public void Parse_UnquotedExe_SplitsOnFirstWhitespace()
+        {
+            WindowsLaunchOverride parsed = WindowsLaunchOverride.Parse("hina run demo \"main\"");
+            Assert.Equal("hina", parsed.Exe);
+            Assert.Equal("run demo \"main\"", parsed.Arguments);
+        }
+
+        [Fact]
+        public void Parse_ExeOnly_HasEmptyArguments()
+        {
+            WindowsLaunchOverride parsed = WindowsLaunchOverride.Parse("\"C:\\hina.exe\"");
+            Assert.Equal("C:\\hina.exe", parsed.Exe);
+            Assert.Equal("", parsed.Arguments);
+        }
+    }
+}

--- a/Hina.PackageManager.Tests/WindowsPlatformIntegrationTests.cs
+++ b/Hina.PackageManager.Tests/WindowsPlatformIntegrationTests.cs
@@ -90,6 +90,30 @@ namespace Hina.PackageManager.Tests
 
         [Fact]
         [SupportedOSPlatform("windows")]
+        public async Task CreateMenuShortcut_WithLaunchOverride_WritesLnkRoutedThroughHina()
+        {
+            if (!IsWindows) return;
+
+            WindowsPlatformIntegration p = NewPlatform();
+
+            string appDir = Path.Combine(_tempDir, "payload");
+            Directory.CreateDirectory(appDir);
+
+            ShellEntry entry = new ShellEntry { Id = "main", Name = "Sandboxed App", Exec = "bin\\demo.exe" };
+            string hinaExe = Path.Combine(_tempDir, "hina.exe");
+            File.WriteAllBytes(hinaExe, new byte[] { 0x4D, 0x5A });
+            string launchOverride = $"\"{hinaExe}\" run demo \"main\"";
+
+            // The sandboxed shortcut must point at hina (so the AppContainer is installed
+            // before the app starts), not the raw binary — the COM write must not throw.
+            string evidence = await p.CreateMenuShortcut(entry, appDir, launchOverride, CancellationToken.None);
+
+            Assert.True(File.Exists(evidence));
+            Assert.EndsWith(".lnk", evidence);
+        }
+
+        [Fact]
+        [SupportedOSPlatform("windows")]
         public async Task RegisterUrlScheme_WritesHkcuKeyWithUrlProtocol()
         {
             if (!IsWindows) return;

--- a/Hina.PackageManager.Tests/WindowsPlatformIntegrationTests.cs
+++ b/Hina.PackageManager.Tests/WindowsPlatformIntegrationTests.cs
@@ -180,7 +180,8 @@ namespace Hina.PackageManager.Tests
 
             string evidence = await p.InstallFont(src, CancellationToken.None);
 
-            string[] parts = evidence.Split('|');
+            // Evidence is "<destPath><US><fontName>" (US = unit separator U+001F), not '|'.
+            string[] parts = evidence.Split('');
             Assert.Equal(2, parts.Length);
             string destPath = parts[0];
             string fontName = parts[1];

--- a/Hina.PackageManager/Install/InstallService.cs
+++ b/Hina.PackageManager/Install/InstallService.cs
@@ -179,12 +179,14 @@ namespace Hina.PackageManager.Install
 
                 // [12] Shell entries. Sandboxed apps launch via `hina run` so the
                 // filesystem sandbox is installed before the app process starts — enforced on
-                // Linux (Landlock) and macOS (sandbox-exec). On Windows the launchOverride is
-                // ignored (the app launches directly), so we must NOT route through `hina run`
-                // (it would gain nothing) and we must tell the user the sandbox is not enforced.
+                // Linux (Landlock), macOS (sandbox-exec) and Windows (AppContainer). On an OS
+                // without a backend the launchOverride is ignored (the app launches directly),
+                // so we must NOT route through `hina run` (it would gain nothing) and we must
+                // tell the user the sandbox is not enforced.
                 bool sandboxRequested = descriptor.Sandbox?.Enabled == true;
                 bool sandboxEnforceable = RuntimeInformation.IsOSPlatform(OSPlatform.Linux)
-                    || RuntimeInformation.IsOSPlatform(OSPlatform.OSX);
+                    || RuntimeInformation.IsOSPlatform(OSPlatform.OSX)
+                    || RuntimeInformation.IsOSPlatform(OSPlatform.Windows);
                 if (sandboxRequested)
                 {
                     DiscloseSandbox(descriptor.Sandbox!, sandboxEnforceable);
@@ -234,9 +236,10 @@ namespace Hina.PackageManager.Install
         }
 
         // Tell the user exactly what filesystem scope a sandboxed app declares, with extra
-        // emphasis on the unrestricted "host" escape hatch. `enforceable` is false on OSes whose
-        // sandbox backend isn't implemented yet (macOS/Windows) — there the scope is declared but
-        // NOT applied, so we must say so plainly instead of implying isolation that won't happen.
+        // emphasis on the unrestricted "host" escape hatch. `enforceable` is false only where the
+        // platform can't enforce (e.g. an old Linux kernel without Landlock) — there the scope is
+        // declared but NOT applied, so we say so plainly instead of implying isolation that won't
+        // happen. Linux, macOS and Windows all have backends now.
         private void DiscloseSandbox(SandboxSpec sandbox, bool enforceable)
         {
             if (!enforceable)

--- a/Hina.PackageManager/Install/InstallService.cs
+++ b/Hina.PackageManager/Install/InstallService.cs
@@ -179,14 +179,14 @@ namespace Hina.PackageManager.Install
 
                 // [12] Shell entries. Sandboxed apps launch via `hina run` so the
                 // filesystem sandbox is installed before the app process starts — enforced on
-                // Linux (Landlock), macOS (sandbox-exec) and Windows (AppContainer). On an OS
-                // without a backend the launchOverride is ignored (the app launches directly),
-                // so we must NOT route through `hina run` (it would gain nothing) and we must
-                // tell the user the sandbox is not enforced.
+                // Linux (Landlock) and macOS (sandbox-exec). On an OS without a working backend
+                // (Windows — its AppContainer backend is implemented but unverified, see
+                // WindowsSandbox) the launchOverride is ignored (the app launches directly), so
+                // we must NOT route through `hina run` (it would gain nothing) and we must tell
+                // the user the sandbox is not enforced.
                 bool sandboxRequested = descriptor.Sandbox?.Enabled == true;
                 bool sandboxEnforceable = RuntimeInformation.IsOSPlatform(OSPlatform.Linux)
-                    || RuntimeInformation.IsOSPlatform(OSPlatform.OSX)
-                    || RuntimeInformation.IsOSPlatform(OSPlatform.Windows);
+                    || RuntimeInformation.IsOSPlatform(OSPlatform.OSX);
                 if (sandboxRequested)
                 {
                     DiscloseSandbox(descriptor.Sandbox!, sandboxEnforceable);
@@ -236,10 +236,10 @@ namespace Hina.PackageManager.Install
         }
 
         // Tell the user exactly what filesystem scope a sandboxed app declares, with extra
-        // emphasis on the unrestricted "host" escape hatch. `enforceable` is false only where the
-        // platform can't enforce (e.g. an old Linux kernel without Landlock) — there the scope is
-        // declared but NOT applied, so we say so plainly instead of implying isolation that won't
-        // happen. Linux, macOS and Windows all have backends now.
+        // emphasis on the unrestricted "host" escape hatch. `enforceable` is false where the
+        // platform can't enforce (Windows — no working backend yet; or an old Linux kernel
+        // without Landlock) — there the scope is declared but NOT applied, so we say so plainly
+        // instead of implying isolation that won't happen.
         private void DiscloseSandbox(SandboxSpec sandbox, bool enforceable)
         {
             if (!enforceable)

--- a/Hina.PackageManager/Platform/Windows/ShellLink.cs
+++ b/Hina.PackageManager/Platform/Windows/ShellLink.cs
@@ -11,13 +11,17 @@ namespace Hina.PackageManager.Platform.Windows
     [SupportedOSPlatform("windows")]
     internal static class ShellLink
     {
-        public static void Create(string linkPath, string targetPath, string workingDir, string description, string? iconPath = null)
+        public static void Create(string linkPath, string targetPath, string workingDir, string description, string? iconPath = null, string? arguments = null)
         {
             IShellLinkW shellLink = new IShellLinkW_Coclass();
             try
             {
                 shellLink.SetPath(targetPath);
                 shellLink.SetWorkingDirectory(workingDir);
+                if (!string.IsNullOrEmpty(arguments))
+                {
+                    shellLink.SetArguments(arguments);
+                }
                 if (!string.IsNullOrEmpty(description))
                 {
                     shellLink.SetDescription(description);

--- a/Hina.PackageManager/Platform/Windows/WindowsLaunchOverride.cs
+++ b/Hina.PackageManager/Platform/Windows/WindowsLaunchOverride.cs
@@ -1,0 +1,47 @@
+namespace Hina.PackageManager.Platform.Windows
+{
+    // Splits InstallService's opaque sandbox launch override (`"<hinaExe>" run <app>
+    // "<entry>"`) into the executable + argument string a .lnk shortcut stores separately.
+    // Pure string logic so it is host-runnable in tests; the COM .lnk write that consumes
+    // it is Windows-only.
+    public readonly struct WindowsLaunchOverride
+    {
+        public string Exe { get; }
+        public string Arguments { get; }
+
+        private WindowsLaunchOverride(string exe, string arguments)
+        {
+            Exe = exe;
+            Arguments = arguments;
+        }
+
+        public static WindowsLaunchOverride Parse(string launchOverride)
+        {
+            string s = launchOverride.Trim();
+            if (s.Length == 0)
+            {
+                return new WindowsLaunchOverride(string.Empty, string.Empty);
+            }
+
+            if (s[0] == '"')
+            {
+                int close = s.IndexOf('"', 1);
+                if (close > 0)
+                {
+                    string exe = s.Substring(1, close - 1);
+                    string args = s.Substring(close + 1).Trim();
+                    return new WindowsLaunchOverride(exe, args);
+                }
+                // Unbalanced quote — treat the rest verbatim as the exe.
+                return new WindowsLaunchOverride(s.Substring(1), string.Empty);
+            }
+
+            int sp = s.IndexOfAny(new[] { ' ', '\t' });
+            if (sp < 0)
+            {
+                return new WindowsLaunchOverride(s, string.Empty);
+            }
+            return new WindowsLaunchOverride(s.Substring(0, sp), s.Substring(sp + 1).Trim());
+        }
+    }
+}

--- a/Hina.PackageManager/Platform/Windows/WindowsPlatformIntegration.cs
+++ b/Hina.PackageManager/Platform/Windows/WindowsPlatformIntegration.cs
@@ -47,15 +47,37 @@ namespace Hina.PackageManager.Platform.Windows
         // ---- Menu shortcut (.lnk via IShellLink) ----
 
         public Task<string> CreateMenuShortcut(ShellEntry entry, string appDir, CancellationToken ct)
+            => CreateMenuShortcut(entry, appDir, launchOverride: null, ct);
+
+        // Sandbox-aware overload: a sandboxed app routes through `hina run` (launchOverride)
+        // so the AppContainer is installed before the real binary starts. The .lnk then points
+        // at the hina executable with `run <app> <entry>` as its arguments — pointing straight
+        // at the binary would bypass the sandbox. Control chars are stripped (the override flows
+        // into a persisted shortcut). Mirrors Linux/macOS.
+        public Task<string> CreateMenuShortcut(ShellEntry entry, string appDir, string? launchOverride, CancellationToken ct)
         {
             Directory.CreateDirectory(_startMenuDir);
 
             string linkPath = Path.Combine(_startMenuDir, SanitizeFileName(entry.Name) + ".lnk");
-            string targetPath = Path.Combine(appDir, entry.Exec);
-            string workingDir = Path.GetDirectoryName(targetPath) ?? appDir;
             string? iconPath = entry.Icon != null ? Path.Combine(appDir, entry.Icon) : null;
 
-            ShellLink.Create(linkPath, targetPath, workingDir, entry.Name, iconPath);
+            string targetPath;
+            string workingDir;
+            string? arguments = null;
+            if (launchOverride != null)
+            {
+                WindowsLaunchOverride parsed = WindowsLaunchOverride.Parse(StripControl(launchOverride));
+                targetPath = parsed.Exe;
+                arguments = parsed.Arguments;
+                workingDir = appDir;
+            }
+            else
+            {
+                targetPath = Path.Combine(appDir, entry.Exec);
+                workingDir = Path.GetDirectoryName(targetPath) ?? appDir;
+            }
+
+            ShellLink.Create(linkPath, targetPath, workingDir, entry.Name, iconPath, arguments);
             return Task.FromResult(linkPath);
         }
 

--- a/Hina.PackageManager/Sandbox/SandboxLauncherFactory.cs
+++ b/Hina.PackageManager/Sandbox/SandboxLauncherFactory.cs
@@ -4,9 +4,14 @@ using Microsoft.Extensions.Logging;
 namespace Hina.PackageManager.Sandbox
 {
     // Selects the sandbox backend for this OS. Linux → Landlock when the kernel
-    // supports it; macOS → sandbox-exec (Seatbelt); Windows → AppContainer (NT 6.2+);
-    // otherwise NoOp. A backend that reports IsSupported=false falls back to NoOp so a
-    // launch is never blocked.
+    // supports it; macOS → sandbox-exec (Seatbelt); otherwise NoOp. A backend that
+    // reports IsSupported=false falls back to NoOp so a launch is never blocked.
+    //
+    // Windows: the AppContainer backend (WindowsSandbox) is implemented but deliberately
+    // NOT selected — see its header. On the windows-latest CI probe the lowbox honored
+    // no runtime DACL grant (package SID, ALL APPLICATION PACKAGES, or lowered integrity,
+    // shallow or deep path all denied), so wiring it in would launch apps that can't read
+    // their own files. Until that is resolved on a real Windows box, Windows stays NoOp.
     public static class SandboxLauncherFactory
     {
         public static ISandboxLauncher Current(ILogger logger)
@@ -27,14 +32,8 @@ namespace Hina.PackageManager.Sandbox
                     return macos;
                 }
             }
-            else if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
-            {
-                WindowsSandbox windows = new WindowsSandbox(logger);
-                if (windows.IsSupported)
-                {
-                    return windows;
-                }
-            }
+            // Windows intentionally falls through to NoOp — WindowsSandbox is unverified
+            // (see header) and selecting it would break app launches.
             return new NoOpSandbox(logger);
         }
     }

--- a/Hina.PackageManager/Sandbox/SandboxLauncherFactory.cs
+++ b/Hina.PackageManager/Sandbox/SandboxLauncherFactory.cs
@@ -4,9 +4,9 @@ using Microsoft.Extensions.Logging;
 namespace Hina.PackageManager.Sandbox
 {
     // Selects the sandbox backend for this OS. Linux → Landlock when the kernel
-    // supports it; macOS → sandbox-exec (Seatbelt); otherwise NoOp. Windows → NoOp
-    // until its backend lands. A backend that reports IsSupported=false falls back
-    // to NoOp so a launch is never blocked.
+    // supports it; macOS → sandbox-exec (Seatbelt); Windows → AppContainer (NT 6.2+);
+    // otherwise NoOp. A backend that reports IsSupported=false falls back to NoOp so a
+    // launch is never blocked.
     public static class SandboxLauncherFactory
     {
         public static ISandboxLauncher Current(ILogger logger)
@@ -25,6 +25,14 @@ namespace Hina.PackageManager.Sandbox
                 if (macos.IsSupported)
                 {
                     return macos;
+                }
+            }
+            else if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            {
+                WindowsSandbox windows = new WindowsSandbox(logger);
+                if (windows.IsSupported)
+                {
+                    return windows;
                 }
             }
             return new NoOpSandbox(logger);

--- a/Hina.PackageManager/Sandbox/WindowsAppContainerPolicy.cs
+++ b/Hina.PackageManager/Sandbox/WindowsAppContainerPolicy.cs
@@ -1,0 +1,98 @@
+using System.Collections.Generic;
+using System.Text;
+
+namespace Hina.PackageManager.Sandbox
+{
+    // The access level granted to the AppContainer SID on a path. ReadExecute lets the
+    // app read + run files (load DLLs, read data); ReadWriteExecute adds modify/create.
+    public enum AppContainerAccess
+    {
+        ReadExecute,
+        ReadWriteExecute,
+    }
+
+    // One ACE to add to a path's DACL: grant the per-app AppContainer SID `Access` on `Path`.
+    public readonly struct AppContainerAce
+    {
+        public string Path { get; }
+        public AppContainerAccess Access { get; }
+
+        public AppContainerAce(string path, AppContainerAccess access)
+        {
+            Path = path;
+            Access = access;
+        }
+    }
+
+    // Pure policy core of the Windows AppContainer sandbox backend — the analogue of
+    // MacOsSeatbeltProfile. Decides, from an OS-agnostic SandboxPlan: the stable container
+    // moniker, the list of (path, access) ACEs to grant the container SID, and the
+    // capability SIDs to attach. String/struct only, so it is unit-testable on any host;
+    // the raw CreateProcess / ACL P/Invoke that consumes it lives in WindowsSandbox and is
+    // proven by the windows-latest CI probe.
+    //
+    // Isolation model: an AppContainer process is DENIED every securable object unless its
+    // DACL grants the AppContainer SID (or a capability SID, or ALL APPLICATION PACKAGES).
+    // System DLL dirs (System32, WinSxS, the GAC) already carry an ALL APPLICATION PACKAGES
+    // ACE granting read+execute to every container, so we do NOT — and must not, it needs
+    // admin and edits a shared system ACL — add ACEs there. We grant only the app's own dir
+    // (so it can load its binary) and each plan rule. Everything else stays denied by default.
+    public static class WindowsAppContainerPolicy
+    {
+        // Well-known capability SID for outbound internet access. Attaching it to the
+        // SECURITY_CAPABILITIES lets the AppContainer open client sockets; omitting it
+        // denies network — mirroring Landlock/Seatbelt's RestrictNetwork.
+        public const string InternetClientCapabilitySid = "S-1-15-3-1";
+
+        // AppContainer monikers are capped at 64 wide chars and a constrained charset.
+        private const int MaxContainerNameLength = 64;
+        private const string ContainerPrefix = "Hina.";
+
+        // Stable per-app container name, e.g. "Hina.signal". Deterministic so re-launches
+        // derive the same SID (the profile is created once, then reused). Sanitized to the
+        // AppContainer charset and capped at 64 chars.
+        public static string ContainerName(string appName)
+        {
+            StringBuilder sb = new StringBuilder(MaxContainerNameLength);
+            sb.Append(ContainerPrefix);
+            foreach (char c in appName)
+            {
+                if (sb.Length >= MaxContainerNameLength) break;
+                if (char.IsLetterOrDigit(c) || c == '.' || c == '-' || c == '_') sb.Append(c);
+                else sb.Append('_');
+            }
+            return sb.ToString();
+        }
+
+        // One ACE per plan rule, in order (rules[0] is conventionally the app dir, which
+        // MUST be granted or the container can't read its own binary). ro → ReadExecute,
+        // rw → ReadWriteExecute. Unrestricted (host opt-out) → no container, no ACEs.
+        public static IReadOnlyList<AppContainerAce> BuildAceList(SandboxPlan plan)
+        {
+            if (plan.Unrestricted)
+            {
+                return System.Array.Empty<AppContainerAce>();
+            }
+
+            List<AppContainerAce> aces = new List<AppContainerAce>(plan.Rules.Count);
+            foreach (ResolvedFsRule rule in plan.Rules)
+            {
+                aces.Add(new AppContainerAce(
+                    rule.Path,
+                    rule.CanWrite ? AppContainerAccess.ReadWriteExecute : AppContainerAccess.ReadExecute));
+            }
+            return aces;
+        }
+
+        // Capability SIDs to attach to the AppContainer. Network is denied by default and
+        // allowed back only when the plan permits it.
+        public static IReadOnlyList<string> BuildCapabilitySids(SandboxPlan plan)
+        {
+            if (plan.RestrictNetwork)
+            {
+                return System.Array.Empty<string>();
+            }
+            return new[] { InternetClientCapabilitySid };
+        }
+    }
+}

--- a/Hina.PackageManager/Sandbox/WindowsSandbox.cs
+++ b/Hina.PackageManager/Sandbox/WindowsSandbox.cs
@@ -106,6 +106,7 @@ namespace Hina.PackageManager.Sandbox
                 {
                     GrantContainerAce(ace.Path, containerSid, ace.Access);
                     _logger.LogDebug("AppContainer grant {Access} on {Path}", ace.Access, ace.Path);
+                    GrantAncestorTraverse(ace.Path, containerSid);
                 }
 
                 // 2. Build the capability SID array (network etc).
@@ -201,13 +202,39 @@ namespace Hina.PackageManager.Sandbox
                 _ => GENERIC_READ | GENERIC_EXECUTE,
             };
             // Inheritable so files created in / already under the dir get the right too.
-            GrantAce(path, containerSid, rights, SUB_CONTAINERS_AND_OBJECTS_INHERIT, throwOnFail: true);
+            // propagate=true (SetNamedSecurityInfo) pushes the inheritable ACE to existing
+            // children — cheap on a small app/data dir and needed so its files are reachable.
+            GrantAce(path, containerSid, rights, SUB_CONTAINERS_AND_OBJECTS_INHERIT, throwOnFail: true, propagate: true);
+        }
+
+        // Grant FILE_TRAVERSE on every ancestor directory of a granted leaf so the lowbox
+        // token (which does NOT bypass traverse — proven on CI) can walk down to it.
+        // Execute-only and NON-inheritable, so the container gains pass-through but cannot
+        // enumerate or read the ancestors' contents. propagate=false so each grant uses
+        // SetFileSecurity (no subtree re-propagation — SetNamedSecurityInfo on a profile dir
+        // walks the whole tree and hangs for minutes). Best-effort: ancestors we can't re-ACL
+        // (the drive root, C:\Users) are skipped — they already grant ALL APPLICATION PACKAGES
+        // traverse; the profile-private dirs we own are the ones that need it.
+        [SupportedOSPlatform("windows")]
+        private void GrantAncestorTraverse(string leafPath, IntPtr containerSid)
+        {
+            DirectoryInfo? dir;
+            try { dir = Directory.GetParent(Path.GetFullPath(leafPath)); }
+            catch { return; }
+
+            while (dir != null)
+            {
+                GrantAce(dir.FullName, containerSid, FILE_TRAVERSE, NO_INHERITANCE, throwOnFail: false, propagate: false);
+                dir = dir.Parent;
+            }
         }
 
         // Merge one GRANT_ACCESS ACE for the container SID into a path's DACL.
         // throwOnFail=false makes it best-effort (used for the ancestor traverse chain).
+        // propagate=false applies the DACL with SetFileSecurity, which does NOT re-propagate
+        // inheritance into the subtree (SetNamedSecurityInfo does, and hangs on big dirs).
         [SupportedOSPlatform("windows")]
-        private void GrantAce(string path, IntPtr containerSid, uint rights, uint inheritance, bool throwOnFail)
+        private void GrantAce(string path, IntPtr containerSid, uint rights, uint inheritance, bool throwOnFail, bool propagate)
         {
             uint getErr = GetNamedSecurityInfoW(path, SE_FILE_OBJECT, DACL_SECURITY_INFORMATION,
                 IntPtr.Zero, IntPtr.Zero, out IntPtr oldDacl, IntPtr.Zero, out IntPtr securityDescriptor);
@@ -244,12 +271,33 @@ namespace Hina.PackageManager.Sandbox
                     return;
                 }
 
-                uint applyErr = SetNamedSecurityInfoW(path, SE_FILE_OBJECT, DACL_SECURITY_INFORMATION,
-                    IntPtr.Zero, IntPtr.Zero, newDacl, IntPtr.Zero);
-                if (applyErr != ERROR_SUCCESS)
+                if (propagate)
                 {
-                    if (throwOnFail) throw new InvalidOperationException($"SetNamedSecurityInfo('{path}') failed ({applyErr}).");
-                    _logger.LogDebug("AppContainer: SetNamedSecurityInfo('{Path}') failed ({Err}); skipped.", path, applyErr);
+                    uint applyErr = SetNamedSecurityInfoW(path, SE_FILE_OBJECT, DACL_SECURITY_INFORMATION,
+                        IntPtr.Zero, IntPtr.Zero, newDacl, IntPtr.Zero);
+                    if (applyErr != ERROR_SUCCESS)
+                    {
+                        if (throwOnFail) throw new InvalidOperationException($"SetNamedSecurityInfo('{path}') failed ({applyErr}).");
+                        _logger.LogDebug("AppContainer: SetNamedSecurityInfo('{Path}') failed ({Err}); skipped.", path, applyErr);
+                    }
+                }
+                else
+                {
+                    // Non-propagating: write just this object's DACL. SetFileSecurity does not
+                    // walk the subtree, so it stays fast on huge profile directories.
+                    IntPtr sd = Marshal.AllocHGlobal(SECURITY_DESCRIPTOR_MIN_LENGTH);
+                    try
+                    {
+                        if (!InitializeSecurityDescriptor(sd, SECURITY_DESCRIPTOR_REVISION)
+                            || !SetSecurityDescriptorDacl(sd, true, newDacl, false)
+                            || !SetFileSecurityW(path, DACL_SECURITY_INFORMATION, sd))
+                        {
+                            int err = Marshal.GetLastWin32Error();
+                            if (throwOnFail) throw new InvalidOperationException($"SetFileSecurity('{path}') failed ({err}).");
+                            _logger.LogDebug("AppContainer: SetFileSecurity('{Path}') failed ({Err}); skipped.", path, err);
+                        }
+                    }
+                    finally { Marshal.FreeHGlobal(sd); }
                 }
             }
             finally
@@ -398,6 +446,10 @@ namespace Hina.PackageManager.Sandbox
 
         private const int GRANT_ACCESS = 1;
         private const uint SUB_CONTAINERS_AND_OBJECTS_INHERIT = 0x3; // CONTAINER_INHERIT_ACE | OBJECT_INHERIT_ACE
+        private const uint NO_INHERITANCE = 0x0;
+        private const uint FILE_TRAVERSE = 0x00000020; // execute right on a directory (pass-through, no list)
+        private const uint SECURITY_DESCRIPTOR_REVISION = 1;
+        private const int SECURITY_DESCRIPTOR_MIN_LENGTH = 40; // absolute SD header on x64
         private const int TRUSTEE_IS_SID = 0;
         private const int TRUSTEE_IS_UNKNOWN = 0;
         private const int NO_MULTIPLE_TRUSTEE = 0;
@@ -511,6 +563,21 @@ namespace Hina.PackageManager.Sandbox
         [DllImport("advapi32.dll", CharSet = CharSet.Unicode)]
         private static extern uint SetNamedSecurityInfoW(string pObjectName, int ObjectType, uint SecurityInfo,
             IntPtr psidOwner, IntPtr psidGroup, IntPtr pDacl, IntPtr pSacl);
+
+        // Legacy by-name DACL setter: unlike SetNamedSecurityInfo it does NOT re-propagate
+        // inheritance into the subtree, so it stays fast on large directories.
+        [DllImport("advapi32.dll", CharSet = CharSet.Unicode, SetLastError = true)]
+        [return: MarshalAs(UnmanagedType.Bool)]
+        private static extern bool SetFileSecurityW(string lpFileName, uint SecurityInformation, IntPtr pSecurityDescriptor);
+
+        [DllImport("advapi32.dll", SetLastError = true)]
+        [return: MarshalAs(UnmanagedType.Bool)]
+        private static extern bool InitializeSecurityDescriptor(IntPtr pSecurityDescriptor, uint dwRevision);
+
+        [DllImport("advapi32.dll", SetLastError = true)]
+        [return: MarshalAs(UnmanagedType.Bool)]
+        private static extern bool SetSecurityDescriptorDacl(IntPtr pSecurityDescriptor,
+            [MarshalAs(UnmanagedType.Bool)] bool bDaclPresent, IntPtr pDacl, [MarshalAs(UnmanagedType.Bool)] bool bDaclDefaulted);
 
         [DllImport("advapi32.dll", CharSet = CharSet.Unicode)]
         private static extern uint SetEntriesInAclW(uint cCountOfExplicitEntries, ref EXPLICIT_ACCESS_W pListOfExplicitEntries,

--- a/Hina.PackageManager/Sandbox/WindowsSandbox.cs
+++ b/Hina.PackageManager/Sandbox/WindowsSandbox.cs
@@ -106,12 +106,6 @@ namespace Hina.PackageManager.Sandbox
                 {
                     GrantContainerAce(ace.Path, containerSid, ace.Access);
                     _logger.LogDebug("AppContainer grant {Access} on {Path}", ace.Access, ace.Path);
-
-                    // A lowbox token is denied traversal of any ancestor directory that does
-                    // not grant it. The leaf ACE alone is useless if the container can't walk
-                    // down to it, so grant FILE_TRAVERSE (execute only — NOT read/list, so the
-                    // ancestors' other contents stay hidden) on each parent up to the root.
-                    GrantAncestorTraverse(ace.Path, containerSid);
                 }
 
                 // 2. Build the capability SID array (network etc).
@@ -208,26 +202,6 @@ namespace Hina.PackageManager.Sandbox
             };
             // Inheritable so files created in / already under the dir get the right too.
             GrantAce(path, containerSid, rights, SUB_CONTAINERS_AND_OBJECTS_INHERIT, throwOnFail: true);
-        }
-
-        // Grant FILE_TRAVERSE on every ancestor directory of a granted leaf so the lowbox
-        // token can walk down to it. Execute-only and NOT inheritable (this folder only), so
-        // the container gains pass-through but cannot enumerate or read the ancestors'
-        // contents. Best-effort: a dir we can't re-ACL (e.g. the drive root) is skipped — the
-        // chain Hina actually owns (its install dir / the temp tree) is what matters, and a
-        // total traversal failure surfaces as the launch failing, never as silent non-isolation.
-        [SupportedOSPlatform("windows")]
-        private void GrantAncestorTraverse(string leafPath, IntPtr containerSid)
-        {
-            DirectoryInfo? dir;
-            try { dir = Directory.GetParent(Path.GetFullPath(leafPath)); }
-            catch { return; }
-
-            while (dir != null)
-            {
-                GrantAce(dir.FullName, containerSid, FILE_TRAVERSE, NO_INHERITANCE, throwOnFail: false);
-                dir = dir.Parent;
-            }
         }
 
         // Merge one GRANT_ACCESS ACE for the container SID into a path's DACL.
@@ -424,8 +398,6 @@ namespace Hina.PackageManager.Sandbox
 
         private const int GRANT_ACCESS = 1;
         private const uint SUB_CONTAINERS_AND_OBJECTS_INHERIT = 0x3; // CONTAINER_INHERIT_ACE | OBJECT_INHERIT_ACE
-        private const uint NO_INHERITANCE = 0x0;
-        private const uint FILE_TRAVERSE = 0x00000020; // execute right on a directory (pass-through, no list)
         private const int TRUSTEE_IS_SID = 0;
         private const int TRUSTEE_IS_UNKNOWN = 0;
         private const int NO_MULTIPLE_TRUSTEE = 0;

--- a/Hina.PackageManager/Sandbox/WindowsSandbox.cs
+++ b/Hina.PackageManager/Sandbox/WindowsSandbox.cs
@@ -92,6 +92,7 @@ namespace Hina.PackageManager.Sandbox
             string containerName = WindowsAppContainerPolicy.ContainerName(DeriveAppName(execAbs));
 
             IntPtr containerSid = CreateOrDeriveContainerSid(containerName);
+            _logger.LogDebug("AppContainer '{Name}' SID {Sid}", containerName, SidToString(containerSid));
             List<IntPtr> capabilitySids = new List<IntPtr>();
             IntPtr capabilitiesArray = IntPtr.Zero;
             IntPtr attributeList = IntPtr.Zero;
@@ -104,6 +105,7 @@ namespace Hina.PackageManager.Sandbox
                 foreach (AppContainerAce ace in WindowsAppContainerPolicy.BuildAceList(plan))
                 {
                     GrantContainerAce(ace.Path, containerSid, ace.Access);
+                    _logger.LogDebug("AppContainer grant {Access} on {Path}", ace.Access, ace.Path);
                 }
 
                 // 2. Build the capability SID array (network etc).
@@ -144,6 +146,18 @@ namespace Hina.PackageManager.Sandbox
                 foreach (IntPtr capSid in capabilitySids) LocalFree(capSid);
                 if (containerSid != IntPtr.Zero) FreeSid(containerSid);
             }
+        }
+
+        // Diagnostic only: render a PSID as its S-1-… string for the Debug log trail.
+        [SupportedOSPlatform("windows")]
+        private static string SidToString(IntPtr sid)
+        {
+            if (ConvertSidToStringSidW(sid, out IntPtr str) && str != IntPtr.Zero)
+            {
+                try { return Marshal.PtrToStringUni(str) ?? "?"; }
+                finally { LocalFree(str); }
+            }
+            return "?";
         }
 
         // App name used for the container moniker: the executable's file name without
@@ -306,6 +320,7 @@ namespace Hina.PackageManager.Sandbox
             {
                 throw new InvalidOperationException($"CreateProcess failed ({Marshal.GetLastWin32Error()}).");
             }
+            _logger.LogDebug("AppContainer launched pid {Pid} for {Exec}", pi.dwProcessId, execAbs);
 
             try
             {
@@ -471,6 +486,10 @@ namespace Hina.PackageManager.Sandbox
 
         [DllImport("advapi32.dll")]
         private static extern IntPtr FreeSid(IntPtr pSid);
+
+        [DllImport("advapi32.dll", CharSet = CharSet.Unicode, SetLastError = true)]
+        [return: MarshalAs(UnmanagedType.Bool)]
+        private static extern bool ConvertSidToStringSidW(IntPtr Sid, out IntPtr StringSid);
 
         [DllImport("advapi32.dll", CharSet = CharSet.Unicode)]
         private static extern uint GetNamedSecurityInfoW(string pObjectName, int ObjectType, uint SecurityInfo,

--- a/Hina.PackageManager/Sandbox/WindowsSandbox.cs
+++ b/Hina.PackageManager/Sandbox/WindowsSandbox.cs
@@ -106,6 +106,12 @@ namespace Hina.PackageManager.Sandbox
                 {
                     GrantContainerAce(ace.Path, containerSid, ace.Access);
                     _logger.LogDebug("AppContainer grant {Access} on {Path}", ace.Access, ace.Path);
+
+                    // A lowbox token is denied traversal of any ancestor directory that does
+                    // not grant it. The leaf ACE alone is useless if the container can't walk
+                    // down to it, so grant FILE_TRAVERSE (execute only — NOT read/list, so the
+                    // ancestors' other contents stay hidden) on each parent up to the root.
+                    GrantAncestorTraverse(ace.Path, containerSid);
                 }
 
                 // 2. Build the capability SID array (network etc).
@@ -200,12 +206,42 @@ namespace Hina.PackageManager.Sandbox
                 AppContainerAccess.ReadWriteExecute => GENERIC_READ | GENERIC_WRITE | GENERIC_EXECUTE,
                 _ => GENERIC_READ | GENERIC_EXECUTE,
             };
+            // Inheritable so files created in / already under the dir get the right too.
+            GrantAce(path, containerSid, rights, SUB_CONTAINERS_AND_OBJECTS_INHERIT, throwOnFail: true);
+        }
 
+        // Grant FILE_TRAVERSE on every ancestor directory of a granted leaf so the lowbox
+        // token can walk down to it. Execute-only and NOT inheritable (this folder only), so
+        // the container gains pass-through but cannot enumerate or read the ancestors'
+        // contents. Best-effort: a dir we can't re-ACL (e.g. the drive root) is skipped — the
+        // chain Hina actually owns (its install dir / the temp tree) is what matters, and a
+        // total traversal failure surfaces as the launch failing, never as silent non-isolation.
+        [SupportedOSPlatform("windows")]
+        private void GrantAncestorTraverse(string leafPath, IntPtr containerSid)
+        {
+            DirectoryInfo? dir;
+            try { dir = Directory.GetParent(Path.GetFullPath(leafPath)); }
+            catch { return; }
+
+            while (dir != null)
+            {
+                GrantAce(dir.FullName, containerSid, FILE_TRAVERSE, NO_INHERITANCE, throwOnFail: false);
+                dir = dir.Parent;
+            }
+        }
+
+        // Merge one GRANT_ACCESS ACE for the container SID into a path's DACL.
+        // throwOnFail=false makes it best-effort (used for the ancestor traverse chain).
+        [SupportedOSPlatform("windows")]
+        private void GrantAce(string path, IntPtr containerSid, uint rights, uint inheritance, bool throwOnFail)
+        {
             uint getErr = GetNamedSecurityInfoW(path, SE_FILE_OBJECT, DACL_SECURITY_INFORMATION,
                 IntPtr.Zero, IntPtr.Zero, out IntPtr oldDacl, IntPtr.Zero, out IntPtr securityDescriptor);
             if (getErr != ERROR_SUCCESS)
             {
-                throw new InvalidOperationException($"GetNamedSecurityInfo('{path}') failed ({getErr}).");
+                if (throwOnFail) throw new InvalidOperationException($"GetNamedSecurityInfo('{path}') failed ({getErr}).");
+                _logger.LogDebug("AppContainer: GetNamedSecurityInfo('{Path}') failed ({Err}); skipped.", path, getErr);
+                return;
             }
 
             IntPtr newDacl = IntPtr.Zero;
@@ -215,7 +251,7 @@ namespace Hina.PackageManager.Sandbox
                 {
                     grfAccessPermissions = rights,
                     grfAccessMode = GRANT_ACCESS,
-                    grfInheritance = SUB_CONTAINERS_AND_OBJECTS_INHERIT,
+                    grfInheritance = inheritance,
                     Trustee = new TRUSTEE_W
                     {
                         pMultipleTrustee = IntPtr.Zero,
@@ -229,14 +265,17 @@ namespace Hina.PackageManager.Sandbox
                 uint setErr = SetEntriesInAclW(1, ref ea, oldDacl, out newDacl);
                 if (setErr != ERROR_SUCCESS)
                 {
-                    throw new InvalidOperationException($"SetEntriesInAcl('{path}') failed ({setErr}).");
+                    if (throwOnFail) throw new InvalidOperationException($"SetEntriesInAcl('{path}') failed ({setErr}).");
+                    _logger.LogDebug("AppContainer: SetEntriesInAcl('{Path}') failed ({Err}); skipped.", path, setErr);
+                    return;
                 }
 
                 uint applyErr = SetNamedSecurityInfoW(path, SE_FILE_OBJECT, DACL_SECURITY_INFORMATION,
                     IntPtr.Zero, IntPtr.Zero, newDacl, IntPtr.Zero);
                 if (applyErr != ERROR_SUCCESS)
                 {
-                    throw new InvalidOperationException($"SetNamedSecurityInfo('{path}') failed ({applyErr}).");
+                    if (throwOnFail) throw new InvalidOperationException($"SetNamedSecurityInfo('{path}') failed ({applyErr}).");
+                    _logger.LogDebug("AppContainer: SetNamedSecurityInfo('{Path}') failed ({Err}); skipped.", path, applyErr);
                 }
             }
             finally
@@ -385,6 +424,8 @@ namespace Hina.PackageManager.Sandbox
 
         private const int GRANT_ACCESS = 1;
         private const uint SUB_CONTAINERS_AND_OBJECTS_INHERIT = 0x3; // CONTAINER_INHERIT_ACE | OBJECT_INHERIT_ACE
+        private const uint NO_INHERITANCE = 0x0;
+        private const uint FILE_TRAVERSE = 0x00000020; // execute right on a directory (pass-through, no list)
         private const int TRUSTEE_IS_SID = 0;
         private const int TRUSTEE_IS_UNKNOWN = 0;
         private const int NO_MULTIPLE_TRUSTEE = 0;

--- a/Hina.PackageManager/Sandbox/WindowsSandbox.cs
+++ b/Hina.PackageManager/Sandbox/WindowsSandbox.cs
@@ -9,10 +9,27 @@ using Microsoft.Extensions.Logging;
 
 namespace Hina.PackageManager.Sandbox
 {
-    // Windows filesystem (+ network) sandbox backend, built on AppContainer. An
-    // AppContainer process is denied every securable object unless its DACL grants the
-    // per-app AppContainer SID (or a capability SID, or ALL APPLICATION PACKAGES), so it
-    // is deny-by-default for free — the Windows analogue of Landlock / Seatbelt.
+    // EXPERIMENTAL — NOT WIRED IN. SandboxLauncherFactory deliberately does NOT select this
+    // backend; Windows uses NoOp. It is kept as a documented scaffold for whoever resumes the
+    // work on a real Windows box (the dev host is macOS, so AppContainer cannot be exercised
+    // or debugged locally — only via the windows-latest CI probe).
+    //
+    // STATUS: the policy + ACL plumbing are correct — the windows-latest probe proved (via
+    // icacls) that every grant lands on disk: the container SID gets (RX,W) on the granted
+    // dir and FILE_TRAVERSE on each ancestor, with the user/Admin/SYSTEM ACEs preserved.
+    // The container also correctly DENIES an ungranted secret (isolation works). BUT the
+    // lowbox honored NO runtime grant for actual access: a granted dir was unreadable AND
+    // unwritable whether granted the specific package SID OR ALL APPLICATION PACKAGES (the
+    // group the token demonstrably has — it runs cmd.exe from System32 via it), with the
+    // object integrity lowered to Low or not, on a deep profile path OR a shallow C:\ path —
+    // all denied; only the System32 baseline was reachable. That points to an over-restricted
+    // token (likely the process integrity / lowbox restricting-SID set), which needs Process
+    // Explorer on a real Windows machine to pin down. Until then, shipping this would launch
+    // apps that cannot read their own install dir — strictly worse than the honest NoOp.
+    //
+    // Design (for reference): an AppContainer process is denied every securable object unless
+    // its DACL grants the per-app AppContainer SID (or a capability SID, or ALL APPLICATION
+    // PACKAGES), so it is deny-by-default for free — the Windows analogue of Landlock / Seatbelt.
     //
     // WindowsAppContainerPolicy (pure, unit-tested) decides the container name, the ACEs
     // to grant, and the capability SIDs. This class does the unmanaged plumbing: create /

--- a/Hina.PackageManager/Sandbox/WindowsSandbox.cs
+++ b/Hina.PackageManager/Sandbox/WindowsSandbox.cs
@@ -224,6 +224,7 @@ namespace Hina.PackageManager.Sandbox
 
             while (dir != null)
             {
+                _logger.LogDebug("AppContainer traverse-grant on {Path}", dir.FullName);
                 GrantAce(dir.FullName, containerSid, FILE_TRAVERSE, NO_INHERITANCE, throwOnFail: false, propagate: false);
                 dir = dir.Parent;
             }

--- a/Hina.PackageManager/Sandbox/WindowsSandbox.cs
+++ b/Hina.PackageManager/Sandbox/WindowsSandbox.cs
@@ -1,0 +1,525 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Runtime.InteropServices;
+using System.Runtime.Versioning;
+using System.Threading;
+using Microsoft.Extensions.Logging;
+
+namespace Hina.PackageManager.Sandbox
+{
+    // Windows filesystem (+ network) sandbox backend, built on AppContainer. An
+    // AppContainer process is denied every securable object unless its DACL grants the
+    // per-app AppContainer SID (or a capability SID, or ALL APPLICATION PACKAGES), so it
+    // is deny-by-default for free — the Windows analogue of Landlock / Seatbelt.
+    //
+    // WindowsAppContainerPolicy (pure, unit-tested) decides the container name, the ACEs
+    // to grant, and the capability SIDs. This class does the unmanaged plumbing: create /
+    // derive the container profile, add the ACEs to each granted path, then CreateProcess
+    // under a SECURITY_CAPABILITIES built from the container SID. All Win32 via P/Invoke,
+    // no reflection, AOT-safe; the declarations compile on every host but only run on
+    // Windows (gated by IsSupported + the OperatingSystem guard in Launch).
+    //
+    // Fail-soft, like the other backends: any setup failure logs a warning and runs the
+    // app directly (unsandboxed) — a sandbox problem never blocks a launch. Real isolation
+    // is proven by the windows-latest CI probe, which cannot run on the dev host.
+    //
+    // System DLL dirs (System32, WinSxS, the GAC) already carry an ALL APPLICATION PACKAGES
+    // ACE granting read+execute to every AppContainer, so we deliberately do NOT ACL them
+    // (it would need admin and edit a shared system DACL). We grant only the app dir and the
+    // plan rules; everything else stays denied.
+    public sealed class WindowsSandbox : ISandboxLauncher
+    {
+        private readonly ILogger _logger;
+
+        public WindowsSandbox(ILogger logger)
+        {
+            _logger = logger;
+        }
+
+        // AppContainer APIs (userenv.dll CreateAppContainerProfile) ship on Windows 8 /
+        // Server 2012 and later (NT 6.2+).
+        public bool IsSupported => OperatingSystem.IsWindowsVersionAtLeast(6, 2);
+
+        public int Launch(string execAbs, IReadOnlyList<string> appArgs, SandboxPlan plan, CancellationToken ct)
+        {
+            // Guard with the concrete OS check (not the IsSupported property) so the
+            // platform-compatibility analyzer can flow it to the AppContainer call below.
+            if (plan.Unrestricted || !OperatingSystem.IsWindowsVersionAtLeast(6, 2))
+            {
+                // Host opt-out or no AppContainer support — run directly.
+                if (!plan.Unrestricted && plan.Rules.Count > 1)
+                {
+                    _logger.LogWarning(
+                        "This app requested filesystem sandboxing, but this platform cannot enforce it. Running unsandboxed.");
+                }
+                return SpawnDirect(execAbs, appArgs, ct);
+            }
+
+            try
+            {
+                return LaunchInAppContainer(execAbs, appArgs, plan, ct);
+            }
+            catch (Exception ex)
+            {
+                // Fail-soft: never block a launch because the sandbox couldn't be set up.
+                _logger.LogWarning("Could not set up AppContainer sandbox ({Message}); running unsandboxed.", ex.Message);
+                return SpawnDirect(execAbs, appArgs, ct);
+            }
+        }
+
+        private int SpawnDirect(string execAbs, IReadOnlyList<string> appArgs, CancellationToken ct)
+        {
+            ProcessStartInfo psi = new ProcessStartInfo { FileName = execAbs, UseShellExecute = false };
+            foreach (string a in appArgs) psi.ArgumentList.Add(a);
+
+            using Process proc = Process.Start(psi)!;
+            using CancellationTokenRegistration reg = ct.Register(() =>
+            {
+                try { if (!proc.HasExited) proc.Kill(entireProcessTree: true); }
+                catch { /* race: already gone */ }
+            });
+            proc.WaitForExit();
+            return proc.ExitCode;
+        }
+
+        // ---- AppContainer launch (Windows-only) ----
+
+        [SupportedOSPlatform("windows")]
+        private int LaunchInAppContainer(string execAbs, IReadOnlyList<string> appArgs, SandboxPlan plan, CancellationToken ct)
+        {
+            string containerName = WindowsAppContainerPolicy.ContainerName(DeriveAppName(execAbs));
+
+            IntPtr containerSid = CreateOrDeriveContainerSid(containerName);
+            List<IntPtr> capabilitySids = new List<IntPtr>();
+            IntPtr capabilitiesArray = IntPtr.Zero;
+            IntPtr attributeList = IntPtr.Zero;
+            IntPtr secCapsPtr = IntPtr.Zero;
+            try
+            {
+                // 1. Grant the container SID the ACEs the policy computed. The app dir grant
+                //    is what lets the container read its own binary — without it the process
+                //    can't even start.
+                foreach (AppContainerAce ace in WindowsAppContainerPolicy.BuildAceList(plan))
+                {
+                    GrantContainerAce(ace.Path, containerSid, ace.Access);
+                }
+
+                // 2. Build the capability SID array (network etc).
+                foreach (string sidString in WindowsAppContainerPolicy.BuildCapabilitySids(plan))
+                {
+                    if (ConvertStringSidToSidW(sidString, out IntPtr capSid) && capSid != IntPtr.Zero)
+                    {
+                        capabilitySids.Add(capSid);
+                    }
+                }
+                capabilitiesArray = BuildCapabilitiesArray(capabilitySids);
+
+                // 3. SECURITY_CAPABILITIES → process-thread attribute list.
+                SECURITY_CAPABILITIES secCaps = new SECURITY_CAPABILITIES
+                {
+                    AppContainerSid = containerSid,
+                    Capabilities = capabilitiesArray,
+                    CapabilityCount = (uint)capabilitySids.Count,
+                    Reserved = 0,
+                };
+                secCapsPtr = Marshal.AllocHGlobal(Marshal.SizeOf<SECURITY_CAPABILITIES>());
+                Marshal.StructureToPtr(secCaps, secCapsPtr, false);
+
+                attributeList = BuildAttributeList(secCapsPtr);
+
+                // 4. Launch under the container and wait for exit.
+                return CreateAndWait(execAbs, appArgs, attributeList, execAbs, ct);
+            }
+            finally
+            {
+                if (attributeList != IntPtr.Zero)
+                {
+                    DeleteProcThreadAttributeList(attributeList);
+                    Marshal.FreeHGlobal(attributeList);
+                }
+                if (secCapsPtr != IntPtr.Zero) Marshal.FreeHGlobal(secCapsPtr);
+                if (capabilitiesArray != IntPtr.Zero) Marshal.FreeHGlobal(capabilitiesArray);
+                foreach (IntPtr capSid in capabilitySids) LocalFree(capSid);
+                if (containerSid != IntPtr.Zero) FreeSid(containerSid);
+            }
+        }
+
+        // App name used for the container moniker: the executable's file name without
+        // extension. Stable per installed app (each app's exec lives in its own dir).
+        private static string DeriveAppName(string execAbs)
+        {
+            string name = Path.GetFileNameWithoutExtension(execAbs);
+            return string.IsNullOrEmpty(name) ? "app" : name;
+        }
+
+        [SupportedOSPlatform("windows")]
+        private IntPtr CreateOrDeriveContainerSid(string containerName)
+        {
+            int hr = CreateAppContainerProfile(containerName, containerName, containerName, IntPtr.Zero, 0, out IntPtr sid);
+            if (hr >= 0 && sid != IntPtr.Zero)
+            {
+                return sid;
+            }
+
+            // ERROR_ALREADY_EXISTS as HRESULT — the profile from a previous launch is fine;
+            // just derive its (stable) SID.
+            const int E_ALREADY_EXISTS = unchecked((int)0x800700B7);
+            if (hr == E_ALREADY_EXISTS)
+            {
+                int dhr = DeriveAppContainerSidFromAppContainerName(containerName, out IntPtr derived);
+                if (dhr >= 0 && derived != IntPtr.Zero)
+                {
+                    return derived;
+                }
+                throw new InvalidOperationException($"DeriveAppContainerSidFromAppContainerName failed (0x{dhr:X8}).");
+            }
+            throw new InvalidOperationException($"CreateAppContainerProfile failed (0x{hr:X8}).");
+        }
+
+        [SupportedOSPlatform("windows")]
+        private void GrantContainerAce(string path, IntPtr containerSid, AppContainerAccess access)
+        {
+            uint rights = access switch
+            {
+                AppContainerAccess.ReadWriteExecute => GENERIC_READ | GENERIC_WRITE | GENERIC_EXECUTE,
+                _ => GENERIC_READ | GENERIC_EXECUTE,
+            };
+
+            uint getErr = GetNamedSecurityInfoW(path, SE_FILE_OBJECT, DACL_SECURITY_INFORMATION,
+                IntPtr.Zero, IntPtr.Zero, out IntPtr oldDacl, IntPtr.Zero, out IntPtr securityDescriptor);
+            if (getErr != ERROR_SUCCESS)
+            {
+                throw new InvalidOperationException($"GetNamedSecurityInfo('{path}') failed ({getErr}).");
+            }
+
+            IntPtr newDacl = IntPtr.Zero;
+            try
+            {
+                EXPLICIT_ACCESS_W ea = new EXPLICIT_ACCESS_W
+                {
+                    grfAccessPermissions = rights,
+                    grfAccessMode = GRANT_ACCESS,
+                    grfInheritance = SUB_CONTAINERS_AND_OBJECTS_INHERIT,
+                    Trustee = new TRUSTEE_W
+                    {
+                        pMultipleTrustee = IntPtr.Zero,
+                        MultipleTrusteeOperation = NO_MULTIPLE_TRUSTEE,
+                        TrusteeForm = TRUSTEE_IS_SID,
+                        TrusteeType = TRUSTEE_IS_UNKNOWN,
+                        ptstrName = containerSid,
+                    },
+                };
+
+                uint setErr = SetEntriesInAclW(1, ref ea, oldDacl, out newDacl);
+                if (setErr != ERROR_SUCCESS)
+                {
+                    throw new InvalidOperationException($"SetEntriesInAcl('{path}') failed ({setErr}).");
+                }
+
+                uint applyErr = SetNamedSecurityInfoW(path, SE_FILE_OBJECT, DACL_SECURITY_INFORMATION,
+                    IntPtr.Zero, IntPtr.Zero, newDacl, IntPtr.Zero);
+                if (applyErr != ERROR_SUCCESS)
+                {
+                    throw new InvalidOperationException($"SetNamedSecurityInfo('{path}') failed ({applyErr}).");
+                }
+            }
+            finally
+            {
+                if (newDacl != IntPtr.Zero) LocalFree(newDacl);
+                if (securityDescriptor != IntPtr.Zero) LocalFree(securityDescriptor);
+            }
+        }
+
+        // Allocate an unmanaged SID_AND_ATTRIBUTES[] for the capability SIDs.
+        [SupportedOSPlatform("windows")]
+        private static IntPtr BuildCapabilitiesArray(List<IntPtr> capabilitySids)
+        {
+            if (capabilitySids.Count == 0)
+            {
+                return IntPtr.Zero;
+            }
+
+            int size = Marshal.SizeOf<SID_AND_ATTRIBUTES>();
+            IntPtr array = Marshal.AllocHGlobal(size * capabilitySids.Count);
+            for (int i = 0; i < capabilitySids.Count; i++)
+            {
+                SID_AND_ATTRIBUTES entry = new SID_AND_ATTRIBUTES
+                {
+                    Sid = capabilitySids[i],
+                    Attributes = SE_GROUP_ENABLED,
+                };
+                Marshal.StructureToPtr(entry, array + (i * size), false);
+            }
+            return array;
+        }
+
+        [SupportedOSPlatform("windows")]
+        private static IntPtr BuildAttributeList(IntPtr secCapsPtr)
+        {
+            IntPtr size = IntPtr.Zero;
+            // First call sizes the buffer; it returns false with ERROR_INSUFFICIENT_BUFFER.
+            InitializeProcThreadAttributeList(IntPtr.Zero, 1, 0, ref size);
+
+            IntPtr list = Marshal.AllocHGlobal(size);
+            if (!InitializeProcThreadAttributeList(list, 1, 0, ref size))
+            {
+                Marshal.FreeHGlobal(list);
+                throw new InvalidOperationException($"InitializeProcThreadAttributeList failed ({Marshal.GetLastWin32Error()}).");
+            }
+
+            if (!UpdateProcThreadAttribute(list, 0, (IntPtr)PROC_THREAD_ATTRIBUTE_SECURITY_CAPABILITIES,
+                    secCapsPtr, (IntPtr)Marshal.SizeOf<SECURITY_CAPABILITIES>(), IntPtr.Zero, IntPtr.Zero))
+            {
+                DeleteProcThreadAttributeList(list);
+                Marshal.FreeHGlobal(list);
+                throw new InvalidOperationException($"UpdateProcThreadAttribute failed ({Marshal.GetLastWin32Error()}).");
+            }
+            return list;
+        }
+
+        [SupportedOSPlatform("windows")]
+        private int CreateAndWait(string execAbs, IReadOnlyList<string> appArgs, IntPtr attributeList, string applicationName, CancellationToken ct)
+        {
+            char[] commandLine = BuildCommandLine(execAbs, appArgs);
+
+            STARTUPINFOEX si = new STARTUPINFOEX();
+            si.StartupInfo.cb = (uint)Marshal.SizeOf<STARTUPINFOEX>();
+            si.lpAttributeList = attributeList;
+
+            string? workingDir = Path.GetDirectoryName(execAbs);
+
+            bool ok = CreateProcessW(
+                applicationName,
+                commandLine,
+                IntPtr.Zero,
+                IntPtr.Zero,
+                bInheritHandles: true,
+                EXTENDED_STARTUPINFO_PRESENT,
+                IntPtr.Zero,
+                string.IsNullOrEmpty(workingDir) ? null : workingDir,
+                ref si,
+                out PROCESS_INFORMATION pi);
+
+            if (!ok)
+            {
+                throw new InvalidOperationException($"CreateProcess failed ({Marshal.GetLastWin32Error()}).");
+            }
+
+            try
+            {
+                // Poll so a cancellation can terminate the child (mirrors the kill-on-cancel
+                // behaviour of the other backends).
+                while (true)
+                {
+                    uint wait = WaitForSingleObject(pi.hProcess, 100);
+                    if (wait == WAIT_OBJECT_0) break;
+                    if (ct.IsCancellationRequested)
+                    {
+                        try { TerminateProcess(pi.hProcess, 1); } catch { /* race */ }
+                        WaitForSingleObject(pi.hProcess, INFINITE);
+                        break;
+                    }
+                }
+                GetExitCodeProcess(pi.hProcess, out uint exitCode);
+                return unchecked((int)exitCode);
+            }
+            finally
+            {
+                CloseHandle(pi.hThread);
+                CloseHandle(pi.hProcess);
+            }
+        }
+
+        // CreateProcessW takes one mutable command-line buffer. argv[0] is the exe path;
+        // every token is quoted the way CommandLineToArgvW expects.
+        private static char[] BuildCommandLine(string execAbs, IReadOnlyList<string> appArgs)
+        {
+            System.Text.StringBuilder sb = new System.Text.StringBuilder();
+            sb.Append(QuoteArg(execAbs));
+            foreach (string a in appArgs)
+            {
+                sb.Append(' ').Append(QuoteArg(a));
+            }
+            string cmd = sb.ToString();
+            char[] buffer = new char[cmd.Length + 1];
+            cmd.CopyTo(0, buffer, 0, cmd.Length);
+            buffer[cmd.Length] = '\0';
+            return buffer;
+        }
+
+        private static string QuoteArg(string arg)
+        {
+            if (arg.Length > 0 && arg.IndexOfAny(new[] { ' ', '\t', '"' }) < 0)
+            {
+                return arg;
+            }
+            return "\"" + arg.Replace("\"", "\\\"") + "\"";
+        }
+
+        // ---- Win32 constants ----
+
+        private const uint GENERIC_READ = 0x80000000;
+        private const uint GENERIC_WRITE = 0x40000000;
+        private const uint GENERIC_EXECUTE = 0x20000000;
+
+        private const int SE_FILE_OBJECT = 1;
+        private const uint DACL_SECURITY_INFORMATION = 0x00000004;
+        private const uint ERROR_SUCCESS = 0;
+
+        private const int GRANT_ACCESS = 1;
+        private const uint SUB_CONTAINERS_AND_OBJECTS_INHERIT = 0x3; // CONTAINER_INHERIT_ACE | OBJECT_INHERIT_ACE
+        private const int TRUSTEE_IS_SID = 0;
+        private const int TRUSTEE_IS_UNKNOWN = 0;
+        private const int NO_MULTIPLE_TRUSTEE = 0;
+
+        private const uint SE_GROUP_ENABLED = 0x00000004;
+        private const int PROC_THREAD_ATTRIBUTE_SECURITY_CAPABILITIES = 0x00020009;
+        private const uint EXTENDED_STARTUPINFO_PRESENT = 0x00080000;
+        private const uint WAIT_OBJECT_0 = 0x00000000;
+        private const uint INFINITE = 0xFFFFFFFF;
+
+        // ---- Win32 structs ----
+
+        [StructLayout(LayoutKind.Sequential)]
+        private struct TRUSTEE_W
+        {
+            public IntPtr pMultipleTrustee;
+            public int MultipleTrusteeOperation;
+            public int TrusteeForm;
+            public int TrusteeType;
+            public IntPtr ptstrName; // PSID when TrusteeForm == TRUSTEE_IS_SID
+        }
+
+        [StructLayout(LayoutKind.Sequential)]
+        private struct EXPLICIT_ACCESS_W
+        {
+            public uint grfAccessPermissions;
+            public int grfAccessMode;
+            public uint grfInheritance;
+            public TRUSTEE_W Trustee;
+        }
+
+        [StructLayout(LayoutKind.Sequential)]
+        private struct SID_AND_ATTRIBUTES
+        {
+            public IntPtr Sid;
+            public uint Attributes;
+        }
+
+        [StructLayout(LayoutKind.Sequential)]
+        private struct SECURITY_CAPABILITIES
+        {
+            public IntPtr AppContainerSid;
+            public IntPtr Capabilities;
+            public uint CapabilityCount;
+            public uint Reserved;
+        }
+
+        [StructLayout(LayoutKind.Sequential, CharSet = CharSet.Unicode)]
+        private struct STARTUPINFOW
+        {
+            public uint cb;
+            public IntPtr lpReserved;
+            public IntPtr lpDesktop;
+            public IntPtr lpTitle;
+            public uint dwX;
+            public uint dwY;
+            public uint dwXSize;
+            public uint dwYSize;
+            public uint dwXCountChars;
+            public uint dwYCountChars;
+            public uint dwFillAttribute;
+            public uint dwFlags;
+            public ushort wShowWindow;
+            public ushort cbReserved2;
+            public IntPtr lpReserved2;
+            public IntPtr hStdInput;
+            public IntPtr hStdOutput;
+            public IntPtr hStdError;
+        }
+
+        [StructLayout(LayoutKind.Sequential)]
+        private struct STARTUPINFOEX
+        {
+            public STARTUPINFOW StartupInfo;
+            public IntPtr lpAttributeList;
+        }
+
+        [StructLayout(LayoutKind.Sequential)]
+        private struct PROCESS_INFORMATION
+        {
+            public IntPtr hProcess;
+            public IntPtr hThread;
+            public uint dwProcessId;
+            public uint dwThreadId;
+        }
+
+        // ---- Win32 P/Invoke (AOT-safe: explicit marshalling, no reflection) ----
+
+        [DllImport("userenv.dll", CharSet = CharSet.Unicode)]
+        private static extern int CreateAppContainerProfile(string pszAppContainerName, string pszDisplayName,
+            string pszDescription, IntPtr pCapabilities, uint dwCapabilityCount, out IntPtr ppSidAppContainerSid);
+
+        [DllImport("userenv.dll", CharSet = CharSet.Unicode)]
+        private static extern int DeriveAppContainerSidFromAppContainerName(string pszAppContainerName, out IntPtr ppSidAppContainerSid);
+
+        [DllImport("advapi32.dll", CharSet = CharSet.Unicode, SetLastError = true)]
+        [return: MarshalAs(UnmanagedType.Bool)]
+        private static extern bool ConvertStringSidToSidW(string StringSid, out IntPtr Sid);
+
+        [DllImport("advapi32.dll")]
+        private static extern IntPtr FreeSid(IntPtr pSid);
+
+        [DllImport("advapi32.dll", CharSet = CharSet.Unicode)]
+        private static extern uint GetNamedSecurityInfoW(string pObjectName, int ObjectType, uint SecurityInfo,
+            IntPtr ppsidOwner, IntPtr ppsidGroup, out IntPtr ppDacl, IntPtr ppSacl, out IntPtr ppSecurityDescriptor);
+
+        [DllImport("advapi32.dll", CharSet = CharSet.Unicode)]
+        private static extern uint SetNamedSecurityInfoW(string pObjectName, int ObjectType, uint SecurityInfo,
+            IntPtr psidOwner, IntPtr psidGroup, IntPtr pDacl, IntPtr pSacl);
+
+        [DllImport("advapi32.dll", CharSet = CharSet.Unicode)]
+        private static extern uint SetEntriesInAclW(uint cCountOfExplicitEntries, ref EXPLICIT_ACCESS_W pListOfExplicitEntries,
+            IntPtr OldAcl, out IntPtr NewAcl);
+
+        [DllImport("kernel32.dll")]
+        private static extern IntPtr LocalFree(IntPtr hMem);
+
+        [DllImport("kernel32.dll", SetLastError = true)]
+        [return: MarshalAs(UnmanagedType.Bool)]
+        private static extern bool InitializeProcThreadAttributeList(IntPtr lpAttributeList, int dwAttributeCount,
+            int dwFlags, ref IntPtr lpSize);
+
+        [DllImport("kernel32.dll", SetLastError = true)]
+        [return: MarshalAs(UnmanagedType.Bool)]
+        private static extern bool UpdateProcThreadAttribute(IntPtr lpAttributeList, uint dwFlags, IntPtr Attribute,
+            IntPtr lpValue, IntPtr cbSize, IntPtr lpPreviousValue, IntPtr lpReturnSize);
+
+        [DllImport("kernel32.dll")]
+        private static extern void DeleteProcThreadAttributeList(IntPtr lpAttributeList);
+
+        [DllImport("kernel32.dll", CharSet = CharSet.Unicode, SetLastError = true)]
+        [return: MarshalAs(UnmanagedType.Bool)]
+        private static extern bool CreateProcessW(string? lpApplicationName, char[]? lpCommandLine,
+            IntPtr lpProcessAttributes, IntPtr lpThreadAttributes, [MarshalAs(UnmanagedType.Bool)] bool bInheritHandles,
+            uint dwCreationFlags, IntPtr lpEnvironment, string? lpCurrentDirectory,
+            ref STARTUPINFOEX lpStartupInfo, out PROCESS_INFORMATION lpProcessInformation);
+
+        [DllImport("kernel32.dll")]
+        private static extern uint WaitForSingleObject(IntPtr hHandle, uint dwMilliseconds);
+
+        [DllImport("kernel32.dll")]
+        [return: MarshalAs(UnmanagedType.Bool)]
+        private static extern bool GetExitCodeProcess(IntPtr hProcess, out uint lpExitCode);
+
+        [DllImport("kernel32.dll", SetLastError = true)]
+        [return: MarshalAs(UnmanagedType.Bool)]
+        private static extern bool TerminateProcess(IntPtr hProcess, uint uExitCode);
+
+        [DllImport("kernel32.dll")]
+        [return: MarshalAs(UnmanagedType.Bool)]
+        private static extern bool CloseHandle(IntPtr hObject);
+    }
+}

--- a/docs/PackageManager-Guide.md
+++ b/docs/PackageManager-Guide.md
@@ -247,17 +247,18 @@ Any token outside this set is rejected at validation (fail closed — Hina never
 silently grants an unknown path).
 
 **`capabilities`** — booleans: `network`, `audio`, `microphone`, `screen`,
-`input`, `devices`. **`network` is enforced on Linux 6.7+** (Landlock ABI ≥ 4),
-**macOS**, and **Windows** (AppContainer): a sandboxed app that does not declare
-`network: true` has outbound network denied. On older Linux kernels `network` is
-declared-only. The remaining capabilities are **not enforced** — surfaced to the
-user (by `hina perms`) as *"declared — not enforced"* so the display never implies
-isolation Hina does not provide.
+`input`, `devices`. **`network` is enforced on Linux 6.7+** (Landlock ABI ≥ 4) and
+**macOS**: a sandboxed app that does not declare `network: true` has outbound
+network denied. On older Linux kernels and other OSes `network` is declared-only.
+The remaining capabilities are **not enforced** — surfaced to the user (by
+`hina perms`) as *"declared — not enforced"* so the display never implies isolation
+Hina does not provide.
 
 **What is enforced where** — the **filesystem** scope and the **`network`**
-capability are enforced on **Linux** (via Landlock; network needs kernel 6.7+),
-**macOS** (via `sandbox-exec`), and **Windows** (via AppContainer). See the
-[Sandboxing](#sandboxing) section for the full model.
+capability are enforced on **Linux** (via Landlock; network needs kernel 6.7+) and
+**macOS** (via `sandbox-exec`). On Windows the declared scope is shown at install
+time with a warning that it is *not* applied (an AppContainer backend is implemented
+but unverified). See the [Sandboxing](#sandboxing) section for the full model.
 
 ### Validation rules
 
@@ -342,21 +343,18 @@ deliberately narrow:
 - **macOS** enforces via `sandbox-exec` (Seatbelt): `hina run` generates a profile
   from the declared scope and launches the app under `sandbox-exec -f <profile>`,
   so its shortcut routes through `hina run` just like Linux.
-- **Windows** enforces via **AppContainer** (NT 6.2+): `hina run` creates a per-app
-  AppContainer profile, grants the container SID an ACE on the app dir and each
-  granted path, then launches the app under a `SECURITY_CAPABILITIES` built from
-  the container SID. The container is denied every other object by default. Its
-  shortcut routes through `hina run` just like Linux/macOS. (System DLL dirs stay
-  reachable via the pre-existing `ALL APPLICATION PACKAGES` ACE, so Hina never
-  edits a system DACL.)
-- **Old kernel / no Landlock / no sandbox-exec / no AppContainer** → a no-op plus a
-  one-time warning. A missing or too-old sandbox backend never blocks a launch.
-- **`network` is enforced on Linux 6.7+, macOS, and Windows.** A sandboxed app that
-  doesn't declare `network: true` has outbound network denied (Landlock ABI ≥ 4 /
-  Seatbelt / AppContainer without the `internetClient` capability); on older Linux
-  kernels it falls back to declared-only. `audio`, `microphone`, `screen`, `input`,
-  and `devices` remain declared-only — surfaced to the user as *"declared — not
-  enforced"*; nothing restricts them yet.
+- **Windows does not enforce the sandbox yet.** An AppContainer backend is
+  implemented but unverified (see `docs/Windows-Sandbox-Design.md`), so Windows uses
+  NoOp: installing a sandboxed app there warns that it runs with full user
+  privileges, and its shortcut launches the binary directly — it does **not** route
+  through `hina run` (which would gain nothing).
+- **Old kernel / no Landlock / no sandbox-exec / Windows** → a no-op plus a one-time
+  warning. A missing or too-old sandbox backend never blocks a launch.
+- **`network` is enforced on Linux 6.7+ and macOS.** A sandboxed app that doesn't
+  declare `network: true` has outbound network denied (Landlock ABI ≥ 4 / Seatbelt);
+  on older Linux kernels and other OSes it falls back to declared-only. `audio`,
+  `microphone`, `screen`, `input`, and `devices` remain declared-only — surfaced to
+  the user as *"declared — not enforced"*; nothing restricts them yet.
 - **No portals.** There are no dynamic file-picker grants. Scope is the static set
   of declared paths plus any paths the user grants manually.
 

--- a/docs/PackageManager-Guide.md
+++ b/docs/PackageManager-Guide.md
@@ -247,18 +247,17 @@ Any token outside this set is rejected at validation (fail closed — Hina never
 silently grants an unknown path).
 
 **`capabilities`** — booleans: `network`, `audio`, `microphone`, `screen`,
-`input`, `devices`. **`network` is enforced on Linux 6.7+** (Landlock ABI ≥ 4): a
-sandboxed app that does not declare `network: true` has all TCP bind/connect
-denied. On older kernels and other OSes `network` is declared-only. The remaining
-capabilities are **not enforced** — surfaced to the user (by `hina perms`) as
-*"declared — not enforced"* so the display never implies isolation Hina does not
-provide.
+`input`, `devices`. **`network` is enforced on Linux 6.7+** (Landlock ABI ≥ 4),
+**macOS**, and **Windows** (AppContainer): a sandboxed app that does not declare
+`network: true` has outbound network denied. On older Linux kernels `network` is
+declared-only. The remaining capabilities are **not enforced** — surfaced to the
+user (by `hina perms`) as *"declared — not enforced"* so the display never implies
+isolation Hina does not provide.
 
 **What is enforced where** — the **filesystem** scope and the **`network`**
-capability are enforced on **Linux** (via Landlock; network needs kernel 6.7+) and
-on **macOS** (via `sandbox-exec`). On Windows the declared scope is shown at
-install time with a warning that it is *not* applied. See the [Sandboxing](#sandboxing)
-section for the full model.
+capability are enforced on **Linux** (via Landlock; network needs kernel 6.7+),
+**macOS** (via `sandbox-exec`), and **Windows** (via AppContainer). See the
+[Sandboxing](#sandboxing) section for the full model.
 
 ### Validation rules
 
@@ -336,24 +335,28 @@ A publisher can opt an app into a Flatpak-style filesystem sandbox via the
 [`sandbox` block](#the-optional-sandbox-block). The enforcement model in v1 is
 deliberately narrow:
 
-- **Filesystem scope is the only enforced category**, and **only on Linux** (via
-  Landlock — kernel ≥ 5.13, unprivileged, no root or bubblewrap). `hina run`
-  installs the Landlock ruleset, then `execv`s the app; the restrictions are
-  inherited across the exec, so the app's process is the restricted one.
+- **Filesystem scope** is enforced on **Linux** (via Landlock — kernel ≥ 5.13,
+  unprivileged, no root or bubblewrap). `hina run` installs the Landlock ruleset,
+  then `execv`s the app; the restrictions are inherited across the exec, so the
+  app's process is the restricted one.
 - **macOS** enforces via `sandbox-exec` (Seatbelt): `hina run` generates a profile
   from the declared scope and launches the app under `sandbox-exec -f <profile>`,
   so its shortcut routes through `hina run` just like Linux.
-- **Windows does not enforce the sandbox yet** (that backend is deferred).
-  Installing a sandboxed app there warns that it runs with full user privileges,
-  and its shortcut launches the binary directly — it does **not** route through
-  `hina run` (which would gain nothing).
-- **Old kernel / no Landlock / no sandbox-exec** → a no-op plus a one-time warning. A missing or
-  too-old sandbox backend never blocks a launch.
-- **`network` is enforced on Linux 6.7+.** A sandboxed app that doesn't declare
-  `network: true` has all TCP bind/connect denied (Landlock ABI ≥ 4); on older
-  kernels and other OSes it falls back to declared-only. `audio`, `microphone`,
-  `screen`, `input`, and `devices` remain declared-only — surfaced to the user as
-  *"declared — not enforced"*; nothing restricts them yet.
+- **Windows** enforces via **AppContainer** (NT 6.2+): `hina run` creates a per-app
+  AppContainer profile, grants the container SID an ACE on the app dir and each
+  granted path, then launches the app under a `SECURITY_CAPABILITIES` built from
+  the container SID. The container is denied every other object by default. Its
+  shortcut routes through `hina run` just like Linux/macOS. (System DLL dirs stay
+  reachable via the pre-existing `ALL APPLICATION PACKAGES` ACE, so Hina never
+  edits a system DACL.)
+- **Old kernel / no Landlock / no sandbox-exec / no AppContainer** → a no-op plus a
+  one-time warning. A missing or too-old sandbox backend never blocks a launch.
+- **`network` is enforced on Linux 6.7+, macOS, and Windows.** A sandboxed app that
+  doesn't declare `network: true` has outbound network denied (Landlock ABI ≥ 4 /
+  Seatbelt / AppContainer without the `internetClient` capability); on older Linux
+  kernels it falls back to declared-only. `audio`, `microphone`, `screen`, `input`,
+  and `devices` remain declared-only — surfaced to the user as *"declared — not
+  enforced"*; nothing restricts them yet.
 - **No portals.** There are no dynamic file-picker grants. Scope is the static set
   of declared paths plus any paths the user grants manually.
 

--- a/docs/Security.md
+++ b/docs/Security.md
@@ -276,8 +276,8 @@ but over-reaching app sees only the paths it declares.
 
 | Surface | Status |
 |---------|--------|
-| **Filesystem scope** | Enforced on **Linux** via Landlock (unprivileged, kernel ≥ 5.13, no root / no bubblewrap) and on **macOS** via `sandbox-exec` (Seatbelt). On **Windows** it is **declared but NOT enforced** — the app runs with full user privileges (warned at install time). |
-| **`network` capability** | Enforced on **Linux 6.7+** (Landlock ABI ≥ 4) and **macOS** (Seatbelt `deny default` network): when a sandboxed app does not declare `network: true`, TCP bind/connect is denied. On older Linux kernels (ABI < 4) and Windows it is declared-only (a log line notes it is not enforced). |
+| **Filesystem scope** | Enforced on **Linux** via Landlock (unprivileged, kernel ≥ 5.13, no root / no bubblewrap), on **macOS** via `sandbox-exec` (Seatbelt), and on **Windows** via **AppContainer** (NT 6.2+): a deny-by-default low-privilege container that can reach only the app dir and the granted paths. |
+| **`network` capability** | Enforced on **Linux 6.7+** (Landlock ABI ≥ 4), **macOS** (Seatbelt `deny default` network), and **Windows** (AppContainer without the `internetClient` capability SID): when a sandboxed app does not declare `network: true`, outbound network is denied. On older Linux kernels (ABI < 4) it is declared-only (a log line notes it is not enforced). |
 | **Other capabilities** (`audio`, `microphone`, `screen`, `input`, `devices`) | **Declared-only, never enforced yet.** `hina perms` shows them as "declared — not enforced". No portals (PipeWire / Wayland / per-OS device policy) are wired up. |
 
 When a descriptor carries no `sandbox` block (or `sandbox.enabled` is `false`), the
@@ -324,27 +324,32 @@ disclosure prints it as an explicit `UNRESTRICTED filesystem access` warning, an
 
 ### How Enforcement Works (`hina run`)
 
-For a sandboxed app on Linux **and macOS**, the shell shortcuts Hina creates do
-**not** point at the app binary — they route through `hina run <app> "<entryId>"`.
-`hina run` resolves the declared scope plus any user grants into a backend ruleset
-and applies it before the app starts:
+For a sandboxed app on Linux, macOS **and Windows**, the shell shortcuts Hina
+creates do **not** point at the app binary — they route through
+`hina run <app> "<entryId>"`. `hina run` resolves the declared scope plus any user
+grants into a backend ruleset and applies it before the app starts:
 - **Linux**: builds a Landlock ruleset, applies it to itself
   (`landlock_restrict_self`), then `execv`s the app, which inherits the
   restrictions (the app's PID is Hina's).
 - **macOS**: generates a Seatbelt profile and launches the app under
   `sandbox-exec -f <profile>`.
+- **Windows**: creates a per-app AppContainer profile, grants the container SID an
+  ACE on the app dir + each granted path, then launches the app under a
+  `SECURITY_CAPABILITIES` built from the container SID. The container is denied
+  every other securable object by default; system DLL dirs stay reachable via the
+  pre-existing `ALL APPLICATION PACKAGES` ACE (so Hina never edits a system DACL).
 
-On **Windows** the shortcut launches the app directly (no backend yet). If the
-Linux kernel is too old for Landlock, or `sandbox-exec` is unavailable, or backend
-setup fails for any reason, enforcement degrades to a **no-op with a one-time
-warning** and the launch is never blocked.
+If the Linux kernel is too old for Landlock, `sandbox-exec` is unavailable, the
+host predates AppContainer, or backend setup fails for any reason, enforcement
+degrades to a **no-op with a one-time warning** and the launch is never blocked.
 
 ### Install-Time Disclosure
 
 When a sandboxed app is installed, Hina discloses the declared scope. On a host
-where the sandbox cannot be enforced (Windows), it warns plainly that the app
-**runs with FULL user privileges (no isolation)** before listing the declared
-scope, so the user is never misled into thinking isolation is in effect.
+where the sandbox cannot be enforced (e.g. a Linux kernel too old for Landlock), it
+warns plainly that the app **runs with FULL user privileges (no isolation)** before
+listing the declared scope, so the user is never misled into thinking isolation is
+in effect.
 
 ### User-Granted Paths (`hina perms`)
 

--- a/docs/Security.md
+++ b/docs/Security.md
@@ -276,8 +276,8 @@ but over-reaching app sees only the paths it declares.
 
 | Surface | Status |
 |---------|--------|
-| **Filesystem scope** | Enforced on **Linux** via Landlock (unprivileged, kernel ≥ 5.13, no root / no bubblewrap), on **macOS** via `sandbox-exec` (Seatbelt), and on **Windows** via **AppContainer** (NT 6.2+): a deny-by-default low-privilege container that can reach only the app dir and the granted paths. |
-| **`network` capability** | Enforced on **Linux 6.7+** (Landlock ABI ≥ 4), **macOS** (Seatbelt `deny default` network), and **Windows** (AppContainer without the `internetClient` capability SID): when a sandboxed app does not declare `network: true`, outbound network is denied. On older Linux kernels (ABI < 4) it is declared-only (a log line notes it is not enforced). |
+| **Filesystem scope** | Enforced on **Linux** via Landlock (unprivileged, kernel ≥ 5.13, no root / no bubblewrap) and on **macOS** via `sandbox-exec` (Seatbelt). On **Windows** it is **declared but NOT enforced** — the app runs with full user privileges (warned at install time). An AppContainer backend is implemented but unverified (see `docs/Windows-Sandbox-Design.md`), so Windows stays NoOp. |
+| **`network` capability** | Enforced on **Linux 6.7+** (Landlock ABI ≥ 4) and **macOS** (Seatbelt `deny default` network): when a sandboxed app does not declare `network: true`, outbound network is denied. On older Linux kernels (ABI < 4) and Windows it is declared-only (a log line notes it is not enforced). |
 | **Other capabilities** (`audio`, `microphone`, `screen`, `input`, `devices`) | **Declared-only, never enforced yet.** `hina perms` shows them as "declared — not enforced". No portals (PipeWire / Wayland / per-OS device policy) are wired up. |
 
 When a descriptor carries no `sandbox` block (or `sandbox.enabled` is `false`), the
@@ -324,32 +324,29 @@ disclosure prints it as an explicit `UNRESTRICTED filesystem access` warning, an
 
 ### How Enforcement Works (`hina run`)
 
-For a sandboxed app on Linux, macOS **and Windows**, the shell shortcuts Hina
-creates do **not** point at the app binary — they route through
-`hina run <app> "<entryId>"`. `hina run` resolves the declared scope plus any user
-grants into a backend ruleset and applies it before the app starts:
+For a sandboxed app on Linux **and macOS**, the shell shortcuts Hina creates do
+**not** point at the app binary — they route through `hina run <app> "<entryId>"`.
+`hina run` resolves the declared scope plus any user grants into a backend ruleset
+and applies it before the app starts:
 - **Linux**: builds a Landlock ruleset, applies it to itself
   (`landlock_restrict_self`), then `execv`s the app, which inherits the
   restrictions (the app's PID is Hina's).
 - **macOS**: generates a Seatbelt profile and launches the app under
   `sandbox-exec -f <profile>`.
-- **Windows**: creates a per-app AppContainer profile, grants the container SID an
-  ACE on the app dir + each granted path, then launches the app under a
-  `SECURITY_CAPABILITIES` built from the container SID. The container is denied
-  every other securable object by default; system DLL dirs stay reachable via the
-  pre-existing `ALL APPLICATION PACKAGES` ACE (so Hina never edits a system DACL).
 
-If the Linux kernel is too old for Landlock, `sandbox-exec` is unavailable, the
-host predates AppContainer, or backend setup fails for any reason, enforcement
+On **Windows** the shortcut launches the app directly (no working backend yet — an
+AppContainer backend is implemented but unverified, see
+`docs/Windows-Sandbox-Design.md`). If the Linux kernel is too old for Landlock,
+`sandbox-exec` is unavailable, or backend setup fails for any reason, enforcement
 degrades to a **no-op with a one-time warning** and the launch is never blocked.
 
 ### Install-Time Disclosure
 
 When a sandboxed app is installed, Hina discloses the declared scope. On a host
-where the sandbox cannot be enforced (e.g. a Linux kernel too old for Landlock), it
-warns plainly that the app **runs with FULL user privileges (no isolation)** before
-listing the declared scope, so the user is never misled into thinking isolation is
-in effect.
+where the sandbox cannot be enforced (Windows, or a Linux kernel too old for
+Landlock), it warns plainly that the app **runs with FULL user privileges (no
+isolation)** before listing the declared scope, so the user is never misled into
+thinking isolation is in effect.
 
 ### User-Granted Paths (`hina perms`)
 

--- a/docs/Windows-Sandbox-Design.md
+++ b/docs/Windows-Sandbox-Design.md
@@ -1,73 +1,75 @@
-# Windows sandbox backend — AppContainer (implemented)
+# Windows sandbox backend — AppContainer (implemented, NOT verified)
 
-Status: **implemented.** On Windows a sandboxed app runs inside a low-privilege
-AppContainer, the deny-by-default analogue of Linux/Landlock and macOS/Seatbelt.
-Backend: `Hina.PackageManager/Sandbox/WindowsSandbox.cs`; pure policy:
-`WindowsAppContainerPolicy.cs`. Proven by the `windows-sandbox` CI job
-(`scripts/windows-sandbox-probe.ps1`), since AppContainer cannot be exercised on
-the macOS/Linux dev host.
+Status: **implemented but unverified — Windows ships as NoOp.** The AppContainer
+backend (`Hina.PackageManager/Sandbox/WindowsSandbox.cs`, pure policy in
+`WindowsAppContainerPolicy.cs`) is written and its ACL plumbing is proven correct on
+CI, but the lowbox it creates honors no runtime access grant, so
+`SandboxLauncherFactory` deliberately does **not** select it. On Windows a sandboxed
+app runs unsandboxed with a one-time warning, exactly like before. This note records
+the design and the investigation so the work can be resumed on a real Windows box.
 
-## How it works: low-privilege AppContainer
+Why it can't be finished here: the dev host is macOS, so AppContainer cannot be run
+or debugged locally — the only feedback channel is the `windows-latest` CI probe
+(`scripts/windows-sandbox-probe.ps1`), which gives logs but no interactive debugging
+(no Process Explorer, no breakpoints).
+
+## Design: low-privilege AppContainer
 
 `WindowsSandbox : ISandboxLauncher`:
 
-1. **Create / derive an AppContainer profile** for the app
-   (`CreateAppContainerProfile`, or `DeriveAppContainerSidFromAppContainerName` when
-   the profile already exists). Stable per-app container name `Hina.<appName>`
-   (sanitized, ≤ 64 chars) so re-launches derive the same SID.
+1. **Create / derive an AppContainer profile** (`CreateAppContainerProfile`, or
+   `DeriveAppContainerSidFromAppContainerName` if it exists). Stable per-app container
+   name `Hina.<appName>` (sanitized, ≤ 64 chars).
 2. **Grant explicit ACEs** for the container SID on the app dir + each declared
-   `ro`/`rw` path and user grant (`GetNamedSecurityInfo` → `SetEntriesInAcl` →
-   `SetNamedSecurityInfo`). `ro` → read+execute, `rw` → +write. The ACEs are
-   inheritable (`SUB_CONTAINERS_AND_OBJECTS_INHERIT`).
+   `ro`/`rw` path (`GetNamedSecurityInfo` → `SetEntriesInAcl` → `SetNamedSecurityInfo`),
+   plus `FILE_TRAVERSE` on each ancestor directory (applied with `SetFileSecurity` so it
+   does not re-propagate inheritance and hang on big profile dirs).
 3. **Launch** with `CreateProcess` + `STARTUPINFOEX` +
-   `PROC_THREAD_ATTRIBUTE_SECURITY_CAPABILITIES` pointing at a
-   `SECURITY_CAPABILITIES` built from the container SID (plus any capability SIDs).
-   All via AOT-safe `[DllImport]` P/Invoke — no reflection. Wait, return the exit
-   code, free the SIDs / attribute list / capability array.
-4. **`IsSupported`** = `OperatingSystem.IsWindowsVersionAtLeast(6, 2)` (Windows 8 /
-   Server 2012+). Fail-soft: any setup failure logs a warning and runs the app
-   directly, never blocking the launch. The factory hands back NoOp when unsupported.
+   `PROC_THREAD_ATTRIBUTE_SECURITY_CAPABILITIES` pointing at a `SECURITY_CAPABILITIES`
+   built from the container SID. All via AOT-safe `[DllImport]` P/Invoke. `RestrictNetwork`
+   maps to omitting the `internetClient` capability SID.
+4. **`IsSupported`** = `OperatingSystem.IsWindowsVersionAtLeast(6, 2)`. Fail-soft.
 
-### Why the system DLL dirs are NOT ACL'd
+System DLL dirs are deliberately not ACL'd — they already carry an `ALL APPLICATION
+PACKAGES` ACE granting read+execute to every container.
 
-An AppContainer is denied every securable object unless its DACL grants the
-container SID, a capability SID, or `ALL APPLICATION PACKAGES` (S-1-15-2-1).
-`C:\Windows\System32`, `WinSxS`, and the .NET GAC already carry an
-`ALL APPLICATION PACKAGES` read+execute ACE — that is how Store apps load system
-DLLs — so the container can load them without any change from Hina. Adding our own
-ACEs there would need admin and would edit a **shared system DACL**, so we
-deliberately don't: only the app dir and the plan rules get container-SID ACEs.
+## What the CI probe proved
 
-### Network
+On a real `windows-latest` runner, with `icacls` + `--verbose` logging:
 
-An AppContainer denies network unless the `internetClient` capability SID
-(`S-1-15-3-1`) is attached. `WindowsAppContainerPolicy.BuildCapabilitySids` maps
-`plan.RestrictNetwork`: omit the SID to deny, add it to allow — mirroring
-Landlock/Seatbelt.
+- **The ACL plumbing is correct.** Every grant lands on disk: the container SID gets
+  `(RX,W)` on the granted dir (plus an inheritable generic ACE for its children) and
+  `(X)` (FILE_TRAVERSE) on each ancestor up to `C:\`, with the existing
+  user / Administrators / SYSTEM ACEs preserved.
+- **Isolation works.** The container is correctly DENIED an ungranted "secret" dir.
+- **But the lowbox honors no runtime grant for actual access.** A granted dir was
+  neither readable nor writable, whether granted:
+  - the specific package SID, **or** `ALL APPLICATION PACKAGES` (the group the token
+    demonstrably has — it runs `cmd.exe` from System32 through it);
+  - with the object's integrity label lowered to **Low**, or not;
+  - on a deep `%TEMP%` profile path, **or** a shallow `C:\` path.
 
-## Shortcut routing
+  Every combination was denied; only the System32 baseline (system-level
+  `ALL APPLICATION PACKAGES`) was reachable.
 
-`WindowsPlatformIntegration`'s 4-arg `CreateMenuShortcut(launchOverride)` writes a
-`.lnk` whose target is the hina executable with `run <app> "<entry>"` as its
-arguments (the opaque override string is split by `WindowsLaunchOverride.Parse` and
-control-stripped), so a sandboxed app's shortcut routes through `hina run` and the
-AppContainer is installed before the app starts — like Linux/macOS.
-`InstallService.sandboxEnforceable` includes Windows, so the install-time
-disclosure says the app runs sandboxed.
+## Leading hypothesis / next step
 
-## Verification
+The pattern — only the system baseline reachable, every runtime grant ignored — points
+to an **over-restricted token**: most likely the AppContainer process is running at an
+integrity level below the objects (so all write-up is blocked), and/or the lowbox
+restricting-SID set isn't being satisfied the way the DACL grants expect. Confirming
+this needs **Process Explorer on a real Windows machine** to read the live process's
+integrity level and token groups/restricting-SIDs, then adjust token creation
+accordingly. Reference implementations that work (e.g. Chromium's AppContainer sandbox)
+do access user-profile paths, so this is a fixable wiring issue, not a Windows limit.
 
-The `windows-sandbox` job in `.github/workflows/dotnet.yml` runs
-`scripts/windows-sandbox-probe.ps1`: a child runs under an AppContainer granted only
-a `docs:rw` dir (not a `secret` dir) and must be **denied** the secret read while
-**allowed** the docs write (`READ=0 WRITE=1`). It skip-passes where AppContainer is
-unavailable. Same contract as `landlock-probe.sh` / the macOS sandbox test.
+Until then, the honest NoOp + install-time warning stays — shipping the backend would
+launch apps that cannot read their own install directory, strictly worse than NoOp.
 
-## Known limitations
+## Verification harness (ready for when it works)
 
-- The container profile and the path ACEs are left in place after exit (the
-  container name / SID is stable per app, so re-grants are idempotent and the ACE
-  only ever benefits that one Hina-managed container). Full teardown on uninstall is
-  future work.
-- `rw` grants read+write+execute but not `DELETE`; apps that must delete files in a
-  granted dir may need a wider right (future work).
+`scripts/windows-sandbox-probe.ps1` + the `windows-sandbox` job in
+`.github/workflows/dotnet.yml`: a child runs under the sandbox granted only a `docs:rw`
+dir (not a `secret` dir) and must be denied the secret read + allowed the docs write
+(`READ=0 WRITE=1`). It SKIP-passes while Windows is NoOp; wire `WindowsSandbox` into the
+factory and it becomes the real enforcement proof with no other changes.

--- a/docs/Windows-Sandbox-Design.md
+++ b/docs/Windows-Sandbox-Design.md
@@ -1,53 +1,73 @@
-# Windows sandbox backend — design note (deferred)
+# Windows sandbox backend — AppContainer (implemented)
 
-Status: **not implemented.** On Windows a sandboxed app currently falls back to
-`NoOpSandbox` (runs unsandboxed, warns once at install). This note records the
-intended design so the work can be picked up without re-deriving it.
+Status: **implemented.** On Windows a sandboxed app runs inside a low-privilege
+AppContainer, the deny-by-default analogue of Linux/Landlock and macOS/Seatbelt.
+Backend: `Hina.PackageManager/Sandbox/WindowsSandbox.cs`; pure policy:
+`WindowsAppContainerPolicy.cs`. Proven by the `windows-sandbox` CI job
+(`scripts/windows-sandbox-probe.ps1`), since AppContainer cannot be exercised on
+the macOS/Linux dev host.
 
-Why deferred: the AppContainer path is large and easy to get subtly wrong (ACL
-inheritance, profile lifecycle, the app needing read on system DLLs), and it cannot
-be verified on the macOS/Linux dev host. Per the project rule "do not ship a
-half-enforcing backend that *looks* like it isolates but doesn't", it is better to
-keep the honest NoOp + warning than to ship an unverified AppContainer.
+## How it works: low-privilege AppContainer
 
-## Intended approach: low-privilege AppContainer
-
-Implement `WindowsSandbox : ISandboxLauncher`:
+`WindowsSandbox : ISandboxLauncher`:
 
 1. **Create / derive an AppContainer profile** for the app
-   (`CreateAppContainerProfile`, or `DeriveAppContainerSidFromAppContainerName` if it
-   already exists). Use a stable per-app container name (e.g. `Hina.<appName>`).
+   (`CreateAppContainerProfile`, or `DeriveAppContainerSidFromAppContainerName` when
+   the profile already exists). Stable per-app container name `Hina.<appName>`
+   (sanitized, ≤ 64 chars) so re-launches derive the same SID.
 2. **Grant explicit ACEs** for the container SID on the app dir + each declared
-   `ro`/`rw` path and each user grant (`SetEntriesInAcl` / `SetNamedSecurityInfo`),
-   plus read+execute on the system DLL directories the app needs to load
-   (`C:\Windows\System32`, the app's own dir). Without these the process can't start
-   — the Windows analogue of the Linux `SystemRuntimePaths` / macOS system baseline.
-3. **Launch** with `CreateProcess` using `STARTUPINFOEX` +
+   `ro`/`rw` path and user grant (`GetNamedSecurityInfo` → `SetEntriesInAcl` →
+   `SetNamedSecurityInfo`). `ro` → read+execute, `rw` → +write. The ACEs are
+   inheritable (`SUB_CONTAINERS_AND_OBJECTS_INHERIT`).
+3. **Launch** with `CreateProcess` + `STARTUPINFOEX` +
    `PROC_THREAD_ATTRIBUTE_SECURITY_CAPABILITIES` pointing at a
-   `SECURITY_CAPABILITIES` built from the container SID (and any capability SIDs).
-   All via AOT-safe `[LibraryImport]`/`[DllImport]` P/Invoke — no reflection.
-4. **`IsSupported`** = AppContainer APIs available (Windows 8+). Fail-soft: any
-   failure logs a warning and runs the app, never blocks the launch.
+   `SECURITY_CAPABILITIES` built from the container SID (plus any capability SIDs).
+   All via AOT-safe `[DllImport]` P/Invoke — no reflection. Wait, return the exit
+   code, free the SIDs / attribute list / capability array.
+4. **`IsSupported`** = `OperatingSystem.IsWindowsVersionAtLeast(6, 2)` (Windows 8 /
+   Server 2012+). Fail-soft: any setup failure logs a warning and runs the app
+   directly, never blocking the launch. The factory hands back NoOp when unsupported.
 
-Network: AppContainer denies network unless the `internetClient` /
-`internetClientServer` capability SID is added — so `capabilities.network` maps
-naturally (omit the SID to deny, add it to allow), mirroring Landlock/Seatbelt.
+### Why the system DLL dirs are NOT ACL'd
+
+An AppContainer is denied every securable object unless its DACL grants the
+container SID, a capability SID, or `ALL APPLICATION PACKAGES` (S-1-15-2-1).
+`C:\Windows\System32`, `WinSxS`, and the .NET GAC already carry an
+`ALL APPLICATION PACKAGES` read+execute ACE — that is how Store apps load system
+DLLs — so the container can load them without any change from Hina. Adding our own
+ACEs there would need admin and would edit a **shared system DACL**, so we
+deliberately don't: only the app dir and the plan rules get container-SID ACEs.
+
+### Network
+
+An AppContainer denies network unless the `internetClient` capability SID
+(`S-1-15-3-1`) is attached. `WindowsAppContainerPolicy.BuildCapabilitySids` maps
+`plan.RestrictNetwork`: omit the SID to deny, add it to allow — mirroring
+Landlock/Seatbelt.
 
 ## Shortcut routing
 
-Wire `WindowsPlatformIntegration`'s 4-arg `CreateMenuShortcut(launchOverride)` so a
-sandboxed app's `.lnk` invokes `hina run <app> <entry>` (like Linux/macOS). Then
-flip `InstallService.sandboxEnforceable` to include Windows. Until the backend
-exists, leave the `.lnk` pointing at the binary and keep the not-enforced warning.
+`WindowsPlatformIntegration`'s 4-arg `CreateMenuShortcut(launchOverride)` writes a
+`.lnk` whose target is the hina executable with `run <app> "<entry>"` as its
+arguments (the opaque override string is split by `WindowsLaunchOverride.Parse` and
+control-stripped), so a sandboxed app's shortcut routes through `hina run` and the
+AppContainer is installed before the app starts — like Linux/macOS.
+`InstallService.sandboxEnforceable` includes Windows, so the install-time
+disclosure says the app runs sandboxed.
 
-## Verification (when implemented)
+## Verification
 
-Add a `windows-latest` CI job analogous to `macos-sandbox`: a probe that runs a
-child under the AppContainer, asserts an ungranted read is denied and a granted
-write allowed, and skip-passes if the AppContainer APIs are unavailable.
+The `windows-sandbox` job in `.github/workflows/dotnet.yml` runs
+`scripts/windows-sandbox-probe.ps1`: a child runs under an AppContainer granted only
+a `docs:rw` dir (not a `secret` dir) and must be **denied** the secret read while
+**allowed** the docs write (`READ=0 WRITE=1`). It skip-passes where AppContainer is
+unavailable. Same contract as `landlock-probe.sh` / the macOS sandbox test.
 
-## Scope guard
+## Known limitations
 
-If time-boxed, ship a **correct minimal** version (deny-by-default AppContainer +
-app dir + declared paths + system DLL dirs) and clearly log/doc the limitations —
-never a backend that appears to isolate but leaks.
+- The container profile and the path ACEs are left in place after exit (the
+  container name / SID is stable per app, so re-grants are idempotent and the ACE
+  only ever benefits that one Hina-managed container). Full teardown on uninstall is
+  future work.
+- `rw` grants read+write+execute but not `DELETE`; apps that must delete files in a
+  granted dir may need a wider right (future work).

--- a/docs/Windows-Sandbox-Resume.md
+++ b/docs/Windows-Sandbox-Resume.md
@@ -1,0 +1,227 @@
+# Windows Sandbox — Resume / Handoff (read this first)
+
+> **Purpose of this file.** Everything attempted on the Windows AppContainer sandbox,
+> why it is not finished, exactly what was proven, and exactly how to resume — written
+> to be exhaustive so a fresh Claude Code session (or a human) can pick it up with
+> minimal doubt. **Tell the new session: "read `docs/Windows-Sandbox-Resume.md`".**
+>
+> One-line status: **the AppContainer backend is fully implemented and its ACL plumbing
+> is proven correct on real Windows CI, but the lowbox process it creates is denied all
+> runtime-granted access; Windows therefore ships as NoOp until this is debugged on a
+> real Windows machine with Process Explorer.**
+
+---
+
+## 1. Context — what the sandbox feature is
+
+Hina is a cross-platform NativeAOT desktop-app package manager (C# / .NET 10) at
+`/Users/arutosio/GitRepositories/Hina`. The sandbox feature gives Hina-installed apps
+Flatpak-style **filesystem (+ network) isolation**, enforced before the app starts.
+
+- **Architecture:** sandboxed apps don't launch their binary directly. Their shortcut
+  routes through `hina run <app> <entry>` (the "launchOverride"), which resolves the
+  declared scope + user grants into an OS backend ruleset and applies it, then launches
+  the app. The chokepoint is `RunCommand.cs`; the cross-OS input is `SandboxPlan`.
+- **Working backends:**
+  - **Linux** → Landlock (`LinuxLandlockSandbox.cs`), proven on Ubuntu CI.
+  - **macOS** → `sandbox-exec`/Seatbelt (`MacOsSandbox.cs` + `MacOsSeatbeltProfile.cs`),
+    proven locally + macOS CI.
+- **Windows** → was the only OS with no backend (NoOp + warn). This branch tried to add
+  an **AppContainer** backend. It did not reach a provable working state.
+
+Key interface: `ISandboxLauncher { bool IsSupported; int Launch(execAbs, appArgs, plan, ct); }`.
+`SandboxLauncherFactory.Current(logger)` selects the backend per OS.
+`SandboxPlan { bool Unrestricted; IReadOnlyList<ResolvedFsRule> Rules; bool RestrictNetwork }`,
+`ResolvedFsRule { string Path; bool CanWrite }`. `plan.Rules[0]` is conventionally the app dir.
+
+**Hard constraint:** the dev host is **macOS**. AppContainer cannot be run or debugged
+locally. The ONLY feedback is the `windows-latest` GitHub Actions CI probe — logs only,
+no interactive debugging (no Process Explorer, no breakpoints). Every theory below was
+tested by pushing a commit and reading CI logs (~4 min/cycle, ~10 cycles total).
+
+---
+
+## 2. Files (all on branch `feature/sandbox-windows`, PR #8)
+
+| File | What it is | Keep? |
+|------|-----------|-------|
+| `Hina.PackageManager/Sandbox/WindowsAppContainerPolicy.cs` | **Pure** policy: container moniker, the `(path, AppContainerAccess)` ACE list, capability SIDs. 9 host-runnable unit tests. **Correct.** | ✅ |
+| `Hina.PackageManager.Tests/WindowsAppContainerPolicyTests.cs` | Tests for the above. Pass. | ✅ |
+| `Hina.PackageManager/Sandbox/WindowsSandbox.cs` | The AppContainer backend (`ISandboxLauncher`) — all Win32 via `[DllImport]`. **EXPERIMENTAL, NOT wired into the factory.** Header documents status. | ✅ scaffold |
+| `Hina.PackageManager/Platform/Windows/WindowsLaunchOverride.cs` | **Pure** parser splitting `"exe" args` into `.lnk` target+args. Tested. | ✅ |
+| `Hina.PackageManager.Tests/WindowsLaunchOverrideTests.cs` | Tests for the parser. Pass. | ✅ |
+| `Hina.PackageManager/Platform/Windows/ShellLink.cs` | Gained a `SetArguments` call (4-arg `.lnk`). | ✅ |
+| `Hina.PackageManager/Platform/Windows/WindowsPlatformIntegration.cs` | 4-arg `CreateMenuShortcut` routing through `hina run` (dormant on Windows while enforcement is off). | ✅ |
+| `scripts/windows-sandbox-probe.ps1` | The CI probe. Currently SKIP-passes under NoOp; becomes the real enforcement check if the backend is wired in. | ✅ |
+| `.github/workflows/dotnet.yml` | New `windows-sandbox` job (mirrors `macos-sandbox`). | ✅ |
+
+**Wiring switches (currently set to OFF / honest):**
+- `SandboxLauncherFactory.cs` — the `else if (...Windows)` branch is **removed**; Windows
+  falls through to `NoOpSandbox`. **To re-enable the backend, restore that branch.**
+- `InstallService.cs` (~line 186) — `sandboxEnforceable = Linux || OSX` (Windows removed).
+  **Add `|| ...Windows` back once the backend works** so shortcuts route through `hina run`
+  and the install disclosure says "runs sandboxed".
+
+---
+
+## 3. How the AppContainer backend works (the design)
+
+`WindowsSandbox.LaunchInAppContainer` (only runs on Windows ≥ 6.2; fail-soft to a direct
+spawn on any error):
+
+1. **Create / derive the profile.** `CreateAppContainerProfile("Hina.<app>", …, out sid)`;
+   on `ERROR_ALREADY_EXISTS` (0x800700B7) → `DeriveAppContainerSidFromAppContainerName`.
+   Returns the **package SID** (`S-1-15-2-…`).
+2. **Grant ACEs** (`WindowsAppContainerPolicy.BuildAceList` → `GrantContainerAce`): for each
+   plan rule, `GetNamedSecurityInfo` → `SetEntriesInAcl` (merge an `ACCESS_ALLOWED` ACE for
+   the container SID) → `SetNamedSecurityInfo`. `ro`→`GENERIC_READ|EXECUTE`, `rw`→`+WRITE`,
+   inheritable (`SUB_CONTAINERS_AND_OBJECTS_INHERIT`).
+3. **Grant ancestor traverse** (`GrantAncestorTraverse`): the lowbox does NOT bypass traverse,
+   so it needs `FILE_TRAVERSE` (execute only, non-inheritable → no list/read) on every parent
+   dir up to the drive root. Applied with **`SetFileSecurity`** (NOT `SetNamedSecurityInfo`)
+   because the latter re-propagates inheritance over the whole subtree and **hangs for minutes**
+   on profile dirs (learned the hard way — see §4).
+4. **Build `SECURITY_CAPABILITIES`** { AppContainerSid, Capabilities[], count } and attach it
+   via `InitializeProcThreadAttributeList` + `UpdateProcThreadAttribute(PROC_THREAD_ATTRIBUTE_SECURITY_CAPABILITIES=0x00020009)`.
+   Capabilities = `internetClient` (`S-1-15-3-1`) unless `RestrictNetwork`.
+5. **`CreateProcessW`** with `EXTENDED_STARTUPINFO_PRESENT` + `STARTUPINFOEX`, wait, return exit code.
+
+System DLL dirs (System32, WinSxS, GAC) are deliberately **not** ACL'd — they already carry an
+`ALL APPLICATION PACKAGES` (`S-1-15-2-1`) ACE granting read+execute to every container.
+
+---
+
+## 4. The investigation — every step, in order
+
+The probe (`scripts/windows-sandbox-probe.ps1`) runs a child `cmd.exe` under the sandbox,
+granting only a `docs:rw` dir (NOT a `secret` dir), and measures booleans via an inline
+`cmd /v:on /c "…"`. `--verbose` makes hina log the SID + each grant + the launched pid;
+the probe also dumps `icacls` of the relevant dirs.
+
+### 4.1 Bring-up bugs (fixed)
+- Probe `cmd.exe` couldn't read a `.cmd` from the app dir → **switched to an inline command**
+  (like the Landlock probe's `sh -c`), removing the app-dir-file-read confound.
+- `--verbose` placed as `args[0]` → the CLI router printed help (it dispatches on the first
+  arg). **Fixed: `--verbose` goes after the `sandbox-run` verb.**
+- First Windows CI run exposed **5 pre-existing Unix-assuming tests** that had never run on
+  Windows (no prior Windows job): `NoOpSandboxTests` (×2, `/bin/sh`), `LinuxPlatformIntegrationTests`
+  / `LinuxSandboxShortcutTests` (Unix path asserts), and a real test bug in
+  `WindowsPlatformIntegrationTests.InstallFont` (split on `|` but code uses `\x1F`). All gated/fixed.
+
+### 4.2 The `SetNamedSecurityInfo` hang (fixed)
+First ancestor-traverse attempt used `SetNamedSecurityInfo` on each ancestor → it re-propagates
+inheritance over the **entire subtree**, so calling it on `C:\Users\runneradmin` walked the whole
+profile and **hung CI for 10+ min**. Replaced with `SetFileSecurity` (sets just that object's DACL,
+no subtree walk). Job time dropped to ~2 min.
+
+### 4.3 The core finding — measurements
+
+Each row is one CI cycle. `RSEC` = read ungranted secret (want 0). `RDOC`/`WPKG` = read/write a
+package-SID-granted dir (want 1). `WAAP` = write an `ALL APPLICATION PACKAGES`-granted dir. `WLOW`
+= write a package-SID dir with the object's integrity label lowered to Low. `WROOT`/`WAR`/`WARLOW`
+= the same but on a **shallow `C:\` dir** (short, system-traversable path).
+
+| Test | Result | Conclusion |
+|------|--------|-----------|
+| Baseline (deep profile, package SID) | `RSEC=0 RDOC=0 WDOC=0` | isolation works; granted dir totally unreachable |
+| + ancestor `FILE_TRAVERSE` grants (deep) | `RSEC=0 RDOC=0 WDOC=0` | **icacls confirms the `(X)` traverse ACE landed on every ancestor and `(RX,W)` on docs, user/Admin/SYSTEM ACEs preserved** — yet still denied |
+| package SID vs `ALL APP PACKAGES` vs Low integrity (deep) | `RSEC=0 WPKG=0 WAAP=0 WLOW=0` | none help — not a SID-match nor an integrity issue |
+| shallow `C:\` dir (package SID) | `RSEC=0 WPKG=0 WROOT=0` | not a profile-path / runner-ACL issue |
+| shallow `C:\` dir, `ALL APP PACKAGES`, ±Low integrity | `RSEC=0 WPKG=0 WAR=0 WARLOW=0` | **even the group the token provably has, on a traversable C:\ path, is denied** |
+
+**`icacls` evidence (representative), proving the grants are correct on disk:**
+```
+docs   S-1-15-2-<pkg>:(RX,W)
+       S-1-15-2-<pkg>:(OI)(CI)(IO)(GR,GW,GE)
+       NT AUTHORITY\SYSTEM:(I)(OI)(CI)(F)
+       BUILTIN\Administrators:(I)(OI)(CI)(F)
+       runnervm…\runneradmin:(I)(OI)(CI)(F)
+<work> S-1-15-2-<pkg>:(X)         <- ancestor traverse landed
+<temp> S-1-15-2-<pkg>:(X)
+rootA  APPLICATION PACKAGE AUTHORITY\ALL APPLICATION PACKAGES:(OI)(CI)(M)   <- still denied
+```
+
+### 4.4 What is therefore PROVEN
+1. The lowbox **is** active and isolating — it correctly denies the ungranted secret.
+2. The token **has** the `ALL APPLICATION PACKAGES` group — it launches `cmd.exe` from System32,
+   which is granted only to that group.
+3. Every ACL grant Hina makes **lands correctly** on disk (verified by `icacls`), with the
+   pre-existing user/Admin/SYSTEM ACEs intact (so the dual-principal **intersection** model has
+   both principals granted).
+4. **Yet the lowbox honors no runtime grant** for read or write — package SID, ALL APP PACKAGES,
+   ±Low integrity, deep or shallow path: all denied. Only the system baseline (System32) is reachable.
+
+### 4.5 Hypotheses tested and RULED OUT
+- ❌ Grant code broken → no (`icacls` shows the ACEs).
+- ❌ User/group principal missing (dual-principal intersection) → no (user ACEs preserved).
+- ❌ Ancestor traversal → granted `(X)` on the full chain, still denied.
+- ❌ Profile-path / runner ACLs → a shallow `C:\` dir behaves identically.
+- ❌ Specific package SID not matching → `ALL APPLICATION PACKAGES` (definitely in the token) also denied.
+- ❌ Mandatory Integrity (write-up) → lowering the object label to Low did not help, and **reads** fail
+  too (read-up isn't integrity-blocked by default).
+
+### 4.6 Leading hypothesis (UNCONFIRMED — needs a real Windows box)
+An **over-restricted token**. Most likely the AppContainer process runs at an integrity level
+**below** the objects (blocking all write-up) AND/OR the lowbox **restricting-SID set** isn't being
+satisfied the way plain DACL grants expect (a lowbox does a second, "restricted" access check using
+only the package SID + capabilities; if our `SECURITY_CAPABILITIES` / token wiring is subtly wrong,
+that second check denies everything outside the system baseline). Reference sandboxes that work
+(e.g. **Chromium's** AppContainer renderer) *do* access user-profile paths, so this is a **fixable
+wiring bug, not a Windows limitation.**
+
+---
+
+## 5. How to resume (next week, on a real Windows machine)
+
+### 5.1 Reproduce locally
+```powershell
+git fetch; git checkout feature/sandbox-windows
+dotnet build Hina.sln -c Release
+$hina = (Get-ChildItem Hina.CLI/bin/Release -Recurse -Filter Hina.CLI.exe | Select-Object -First 1).FullName
+# Temporarily re-enable the backend (see §2 wiring switches) THEN rebuild before this:
+./scripts/windows-sandbox-probe.ps1 -HinaExe $hina
+```
+(The probe currently SKIP-passes because the factory returns NoOp. To exercise the real backend,
+first restore the `Windows → WindowsSandbox` branch in `SandboxLauncherFactory.cs` and rebuild.)
+
+### 5.2 Diagnose the token (the key missing data)
+Launch a sandboxed `cmd.exe` that **stays alive** (e.g. `cmd /k` or a sleeping child), then with
+**Process Explorer** (Sysinternals) inspect that child process:
+- **Security tab → Integrity level.** If it's below Medium/Low, that explains the universal write
+  denial (write-up). Compare to a known-good AppContainer app.
+- **Token groups & "restricting SIDs".** Confirm the package SID + `ALL APPLICATION PACKAGES` are in
+  BOTH the normal and the restricting sets. If the restricting set is wrong/empty, the second access
+  check denies everything → matches the symptom.
+- Cross-check with `whoami /groups` / `whoami /all` run *inside* the container.
+- Also useful: Sysinternals **AccessChk** — `accesschk.exe -<pkgSID> C:\path\docs` to see the
+  effective access the kernel computes for that SID on the granted dir.
+
+### 5.3 Likely fixes to try (once the cause is confirmed)
+- If integrity is the issue: ensure the process isn't created below the object IL; or set granted
+  objects' mandatory label appropriately. (Note: the *real* Hina install dir is `%LOCALAPPDATA%\Hina\Apps\<app>`.)
+- If the restricting-SID/capabilities wiring is the issue: re-check the `SECURITY_CAPABILITIES`
+  struct marshalling, the `SID_AND_ATTRIBUTES` array (`SE_GROUP_ENABLED=0x4`), and that the
+  attribute value `0x00020009` + sizes are correct. Compare byte-for-byte against a known-good C++
+  sample (e.g. `MalwareTech/AppContainerSandbox` `ContainerCreate.cpp`, or Pavel Yosifovich's
+  "Fun with AppContainers").
+- The pure policy (`WindowsAppContainerPolicy`) is correct; the bug is in `WindowsSandbox`'s token
+  creation, not the policy.
+
+### 5.4 When it works
+1. Restore the factory branch + `sandboxEnforceable |= Windows` (§2).
+2. The probe asserts `READ=0 WRITE=1` on real Windows → it will PASS (not SKIP) → that is the proof.
+3. Update the docs (Security / PackageManager-Guide / Windows-Sandbox-Design) back to "Windows enforces".
+4. Remove the "EXPERIMENTAL — NOT WIRED IN" header from `WindowsSandbox.cs`.
+
+---
+
+## 6. Reference
+
+- **Branch:** `feature/sandbox-windows` → **PR #8**. 14 commits (`84a2264` first … `7fb54cc` last).
+- **CI:** `.github/workflows/dotnet.yml` job `windows-sandbox` on `windows-latest` (Windows Server 2025).
+  Read logs with `gh run view --job <id> --log`.
+- **External docs consulted:** Microsoft "Implementing an AppContainer" (Win32 SecAuthZ); Pavel
+  Yosifovich "Fun with AppContainers"; Project Zero "Understanding Network Access in Windows
+  AppContainers"; `MalwareTech/AppContainerSandbox`.
+- **Companion design note:** `docs/Windows-Sandbox-Design.md` (shorter summary of the same).
+- Linux/macOS backends are unaffected and fully working; this is Windows-only.

--- a/scripts/windows-sandbox-probe.ps1
+++ b/scripts/windows-sandbox-probe.ps1
@@ -1,0 +1,96 @@
+<#
+.SYNOPSIS
+  Windows AppContainer filesystem-sandbox integration probe.
+
+.DESCRIPTION
+  The Windows analogue of scripts/landlock-probe.sh. Runs a child (cmd.exe) under a
+  Hina AppContainer sandbox that grants ONLY:
+    - the app dir (read+execute, so the container can read its own files)
+    - a "documents" dir (read-write)
+  and NOTHING else. It deliberately does NOT grant a "secret" dir.
+
+  Under real AppContainer enforcement the child must be DENIED reading the secret
+  (the secret dir's DACL grants no AppContainer/package SID) and ALLOWED writing the
+  document (its DACL has an explicit container-SID ACE) — i.e. READ=0 WRITE=1.
+
+  System DLL dirs (System32, where cmd.exe lives) are reachable because they already
+  carry an ALL APPLICATION PACKAGES ACE — which is exactly why we don't ACL them.
+
+  On a host where AppContainer is unavailable Hina logs that it is running unsandboxed
+  and the child sees READ=1 WRITE=1; the probe then SKIP-passes so CI stays green on
+  runners without AppContainer (mirrors the Landlock probe's behaviour on old kernels).
+
+.PARAMETER HinaExe
+  Path to the built Hina.CLI executable.
+#>
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory = $true)]
+    [string]$HinaExe
+)
+
+$ErrorActionPreference = 'Stop'
+
+if (-not (Test-Path $HinaExe)) {
+    Write-Error "hina binary not found: $HinaExe"
+    exit 1
+}
+
+$work = Join-Path ([System.IO.Path]::GetTempPath()) ("hina-sbx-" + [System.Guid]::NewGuid().ToString("N"))
+$app = Join-Path $work "app"
+$docs = Join-Path $work "docs"
+$secret = Join-Path $work "secret"
+New-Item -ItemType Directory -Force -Path $app, $docs, $secret | Out-Null
+Set-Content -Path (Join-Path $secret "key") -Value "topsecret" -NoNewline
+
+# probe.cmd lives in the app dir (granted read+execute). It tries to read the secret
+# (must fail) and write the doc (must succeed), then prints the verdict. %~1 = secret
+# dir, %~2 = docs dir.
+$probe = Join-Path $app "probe.cmd"
+@'
+@echo off
+set R=0
+set W=0
+type "%~1\key" >nul 2>&1 && set R=1
+>"%~2\out" echo data 2>nul && set W=1
+echo READ=%R% WRITE=%W%
+'@ | Set-Content -Path $probe -Encoding ASCII
+
+$cmdExe = Join-Path $env:SystemRoot "System32\cmd.exe"
+$stderrFile = Join-Path $work "stderr.txt"
+
+$hinaArgs = @(
+    'dev', 'sandbox-run',
+    '--app-dir', $app,
+    '--allow', ($docs + ':rw'),
+    '--',
+    $cmdExe, '/c', $probe, $secret, $docs
+)
+
+Write-Host "Using hina: $HinaExe"
+Write-Host "OS: $([System.Environment]::OSVersion.VersionString)"
+
+$out = & $HinaExe @hinaArgs 2>$stderrFile
+$err = (Test-Path $stderrFile) ? (Get-Content $stderrFile -Raw) : ""
+
+Write-Host "---- probe stdout ----"
+Write-Host $out
+Write-Host "---- probe stderr ----"
+Write-Host $err
+
+$combined = "$out`n$err"
+
+try { Remove-Item -Recurse -Force $work -ErrorAction SilentlyContinue } catch { }
+
+if ($combined -match 'cannot enforce' -or $combined -match 'running unsandboxed') {
+    Write-Host "SKIP: AppContainer not available on this host; passing."
+    exit 0
+}
+
+if ($combined -match 'READ=0 WRITE=1') {
+    Write-Host "PASS: secret read denied, document write allowed under AppContainer."
+    exit 0
+}
+
+Write-Error "FAIL: expected 'READ=0 WRITE=1' (secret denied, docs writable). Got: $combined"
+exit 1

--- a/scripts/windows-sandbox-probe.ps1
+++ b/scripts/windows-sandbox-probe.ps1
@@ -43,28 +43,22 @@ $secret = Join-Path $work "secret"
 New-Item -ItemType Directory -Force -Path $app, $docs, $secret | Out-Null
 Set-Content -Path (Join-Path $secret "key") -Value "topsecret" -NoNewline
 
-# probe.cmd lives in the app dir (granted read+execute). It tries to read the secret
-# (must fail) and write the doc (must succeed), then prints the verdict. %~1 = secret
-# dir, %~2 = docs dir.
-$probe = Join-Path $app "probe.cmd"
-@'
-@echo off
-set R=0
-set W=0
-type "%~1\key" >nul 2>&1 && set R=1
->"%~2\out" echo data 2>nul && set W=1
-echo READ=%R% WRITE=%W%
-'@ | Set-Content -Path $probe -Encoding ASCII
-
+# Inline cmd command (mirrors the Landlock probe's inline `sh -c`): try to read the
+# secret (must fail — secret dir is NOT granted) and write the doc (must succeed —
+# docs is granted rw), then print the verdict. cmd.exe itself is in System32, reachable
+# via the ALL APPLICATION PACKAGES ACE. /v:on so !R!/!W! expand at run time, not parse
+# time. Temp paths on the runner have no spaces, so no inner quoting is needed.
 $cmdExe = Join-Path $env:SystemRoot "System32\cmd.exe"
 $stderrFile = Join-Path $work "stderr.txt"
+$inner = "set R=0& set W=0& ( type $secret\key 1>nul 2>nul && set R=1 ) & ( echo data 1>$docs\out 2>nul && set W=1 ) & echo READ=!R! WRITE=!W!"
 
 $hinaArgs = @(
+    '--verbose',
     'dev', 'sandbox-run',
     '--app-dir', $app,
     '--allow', ($docs + ':rw'),
     '--',
-    $cmdExe, '/c', $probe, $secret, $docs
+    $cmdExe, '/v:on', '/c', $inner
 )
 
 Write-Host "Using hina: $HinaExe"

--- a/scripts/windows-sandbox-probe.ps1
+++ b/scripts/windows-sandbox-probe.ps1
@@ -38,30 +38,38 @@ if (-not (Test-Path $HinaExe)) {
 
 $work = Join-Path ([System.IO.Path]::GetTempPath()) ("hina-sbx-" + [System.Guid]::NewGuid().ToString("N"))
 $app = Join-Path $work "app"
-$docs = Join-Path $work "docs"
+$docs = Join-Path $work "docs"        # granted by hina (specific package SID) — baseline
+$docsLow = Join-Path $work "docslow"  # granted by hina (package SID) + we set its integrity label to Low
+$docsAap = Join-Path $work "docsaap"  # we grant ALL APPLICATION PACKAGES (S-1-15-2-1) via icacls
 $secret = Join-Path $work "secret"
-New-Item -ItemType Directory -Force -Path $app, $docs, $secret | Out-Null
+New-Item -ItemType Directory -Force -Path $app, $docs, $docsLow, $docsAap, $secret | Out-Null
 Set-Content -Path (Join-Path $secret "key") -Value "topsecret" -NoNewline
-# Pre-create a file INSIDE the granted docs dir so we can measure a granted-dir READ
-# separately from a granted-dir WRITE. Integrity (MIC) only blocks write-up, never
-# read-up — so if the container can READ this but not WRITE docs\out, the blocker is
-# integrity, not traversal; if it can't even read it, the blocker is traversal.
-Set-Content -Path (Join-Path $docs "readme") -Value "hello" -NoNewline
 
-# Inline cmd command (mirrors the Landlock probe's inline `sh -c`). Three measurements:
-#   RSEC = read the ungranted secret (must be 0 — isolation)
-#   RDOC = read a granted-dir file   (traverse test: 1 = reached docs)
-#   WDOC = write a granted-dir file  (must be 1 — the grant works end to end)
-# cmd.exe is in System32, reachable via ALL APPLICATION PACKAGES. /v:on so !..! expand
-# at run time. Temp paths on the runner have no spaces, so no inner quoting is needed.
+# DACLs are provably correct yet the lowbox is denied. Test the two remaining
+# hypotheses in one run:
+#   WPKG -> write a dir granted the specific package SID (baseline; currently fails)
+#   WAAP -> write a dir granted ALL APPLICATION PACKAGES (every lowbox has that group;
+#           if this works but WPKG doesn't, the token's package SID isn't matching)
+#   WLOW -> write a dir granted the package SID but whose integrity label is lowered to
+#           Low (if this works, Mandatory Integrity write-up was the blocker)
+$aap = '*S-1-15-2-1'
+# ALL APPLICATION PACKAGES: modify on docsAap + traverse (RX, this-folder-only so secret
+# doesn't inherit) on every ancestor up the chain.
+icacls $docsAap /grant "${aap}:(OI)(CI)(M)" /Q | Out-Null
+$d = $work
+while ($d) { icacls $d /grant "${aap}:(RX)" /Q | Out-Null; $p = Split-Path $d -Parent; if (-not $p -or $p -eq $d) { break }; $d = $p }
+# Lower docsLow's integrity label to Low (inheritable) so a low-IL container can write it.
+icacls $docsLow /setintegritylevel "(OI)(CI)L" /Q | Out-Null
+
 $cmdExe = Join-Path $env:SystemRoot "System32\cmd.exe"
 $stderrFile = Join-Path $work "stderr.txt"
-$inner = "set RS=0& set RD=0& set W=0& ( type $secret\key 1>nul 2>nul && set RS=1 ) & ( type $docs\readme 1>nul 2>nul && set RD=1 ) & ( echo data 1>$docs\out 2>nul && set W=1 ) & echo RSEC=!RS! RDOC=!RD! WDOC=!W!"
+$inner = "set RS=0& set WP=0& set WA=0& set WL=0& ( type $secret\key 1>nul 2>nul && set RS=1 ) & ( echo x 1>$docs\out 2>nul && set WP=1 ) & ( echo x 1>$docsAap\out 2>nul && set WA=1 ) & ( echo x 1>$docsLow\out 2>nul && set WL=1 ) & echo RSEC=!RS! WPKG=!WP! WAAP=!WA! WLOW=!WL!"
 
 $hinaArgs = @(
     'dev', 'sandbox-run', '--verbose',
     '--app-dir', $app,
     '--allow', ($docs + ':rw'),
+    '--allow', ($docsLow + ':rw'),
     '--',
     $cmdExe, '/v:on', '/c', $inner
 )
@@ -77,18 +85,12 @@ Write-Host $out
 Write-Host "---- probe stderr ----"
 Write-Host $err
 
-# Diagnostics: did the container-SID ACE actually land on docs, and is docs writable
-# at all from a normal (unsandboxed) context? Separates "grant code broken" from
-# "container cannot traverse / leaf ACE ineffective".
-Write-Host "---- icacls docs ----"
+Write-Host "---- icacls docs (package SID) ----"
 icacls $docs 2>&1 | Out-String | Write-Host
-Write-Host "---- icacls work (ancestor) ----"
-icacls $work 2>&1 | Out-String | Write-Host
-Write-Host "---- icacls temp (ancestor) ----"
-icacls (Split-Path $work -Parent) 2>&1 | Out-String | Write-Host
-Write-Host "---- unsandboxed write sanity ----"
-try { Set-Content -Path (Join-Path $docs "sanity") -Value "ok"; Write-Host "unsandboxed docs write OK" }
-catch { Write-Host "unsandboxed docs write FAILED: $_" }
+Write-Host "---- icacls docsaap (ALL APP PACKAGES) ----"
+icacls $docsAap 2>&1 | Out-String | Write-Host
+Write-Host "---- icacls docslow (Low integrity) ----"
+icacls $docsLow 2>&1 | Out-String | Write-Host
 
 $combined = "$out`n$err"
 
@@ -99,21 +101,26 @@ if ($combined -match 'cannot enforce' -or $combined -match 'running unsandboxed'
     exit 0
 }
 
-# Parse the three measurements for the diagnosis.
+# Parse the four measurements.
 $rsec = if ($combined -match 'RSEC=(\d)') { $matches[1] } else { '?' }
-$rdoc = if ($combined -match 'RDOC=(\d)') { $matches[1] } else { '?' }
-$wdoc = if ($combined -match 'WDOC=(\d)') { $matches[1] } else { '?' }
-Write-Host "---- diagnosis ---- RSEC=$rsec RDOC=$rdoc WDOC=$wdoc"
-if ($rsec -eq '0' -and $rdoc -eq '1' -and $wdoc -eq '0') {
-    Write-Host "DIAGNOSIS: container reached+read the granted dir but write was blocked -> INTEGRITY (write-up), not traversal."
-} elseif ($rsec -eq '0' -and $rdoc -eq '0') {
-    Write-Host "DIAGNOSIS: container could not even read the granted dir -> TRAVERSAL is the blocker."
+$wpkg = if ($combined -match 'WPKG=(\d)') { $matches[1] } else { '?' }
+$waap = if ($combined -match 'WAAP=(\d)') { $matches[1] } else { '?' }
+$wlow = if ($combined -match 'WLOW=(\d)') { $matches[1] } else { '?' }
+Write-Host "---- diagnosis ---- RSEC=$rsec WPKG=$wpkg WAAP=$waap WLOW=$wlow"
+if ($waap -eq '1' -and $wpkg -eq '0') {
+    Write-Host "DIAGNOSIS: ALL APPLICATION PACKAGES works but the specific package SID does not -> token package SID is not matching the granted SID."
+}
+if ($wlow -eq '1' -and $wpkg -eq '0') {
+    Write-Host "DIAGNOSIS: lowering the integrity label let the write through -> Mandatory Integrity (write-up) was the blocker."
+}
+if ($wpkg -eq '0' -and $waap -eq '0' -and $wlow -eq '0') {
+    Write-Host "DIAGNOSIS: nothing worked -> the blocker is deeper than SID matching or integrity (capability-gated FS?)."
 }
 
-if ($rsec -eq '0' -and $wdoc -eq '1') {
-    Write-Host "PASS: secret read denied, document write allowed under AppContainer."
+if ($rsec -eq '0' -and $wpkg -eq '1') {
+    Write-Host "PASS: secret read denied, package-SID-granted write allowed under AppContainer."
     exit 0
 }
 
-Write-Error "FAIL: expected RSEC=0 WDOC=1 (secret denied, docs writable). Got: RSEC=$rsec RDOC=$rdoc WDOC=$wdoc"
+Write-Error "FAIL (diagnostic run): RSEC=$rsec WPKG=$wpkg WAAP=$waap WLOW=$wlow"
 exit 1

--- a/scripts/windows-sandbox-probe.ps1
+++ b/scripts/windows-sandbox-probe.ps1
@@ -42,15 +42,21 @@ $docs = Join-Path $work "docs"
 $secret = Join-Path $work "secret"
 New-Item -ItemType Directory -Force -Path $app, $docs, $secret | Out-Null
 Set-Content -Path (Join-Path $secret "key") -Value "topsecret" -NoNewline
+# Pre-create a file INSIDE the granted docs dir so we can measure a granted-dir READ
+# separately from a granted-dir WRITE. Integrity (MIC) only blocks write-up, never
+# read-up — so if the container can READ this but not WRITE docs\out, the blocker is
+# integrity, not traversal; if it can't even read it, the blocker is traversal.
+Set-Content -Path (Join-Path $docs "readme") -Value "hello" -NoNewline
 
-# Inline cmd command (mirrors the Landlock probe's inline `sh -c`): try to read the
-# secret (must fail — secret dir is NOT granted) and write the doc (must succeed —
-# docs is granted rw), then print the verdict. cmd.exe itself is in System32, reachable
-# via the ALL APPLICATION PACKAGES ACE. /v:on so !R!/!W! expand at run time, not parse
-# time. Temp paths on the runner have no spaces, so no inner quoting is needed.
+# Inline cmd command (mirrors the Landlock probe's inline `sh -c`). Three measurements:
+#   RSEC = read the ungranted secret (must be 0 — isolation)
+#   RDOC = read a granted-dir file   (traverse test: 1 = reached docs)
+#   WDOC = write a granted-dir file  (must be 1 — the grant works end to end)
+# cmd.exe is in System32, reachable via ALL APPLICATION PACKAGES. /v:on so !..! expand
+# at run time. Temp paths on the runner have no spaces, so no inner quoting is needed.
 $cmdExe = Join-Path $env:SystemRoot "System32\cmd.exe"
 $stderrFile = Join-Path $work "stderr.txt"
-$inner = "set R=0& set W=0& ( type $secret\key 1>nul 2>nul && set R=1 ) & ( echo data 1>$docs\out 2>nul && set W=1 ) & echo READ=!R! WRITE=!W!"
+$inner = "set RS=0& set RD=0& set W=0& ( type $secret\key 1>nul 2>nul && set RS=1 ) & ( type $docs\readme 1>nul 2>nul && set RD=1 ) & ( echo data 1>$docs\out 2>nul && set W=1 ) & echo RSEC=!RS! RDOC=!RD! WDOC=!W!"
 
 $hinaArgs = @(
     'dev', 'sandbox-run', '--verbose',
@@ -89,10 +95,21 @@ if ($combined -match 'cannot enforce' -or $combined -match 'running unsandboxed'
     exit 0
 }
 
-if ($combined -match 'READ=0 WRITE=1') {
+# Parse the three measurements for the diagnosis.
+$rsec = if ($combined -match 'RSEC=(\d)') { $matches[1] } else { '?' }
+$rdoc = if ($combined -match 'RDOC=(\d)') { $matches[1] } else { '?' }
+$wdoc = if ($combined -match 'WDOC=(\d)') { $matches[1] } else { '?' }
+Write-Host "---- diagnosis ---- RSEC=$rsec RDOC=$rdoc WDOC=$wdoc"
+if ($rsec -eq '0' -and $rdoc -eq '1' -and $wdoc -eq '0') {
+    Write-Host "DIAGNOSIS: container reached+read the granted dir but write was blocked -> INTEGRITY (write-up), not traversal."
+} elseif ($rsec -eq '0' -and $rdoc -eq '0') {
+    Write-Host "DIAGNOSIS: container could not even read the granted dir -> TRAVERSAL is the blocker."
+}
+
+if ($rsec -eq '0' -and $wdoc -eq '1') {
     Write-Host "PASS: secret read denied, document write allowed under AppContainer."
     exit 0
 }
 
-Write-Error "FAIL: expected 'READ=0 WRITE=1' (secret denied, docs writable). Got: $combined"
+Write-Error "FAIL: expected RSEC=0 WDOC=1 (secret denied, docs writable). Got: RSEC=$rsec RDOC=$rdoc WDOC=$wdoc"
 exit 1

--- a/scripts/windows-sandbox-probe.ps1
+++ b/scripts/windows-sandbox-probe.ps1
@@ -82,6 +82,10 @@ Write-Host $err
 # "container cannot traverse / leaf ACE ineffective".
 Write-Host "---- icacls docs ----"
 icacls $docs 2>&1 | Out-String | Write-Host
+Write-Host "---- icacls work (ancestor) ----"
+icacls $work 2>&1 | Out-String | Write-Host
+Write-Host "---- icacls temp (ancestor) ----"
+icacls (Split-Path $work -Parent) 2>&1 | Out-String | Write-Host
 Write-Host "---- unsandboxed write sanity ----"
 try { Set-Content -Path (Join-Path $docs "sanity") -Value "ok"; Write-Host "unsandboxed docs write OK" }
 catch { Write-Host "unsandboxed docs write FAILED: $_" }

--- a/scripts/windows-sandbox-probe.ps1
+++ b/scripts/windows-sandbox-probe.ps1
@@ -71,6 +71,15 @@ Write-Host $out
 Write-Host "---- probe stderr ----"
 Write-Host $err
 
+# Diagnostics: did the container-SID ACE actually land on docs, and is docs writable
+# at all from a normal (unsandboxed) context? Separates "grant code broken" from
+# "container cannot traverse / leaf ACE ineffective".
+Write-Host "---- icacls docs ----"
+icacls $docs 2>&1 | Out-String | Write-Host
+Write-Host "---- unsandboxed write sanity ----"
+try { Set-Content -Path (Join-Path $docs "sanity") -Value "ok"; Write-Host "unsandboxed docs write OK" }
+catch { Write-Host "unsandboxed docs write FAILED: $_" }
+
 $combined = "$out`n$err"
 
 try { Remove-Item -Recurse -Force $work -ErrorAction SilentlyContinue } catch { }

--- a/scripts/windows-sandbox-probe.ps1
+++ b/scripts/windows-sandbox-probe.ps1
@@ -53,8 +53,7 @@ $stderrFile = Join-Path $work "stderr.txt"
 $inner = "set R=0& set W=0& ( type $secret\key 1>nul 2>nul && set R=1 ) & ( echo data 1>$docs\out 2>nul && set W=1 ) & echo READ=!R! WRITE=!W!"
 
 $hinaArgs = @(
-    '--verbose',
-    'dev', 'sandbox-run',
+    'dev', 'sandbox-run', '--verbose',
     '--app-dir', $app,
     '--allow', ($docs + ':rw'),
     '--',

--- a/scripts/windows-sandbox-probe.ps1
+++ b/scripts/windows-sandbox-probe.ps1
@@ -43,26 +43,33 @@ $secret = Join-Path $work "secret"
 New-Item -ItemType Directory -Force -Path $app, $docs, $secret | Out-Null
 Set-Content -Path (Join-Path $secret "key") -Value "topsecret" -NoNewline
 
-# Nothing under the profile worked (package SID / ALL APP PACKAGES / Low integrity all
-# denied) though system32 is reachable. Test whether the PATH LOCATION is the blocker:
-# grant a SHALLOW dir directly under C:\ (off the user profile, short traverse chain).
-#   WPKG  -> write the deep profile dir (baseline; currently fails)
-#   WROOT -> write the shallow C:\ dir
-# If WROOT=1 while WPKG=0, the user-profile path (runner ACLs) is the blocker, not the
-# AppContainer mechanism.
+# Even a shallow C:\ dir granted the package SID was denied — only system32 (system
+# ALL-APP-PACKAGES baseline) is reachable. Final decisive test, shallow under C:\ (which
+# is provably traversable since system32 works), using ALL APPLICATION PACKAGES (the
+# group the container demonstrably has):
+#   WAR    -> write a C:\ dir granted ALL APPLICATION PACKAGES
+#   WARLOW -> same, but with the integrity label lowered to Low
+# WAR=1 -> the mechanism works and the earlier failures were SID-matching/traversal.
+# WARLOW=1 only -> Mandatory Integrity was the blocker. Both 0 -> fundamental token
+# restriction; the AppContainer cannot honor any runtime grant -> ship NoOp + document.
+$aap = '*S-1-15-2-1'
 $rootDir = "C:\hina-sbx-" + [System.Guid]::NewGuid().ToString("N")
-$rootDocs = Join-Path $rootDir "docs"
-New-Item -ItemType Directory -Force -Path $rootDocs | Out-Null
+$rootA = Join-Path $rootDir "a"
+$rootB = Join-Path $rootDir "b"
+New-Item -ItemType Directory -Force -Path $rootA, $rootB | Out-Null
+icacls $rootDir /grant "${aap}:(RX)" /Q | Out-Null            # traverse the C:\ test root
+icacls $rootA /grant "${aap}:(OI)(CI)(M)" /Q | Out-Null
+icacls $rootB /grant "${aap}:(OI)(CI)(M)" /Q | Out-Null
+icacls $rootB /setintegritylevel "(OI)(CI)L" /Q | Out-Null
 
 $cmdExe = Join-Path $env:SystemRoot "System32\cmd.exe"
 $stderrFile = Join-Path $work "stderr.txt"
-$inner = "set RS=0& set WP=0& set WR=0& ( type $secret\key 1>nul 2>nul && set RS=1 ) & ( echo x 1>$docs\out 2>nul && set WP=1 ) & ( echo x 1>$rootDocs\out 2>nul && set WR=1 ) & echo RSEC=!RS! WPKG=!WP! WROOT=!WR!"
+$inner = "set RS=0& set WP=0& set WA=0& set WB=0& ( type $secret\key 1>nul 2>nul && set RS=1 ) & ( echo x 1>$docs\out 2>nul && set WP=1 ) & ( echo x 1>$rootA\out 2>nul && set WA=1 ) & ( echo x 1>$rootB\out 2>nul && set WB=1 ) & echo RSEC=!RS! WPKG=!WP! WAR=!WA! WARLOW=!WB!"
 
 $hinaArgs = @(
     'dev', 'sandbox-run', '--verbose',
     '--app-dir', $app,
     '--allow', ($docs + ':rw'),
-    '--allow', ($rootDocs + ':rw'),
     '--',
     $cmdExe, '/v:on', '/c', $inner
 )
@@ -78,10 +85,10 @@ Write-Host $out
 Write-Host "---- probe stderr ----"
 Write-Host $err
 
-Write-Host "---- icacls docs (deep profile) ----"
-icacls $docs 2>&1 | Out-String | Write-Host
-Write-Host "---- icacls rootDocs (shallow C:\) ----"
-icacls $rootDocs 2>&1 | Out-String | Write-Host
+Write-Host "---- icacls rootA (C:\ ALL APP PACKAGES) ----"
+icacls $rootA 2>&1 | Out-String | Write-Host
+Write-Host "---- icacls rootB (C:\ ALL APP PACKAGES + Low IL) ----"
+icacls $rootB 2>&1 | Out-String | Write-Host
 
 $combined = "$out`n$err"
 
@@ -96,20 +103,21 @@ if ($combined -match 'cannot enforce' -or $combined -match 'running unsandboxed'
 # Parse the measurements.
 $rsec = if ($combined -match 'RSEC=(\d)') { $matches[1] } else { '?' }
 $wpkg = if ($combined -match 'WPKG=(\d)') { $matches[1] } else { '?' }
-$wroot = if ($combined -match 'WROOT=(\d)') { $matches[1] } else { '?' }
-Write-Host "---- diagnosis ---- RSEC=$rsec WPKG=$wpkg WROOT=$wroot"
-if ($wroot -eq '1' -and $wpkg -eq '0') {
-    Write-Host "DIAGNOSIS: shallow C:\ dir works but the deep profile dir does not -> the user-profile path (runner ACLs) is the blocker, not the AppContainer mechanism."
-}
-if ($wroot -eq '0' -and $wpkg -eq '0') {
-    Write-Host "DIAGNOSIS: even a shallow C:\ dir is denied -> the blocker is fundamental, not path-specific."
+$war = if ($combined -match 'WAR=(\d)') { $matches[1] } else { '?' }
+$warlow = if ($combined -match 'WARLOW=(\d)') { $matches[1] } else { '?' }
+Write-Host "---- diagnosis ---- RSEC=$rsec WPKG=$wpkg WAR=$war WARLOW=$warlow"
+if ($war -eq '1') {
+    Write-Host "DIAGNOSIS: ALL APPLICATION PACKAGES write works on a shallow C:\ dir -> mechanism is fine; earlier failures were SID-matching/traversal under the profile."
+} elseif ($warlow -eq '1') {
+    Write-Host "DIAGNOSIS: only the Low-integrity dir was writable -> Mandatory Integrity (write-up) is the blocker."
+} else {
+    Write-Host "DIAGNOSIS: even ALL APPLICATION PACKAGES on a shallow C:\ dir is denied -> fundamental token restriction; the AppContainer honors no runtime grant. Recommend NoOp + documented gap."
 }
 
-# Real success: the deep profile dir is what production uses, so require WPKG=1.
 if ($rsec -eq '0' -and $wpkg -eq '1') {
     Write-Host "PASS: secret read denied, granted write allowed under AppContainer."
     exit 0
 }
 
-Write-Error "FAIL (diagnostic run): RSEC=$rsec WPKG=$wpkg WROOT=$wroot"
+Write-Error "FAIL (diagnostic run): RSEC=$rsec WPKG=$wpkg WAR=$war WARLOW=$warlow"
 exit 1

--- a/scripts/windows-sandbox-probe.ps1
+++ b/scripts/windows-sandbox-probe.ps1
@@ -38,38 +38,31 @@ if (-not (Test-Path $HinaExe)) {
 
 $work = Join-Path ([System.IO.Path]::GetTempPath()) ("hina-sbx-" + [System.Guid]::NewGuid().ToString("N"))
 $app = Join-Path $work "app"
-$docs = Join-Path $work "docs"        # granted by hina (specific package SID) — baseline
-$docsLow = Join-Path $work "docslow"  # granted by hina (package SID) + we set its integrity label to Low
-$docsAap = Join-Path $work "docsaap"  # we grant ALL APPLICATION PACKAGES (S-1-15-2-1) via icacls
+$docs = Join-Path $work "docs"        # under the deep user-profile temp tree (baseline)
 $secret = Join-Path $work "secret"
-New-Item -ItemType Directory -Force -Path $app, $docs, $docsLow, $docsAap, $secret | Out-Null
+New-Item -ItemType Directory -Force -Path $app, $docs, $secret | Out-Null
 Set-Content -Path (Join-Path $secret "key") -Value "topsecret" -NoNewline
 
-# DACLs are provably correct yet the lowbox is denied. Test the two remaining
-# hypotheses in one run:
-#   WPKG -> write a dir granted the specific package SID (baseline; currently fails)
-#   WAAP -> write a dir granted ALL APPLICATION PACKAGES (every lowbox has that group;
-#           if this works but WPKG doesn't, the token's package SID isn't matching)
-#   WLOW -> write a dir granted the package SID but whose integrity label is lowered to
-#           Low (if this works, Mandatory Integrity write-up was the blocker)
-$aap = '*S-1-15-2-1'
-# ALL APPLICATION PACKAGES: modify on docsAap + traverse (RX, this-folder-only so secret
-# doesn't inherit) on every ancestor up the chain.
-icacls $docsAap /grant "${aap}:(OI)(CI)(M)" /Q | Out-Null
-$d = $work
-while ($d) { icacls $d /grant "${aap}:(RX)" /Q | Out-Null; $p = Split-Path $d -Parent; if (-not $p -or $p -eq $d) { break }; $d = $p }
-# Lower docsLow's integrity label to Low (inheritable) so a low-IL container can write it.
-icacls $docsLow /setintegritylevel "(OI)(CI)L" /Q | Out-Null
+# Nothing under the profile worked (package SID / ALL APP PACKAGES / Low integrity all
+# denied) though system32 is reachable. Test whether the PATH LOCATION is the blocker:
+# grant a SHALLOW dir directly under C:\ (off the user profile, short traverse chain).
+#   WPKG  -> write the deep profile dir (baseline; currently fails)
+#   WROOT -> write the shallow C:\ dir
+# If WROOT=1 while WPKG=0, the user-profile path (runner ACLs) is the blocker, not the
+# AppContainer mechanism.
+$rootDir = "C:\hina-sbx-" + [System.Guid]::NewGuid().ToString("N")
+$rootDocs = Join-Path $rootDir "docs"
+New-Item -ItemType Directory -Force -Path $rootDocs | Out-Null
 
 $cmdExe = Join-Path $env:SystemRoot "System32\cmd.exe"
 $stderrFile = Join-Path $work "stderr.txt"
-$inner = "set RS=0& set WP=0& set WA=0& set WL=0& ( type $secret\key 1>nul 2>nul && set RS=1 ) & ( echo x 1>$docs\out 2>nul && set WP=1 ) & ( echo x 1>$docsAap\out 2>nul && set WA=1 ) & ( echo x 1>$docsLow\out 2>nul && set WL=1 ) & echo RSEC=!RS! WPKG=!WP! WAAP=!WA! WLOW=!WL!"
+$inner = "set RS=0& set WP=0& set WR=0& ( type $secret\key 1>nul 2>nul && set RS=1 ) & ( echo x 1>$docs\out 2>nul && set WP=1 ) & ( echo x 1>$rootDocs\out 2>nul && set WR=1 ) & echo RSEC=!RS! WPKG=!WP! WROOT=!WR!"
 
 $hinaArgs = @(
     'dev', 'sandbox-run', '--verbose',
     '--app-dir', $app,
     '--allow', ($docs + ':rw'),
-    '--allow', ($docsLow + ':rw'),
+    '--allow', ($rootDocs + ':rw'),
     '--',
     $cmdExe, '/v:on', '/c', $inner
 )
@@ -85,42 +78,38 @@ Write-Host $out
 Write-Host "---- probe stderr ----"
 Write-Host $err
 
-Write-Host "---- icacls docs (package SID) ----"
+Write-Host "---- icacls docs (deep profile) ----"
 icacls $docs 2>&1 | Out-String | Write-Host
-Write-Host "---- icacls docsaap (ALL APP PACKAGES) ----"
-icacls $docsAap 2>&1 | Out-String | Write-Host
-Write-Host "---- icacls docslow (Low integrity) ----"
-icacls $docsLow 2>&1 | Out-String | Write-Host
+Write-Host "---- icacls rootDocs (shallow C:\) ----"
+icacls $rootDocs 2>&1 | Out-String | Write-Host
 
 $combined = "$out`n$err"
 
 try { Remove-Item -Recurse -Force $work -ErrorAction SilentlyContinue } catch { }
+try { Remove-Item -Recurse -Force $rootDir -ErrorAction SilentlyContinue } catch { }
 
 if ($combined -match 'cannot enforce' -or $combined -match 'running unsandboxed') {
     Write-Host "SKIP: AppContainer not available on this host; passing."
     exit 0
 }
 
-# Parse the four measurements.
+# Parse the measurements.
 $rsec = if ($combined -match 'RSEC=(\d)') { $matches[1] } else { '?' }
 $wpkg = if ($combined -match 'WPKG=(\d)') { $matches[1] } else { '?' }
-$waap = if ($combined -match 'WAAP=(\d)') { $matches[1] } else { '?' }
-$wlow = if ($combined -match 'WLOW=(\d)') { $matches[1] } else { '?' }
-Write-Host "---- diagnosis ---- RSEC=$rsec WPKG=$wpkg WAAP=$waap WLOW=$wlow"
-if ($waap -eq '1' -and $wpkg -eq '0') {
-    Write-Host "DIAGNOSIS: ALL APPLICATION PACKAGES works but the specific package SID does not -> token package SID is not matching the granted SID."
+$wroot = if ($combined -match 'WROOT=(\d)') { $matches[1] } else { '?' }
+Write-Host "---- diagnosis ---- RSEC=$rsec WPKG=$wpkg WROOT=$wroot"
+if ($wroot -eq '1' -and $wpkg -eq '0') {
+    Write-Host "DIAGNOSIS: shallow C:\ dir works but the deep profile dir does not -> the user-profile path (runner ACLs) is the blocker, not the AppContainer mechanism."
 }
-if ($wlow -eq '1' -and $wpkg -eq '0') {
-    Write-Host "DIAGNOSIS: lowering the integrity label let the write through -> Mandatory Integrity (write-up) was the blocker."
-}
-if ($wpkg -eq '0' -and $waap -eq '0' -and $wlow -eq '0') {
-    Write-Host "DIAGNOSIS: nothing worked -> the blocker is deeper than SID matching or integrity (capability-gated FS?)."
+if ($wroot -eq '0' -and $wpkg -eq '0') {
+    Write-Host "DIAGNOSIS: even a shallow C:\ dir is denied -> the blocker is fundamental, not path-specific."
 }
 
+# Real success: the deep profile dir is what production uses, so require WPKG=1.
 if ($rsec -eq '0' -and $wpkg -eq '1') {
-    Write-Host "PASS: secret read denied, package-SID-granted write allowed under AppContainer."
+    Write-Host "PASS: secret read denied, granted write allowed under AppContainer."
     exit 0
 }
 
-Write-Error "FAIL (diagnostic run): RSEC=$rsec WPKG=$wpkg WAAP=$waap WLOW=$wlow"
+Write-Error "FAIL (diagnostic run): RSEC=$rsec WPKG=$wpkg WROOT=$wroot"
 exit 1

--- a/scripts/windows-sandbox-probe.ps1
+++ b/scripts/windows-sandbox-probe.ps1
@@ -4,21 +4,15 @@
 
 .DESCRIPTION
   The Windows analogue of scripts/landlock-probe.sh. Runs a child (cmd.exe) under a
-  Hina AppContainer sandbox that grants ONLY:
-    - the app dir (read+execute, so the container can read its own files)
-    - a "documents" dir (read-write)
-  and NOTHING else. It deliberately does NOT grant a "secret" dir.
+  Hina sandbox that grants ONLY a "documents" dir (read-write) and deliberately NOT a
+  "secret" dir. Under real enforcement the child must be DENIED reading the secret and
+  ALLOWED writing the document — i.e. READ=0 WRITE=1.
 
-  Under real AppContainer enforcement the child must be DENIED reading the secret
-  (the secret dir's DACL grants no AppContainer/package SID) and ALLOWED writing the
-  document (its DACL has an explicit container-SID ACE) — i.e. READ=0 WRITE=1.
-
-  System DLL dirs (System32, where cmd.exe lives) are reachable because they already
-  carry an ALL APPLICATION PACKAGES ACE — which is exactly why we don't ACL them.
-
-  On a host where AppContainer is unavailable Hina logs that it is running unsandboxed
-  and the child sees READ=1 WRITE=1; the probe then SKIP-passes so CI stays green on
-  runners without AppContainer (mirrors the Landlock probe's behaviour on old kernels).
+  STATUS: Windows currently uses NoOp (the AppContainer backend is implemented but
+  unverified — see WindowsSandbox.cs). With NoOp, Hina logs that it is running
+  unsandboxed; this probe then SKIP-passes so CI stays green, mirroring the Landlock
+  probe's behaviour on a host without Landlock. If the AppContainer backend is wired in
+  later, this probe becomes its real end-to-end enforcement check with no changes.
 
 .PARAMETER HinaExe
   Path to the built Hina.CLI executable.
@@ -38,36 +32,20 @@ if (-not (Test-Path $HinaExe)) {
 
 $work = Join-Path ([System.IO.Path]::GetTempPath()) ("hina-sbx-" + [System.Guid]::NewGuid().ToString("N"))
 $app = Join-Path $work "app"
-$docs = Join-Path $work "docs"        # under the deep user-profile temp tree (baseline)
+$docs = Join-Path $work "docs"
 $secret = Join-Path $work "secret"
 New-Item -ItemType Directory -Force -Path $app, $docs, $secret | Out-Null
 Set-Content -Path (Join-Path $secret "key") -Value "topsecret" -NoNewline
 
-# Even a shallow C:\ dir granted the package SID was denied — only system32 (system
-# ALL-APP-PACKAGES baseline) is reachable. Final decisive test, shallow under C:\ (which
-# is provably traversable since system32 works), using ALL APPLICATION PACKAGES (the
-# group the container demonstrably has):
-#   WAR    -> write a C:\ dir granted ALL APPLICATION PACKAGES
-#   WARLOW -> same, but with the integrity label lowered to Low
-# WAR=1 -> the mechanism works and the earlier failures were SID-matching/traversal.
-# WARLOW=1 only -> Mandatory Integrity was the blocker. Both 0 -> fundamental token
-# restriction; the AppContainer cannot honor any runtime grant -> ship NoOp + document.
-$aap = '*S-1-15-2-1'
-$rootDir = "C:\hina-sbx-" + [System.Guid]::NewGuid().ToString("N")
-$rootA = Join-Path $rootDir "a"
-$rootB = Join-Path $rootDir "b"
-New-Item -ItemType Directory -Force -Path $rootA, $rootB | Out-Null
-icacls $rootDir /grant "${aap}:(RX)" /Q | Out-Null            # traverse the C:\ test root
-icacls $rootA /grant "${aap}:(OI)(CI)(M)" /Q | Out-Null
-icacls $rootB /grant "${aap}:(OI)(CI)(M)" /Q | Out-Null
-icacls $rootB /setintegritylevel "(OI)(CI)L" /Q | Out-Null
-
+# Inline cmd (mirrors the Landlock probe's inline `sh -c`): try to read the ungranted
+# secret (must fail) and write the granted doc (must succeed). cmd.exe is in System32,
+# reachable via ALL APPLICATION PACKAGES. /v:on so !..! expand at run time.
 $cmdExe = Join-Path $env:SystemRoot "System32\cmd.exe"
 $stderrFile = Join-Path $work "stderr.txt"
-$inner = "set RS=0& set WP=0& set WA=0& set WB=0& ( type $secret\key 1>nul 2>nul && set RS=1 ) & ( echo x 1>$docs\out 2>nul && set WP=1 ) & ( echo x 1>$rootA\out 2>nul && set WA=1 ) & ( echo x 1>$rootB\out 2>nul && set WB=1 ) & echo RSEC=!RS! WPKG=!WP! WAR=!WA! WARLOW=!WB!"
+$inner = "set R=0& set W=0& ( type $secret\key 1>nul 2>nul && set R=1 ) & ( echo data 1>$docs\out 2>nul && set W=1 ) & echo READ=!R! WRITE=!W!"
 
 $hinaArgs = @(
-    'dev', 'sandbox-run', '--verbose',
+    'dev', 'sandbox-run',
     '--app-dir', $app,
     '--allow', ($docs + ':rw'),
     '--',
@@ -85,39 +63,19 @@ Write-Host $out
 Write-Host "---- probe stderr ----"
 Write-Host $err
 
-Write-Host "---- icacls rootA (C:\ ALL APP PACKAGES) ----"
-icacls $rootA 2>&1 | Out-String | Write-Host
-Write-Host "---- icacls rootB (C:\ ALL APP PACKAGES + Low IL) ----"
-icacls $rootB 2>&1 | Out-String | Write-Host
-
 $combined = "$out`n$err"
 
 try { Remove-Item -Recurse -Force $work -ErrorAction SilentlyContinue } catch { }
-try { Remove-Item -Recurse -Force $rootDir -ErrorAction SilentlyContinue } catch { }
 
 if ($combined -match 'cannot enforce' -or $combined -match 'running unsandboxed') {
-    Write-Host "SKIP: AppContainer not available on this host; passing."
+    Write-Host "SKIP: filesystem sandbox not enforced on this host (Windows uses NoOp today); passing."
     exit 0
 }
 
-# Parse the measurements.
-$rsec = if ($combined -match 'RSEC=(\d)') { $matches[1] } else { '?' }
-$wpkg = if ($combined -match 'WPKG=(\d)') { $matches[1] } else { '?' }
-$war = if ($combined -match 'WAR=(\d)') { $matches[1] } else { '?' }
-$warlow = if ($combined -match 'WARLOW=(\d)') { $matches[1] } else { '?' }
-Write-Host "---- diagnosis ---- RSEC=$rsec WPKG=$wpkg WAR=$war WARLOW=$warlow"
-if ($war -eq '1') {
-    Write-Host "DIAGNOSIS: ALL APPLICATION PACKAGES write works on a shallow C:\ dir -> mechanism is fine; earlier failures were SID-matching/traversal under the profile."
-} elseif ($warlow -eq '1') {
-    Write-Host "DIAGNOSIS: only the Low-integrity dir was writable -> Mandatory Integrity (write-up) is the blocker."
-} else {
-    Write-Host "DIAGNOSIS: even ALL APPLICATION PACKAGES on a shallow C:\ dir is denied -> fundamental token restriction; the AppContainer honors no runtime grant. Recommend NoOp + documented gap."
-}
-
-if ($rsec -eq '0' -and $wpkg -eq '1') {
-    Write-Host "PASS: secret read denied, granted write allowed under AppContainer."
+if ($combined -match 'READ=0 WRITE=1') {
+    Write-Host "PASS: secret read denied, document write allowed under the sandbox."
     exit 0
 }
 
-Write-Error "FAIL (diagnostic run): RSEC=$rsec WPKG=$wpkg WAR=$war WARLOW=$warlow"
+Write-Error "FAIL: expected 'READ=0 WRITE=1' (secret denied, docs writable). Got: $combined"
 exit 1


### PR DESCRIPTION
Investigates a Windows filesystem-sandbox backend (AppContainer). **Outcome: Windows stays on NoOp** — the backend is implemented and its ACL plumbing is proven correct, but the lowbox honors no runtime access grant, so wiring it in would break app launches. Per the project rule (never ship a backend that *looks* like it isolates but doesn't), it is left as a documented experimental scaffold for whoever resumes on a real Windows box.

## What landed (kept)
- **`WindowsAppContainerPolicy`** (pure, 9 host tests) + **`WindowsSandbox`** AppContainer backend via AOT-safe `[DllImport]` P/Invoke — present but **NOT selected by `SandboxLauncherFactory`** (clear EXPERIMENTAL header with findings).
- **`WindowsLaunchOverride.Parse`** (pure, tested) + 4-arg `CreateMenuShortcut` `.lnk` routing + `ShellLink.SetArguments` — correct, kept (dormant on Windows since enforcement is off).
- New **`windows-sandbox`** CI job + `scripts/windows-sandbox-probe.ps1` — SKIP-passes under NoOp, becomes the real enforcement proof unchanged if the backend is ever wired in.
- Test suite hardened to run green on a real Windows runner for the first time (5 pre-existing Unix-assuming tests gated/fixed).

## What the CI probe proved (on real windows-latest, via icacls + --verbose)
- ✅ ACL plumbing correct: every container-SID grant + ancestor `FILE_TRAVERSE` lands on disk; user/Admin/SYSTEM ACEs preserved.
- ✅ Isolation works: an ungranted secret dir is denied.
- ❌ But the lowbox honored **no** runtime grant for actual access — a granted dir was neither readable nor writable whether granted the package SID **or** `ALL APPLICATION PACKAGES` (the group the token provably has — it runs cmd.exe from System32 through it), integrity lowered to Low or not, deep `%TEMP%` path or shallow `C:\` path. Only the System32 baseline was reachable.

Leading hypothesis: over-restricted token (process integrity / restricting-SID set) — needs Process Explorer on a real Windows machine to confirm and fix (the macOS dev host can't run or debug AppContainer; only the CI probe gives signal). See `docs/Windows-Sandbox-Design.md` for the full investigation and next step.

## Honest state
`InstallService.sandboxEnforceable` = Linux || OSX; Windows install-time disclosure warns the app runs unsandboxed. Docs (Security, PackageManager-Guide, Windows-Sandbox-Design) state Windows is declared-not-enforced. 449 tests green, AOT clean, all 3 CI jobs green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)