### PR TITLE
docs: Mermaid diagrams companion (architecture, class, pipelines, sandbox-per-OS)

### DIFF
--- a/docs/Architecture.md
+++ b/docs/Architecture.md
@@ -20,14 +20,7 @@ Hina is organized into five projects plus two test projects:
 
 ### Dependency Graph
 
-```
-Hina.CLI ------------------> Hina.PackageManager ----> Hina.Core
-Hina.CLI ------------------> Hina.Core                 (also direct, for `hina dev`)
-Hina.Builder --------------> Hina.Core
-Hina.Host                     (standalone, serves static files)
-Hina.Core.Tests -----------> Hina.Core
-Hina.PackageManager.Tests -> Hina.PackageManager + Hina.Core
-```
+> 📊 Rendered: [System architecture](Diagrams.md#system-architecture) in [Diagrams.md](Diagrams.md).
 
 `Hina.CLI` references both `Hina.PackageManager` (for the top-level package commands)
 and `Hina.Core` directly (for the patcher subcommands surfaced under `hina dev`).
@@ -243,7 +236,12 @@ threads `MaxRetries`, `MaxRetryDelayMs`, `ConnectTimeoutMs`, and
 
 ### Sandbox/
 
-Optional Flatpak-style filesystem isolation. v1 enforces **filesystem scope only**, on **Linux/Landlock only**; declared non-filesystem capabilities are surfaced but not enforced, and there are no portals.
+Optional Flatpak-style filesystem isolation. Filesystem scope (and the `network`
+capability) is **enforced on Linux (Landlock) and macOS (Seatbelt)**; **Windows is NoOp**
+(an unwired experimental AppContainer backend exists — see
+[Windows-Sandbox-Resume.md](Windows-Sandbox-Resume.md)). The other declared capabilities
+are surfaced but not enforced, and there are no portals. See the rendered
+[sandbox isolation per OS](Diagrams.md#sandbox--container-isolation-per-os) diagrams.
 
 The architecture mirrors `Platform/`: a per-OS interface (`ISandboxLauncher`) with a factory that selects one implementation. The pivot is that **Hina becomes the launcher for sandboxed apps** — their shell shortcut's launch command points at `hina run <app> <entry>` instead of the app binary, so `hina run` can build the filesystem plan and install the sandbox before the app starts. Non-sandboxed apps continue to launch their binary directly.
 
@@ -255,8 +253,10 @@ The architecture mirrors `Platform/`: a per-OS interface (`ISandboxLauncher`) wi
 | `SandboxPaths` | `Resolve(token, appDir, env)` maps a `SandboxTokens` value to an absolute path. Returns `null` for `host` (means "no restriction", not a path) and for unknown tokens (already rejected by `DescriptorValidator`). |
 | `ISandboxLauncher` | Per-OS launcher: `bool IsSupported` + `int Launch(execAbs, appArgs, plan, ct)`. A backend MAY replace the current process image (`execv`) rather than spawn a child — in that case `Launch` returns only on exec failure. |
 | `LinuxLandlockSandbox` | Linux backend (kernel 5.13+). Unprivileged P/Invoke into `landlock_create_ruleset` / `landlock_add_rule` / `landlock_restrict_self` plus `prctl(NO_NEW_PRIVS)`, then `execv`. Builds a ruleset that denies every filesystem access right the running ABI knows and grants back only the resolved paths; restrictions apply to `hina` itself and are inherited across `execv`, so the sandboxed app's PID is hina's. ABI-probed; any failure logs a warning and execs unsandboxed — it never blocks a launch. |
-| `NoOpSandbox` | Fallback for macOS, Windows, or a too-old Linux kernel. Spawns the app and waits; warns once if the plan asked for real scoping it cannot enforce. `IsSupported` is `false`. |
-| `SandboxLauncherFactory` | `Current(logger)` returns `LinuxLandlockSandbox` when on Linux and supported, otherwise `NoOpSandbox`. |
+| `MacOsSandbox` / `MacOsSeatbeltProfile` | macOS backend. `MacOsSeatbeltProfile.Build` generates a Seatbelt `.sb` profile from the plan (deny-default, `bsd.sb` import, system read baseline, plan rules `ro`→read / `rw`→+write, network unless `RestrictNetwork`); `MacOsSandbox` canonicalizes paths and launches the app as a **child** under `sandbox-exec -f <profile>`, cleaning up the temp profile on exit. |
+| `WindowsSandbox` | Windows AppContainer backend — **EXPERIMENTAL, not wired into the factory**. The ACL plumbing is correct but the lowbox denied all granted access on CI; Windows stays NoOp until debugged on a real Windows box. See [Windows-Sandbox-Resume.md](Windows-Sandbox-Resume.md). |
+| `NoOpSandbox` | Fallback for Windows or a too-old Linux kernel (no `sandbox-exec`/Landlock). Spawns the app and waits; warns once if the plan asked for real scoping it cannot enforce. `IsSupported` is `false`. |
+| `SandboxLauncherFactory` | `Current(logger)` returns `LinuxLandlockSandbox` on Linux (when supported), `MacOsSandbox` on macOS, otherwise `NoOpSandbox` (Windows + unsupported hosts). |
 | `AppPermissions` | Pure flat view of one app's permissions, folded from the cached descriptor (declared scope + capabilities) and the registry row (`UserGrants`). No I/O. Drives `hina perms`. |
 | `PermissionsFormatter` | Renders `AppPermissions` as the `hina perms` table (all apps) and detail (one app). Every non-filesystem capability is rendered with a "declared — not enforced" caveat. |
 | `SandboxDiff` | `Compute(oldSpec, newSpec)` → `{ Broadened, Added, Removed }`. A null/disabled sandbox means "unsandboxed = full access", so dropping or loosening a sandbox broadens (needs consent) while enabling or tightening it narrows (applies silently). Drives the update-flow permission-consent gate (a broadening update fails unless re-run with `--accept-new-permissions`). |
@@ -271,241 +271,44 @@ The descriptor wire model for the sandbox lives in `Descriptor/`: `SandboxSpec` 
 
 The builder (`Hina.Builder`) takes a directory of application files and produces a manifest and chunk store.
 
-```
- Input directory (game/app files)
-         |
-         v
- [1] Enumerate all files recursively
-         |
-         v
- [2] For each file:
-     +-- Open FileStream
-     +-- Chunk the file (IChunker: RsyncChunker or ContentDefinedChunker)
-     |   +-- Compute rolling checksum (weak) for each chunk
-     |   +-- Compute SHA-256 hash (strong) for each chunk
-     +-- Compute full-file SHA-256 hash
-     +-- Produce ManifestFile with chunk list
-         |
-         v
- [3] Assemble Manifest object
-     +-- Set Version, BaseUrl, BuildId
-     +-- Attach ManifestFile entries
-         |
-         v
- [4] (Optional) Sign manifest with Ed25519 private key
-     +-- Serialize manifest without signature to canonical JSON
-     +-- Sign canonical bytes with NSec Ed25519
-     +-- Attach ManifestSignature (algorithm, signature, public key)
-         |
-         v
- [5] Write manifest.json to output directory
-         |
-         v
- [6] Write chunks to output/chunks/ directory
-     +-- For each chunk, Brotli-compress the raw bytes
-     +-- Store as chunks/<bucket>/<hash>.chunk.br
-     +-- Bucket = first 2 hex characters of hash
-     +-- Deduplicate: skip if file already exists
-         |
-         v
- Output: manifest.json + chunks/ directory
-```
+> 📊 Rendered: [Build pipeline](Diagrams.md#build-pipeline-hinabuilder) in [Diagrams.md](Diagrams.md).
 
 ### Client Patch Pipeline
 
 The client (`PatchClient`) downloads the manifest, matches local data, and applies changes.
 
-```
- [1] Fetch manifest.json from server
-     +-- URL: <BaseUrl>/manifest.json (or manifest.<channel>.json)
-     +-- Retry with exponential backoff on transient errors
-         |
-         v
- [2] Verify Ed25519 signature (if TrustedPublicKey is configured)
-     +-- Serialize manifest without signature to canonical JSON
-     +-- Verify signature against trusted public key
-     +-- Reject patch if verification fails
-         |
-         v
- [3] Check for incomplete previous patch
-     +-- Load journal from .hina/journal.json
-     +-- If found, rollback previous patch first
-         |
-         v
- [4] Create new PatchJournal
-         |
-         v
- [5] For each file in manifest:
-     +-- Compute local file hash
-     +-- Skip if hash matches (already up to date)
-     +-- Build weak checksum lookup table from manifest chunks
-     +-- Rsync match: slide rolling checksum window over local file
-     |   +-- On weak match, compute strong hash to confirm
-     |   +-- Record matched chunks with their local file offsets
-     +-- Rebuild file to temp path (.hina.tmp):
-     |   +-- For matched chunks: copy bytes from local file
-     |   +-- For missing chunks: download from server
-     |       +-- URL: <BaseUrl>/chunks/<bucket>/<hash>.chunk.br
-     |       +-- Decompress Brotli, write to output
-     +-- Verify rebuilt file hash against manifest
-     +-- Backup original file (.hina.bak) if Backup is enabled
-     +-- Record backup in journal
-     +-- Swap temp file into place
-         |
-         v
- [6] On success: mark journal as "Completed"
-     On failure: rollback all files from backups, mark journal as "Failed"
-```
+> 📊 Rendered: [Client patch pipeline](Diagrams.md#client-patch-pipeline-patchclient) in [Diagrams.md](Diagrams.md).
 
 ### Rollback Flow
 
-```
- [1] Load journal from .hina/journal.json
- [2] For each journal entry:
-     +-- Copy .hina.bak back to original path
-     +-- Delete .hina.bak
- [3] Delete journal file
-```
+> 📊 Rendered: [Rollback flow](Diagrams.md#rollback-flow) in [Diagrams.md](Diagrams.md).
 
 ### Cleanup Flow
 
-```
- [1] Recursively scan target directory
- [2] Delete all *.hina.tmp files
- [3] Delete all *.hina.bak files
- [4] Delete .hina/journal.json
-```
+> 📊 Rendered: [Cleanup flow](Diagrams.md#cleanup-flow) in [Diagrams.md](Diagrams.md).
 
 ### Install Flow (Hina.PackageManager)
 
-```
- hina install <url-to-hina.app.json>
-        |
- [1] DescriptorFetcher.FetchAsync (5 MB cap, 30s timeout)
-        |
- [2] DescriptorParser.Parse (source-gen JSON)
-        |
- [3] DescriptorValidator.Validate (name/SemVer/HTTPS/no path traversal/entry refs)
-        |
- [4] DescriptorSigner.Verify against descriptor.publicKey
-        |
- [5] TOFU prompt: publisher + Ed25519 fingerprint → user accept/reject
-        |
- [6] LockManager.AcquireAsync (registry-wide exclusive)
-        |
- [7] If already installed → abort, suggest reinstall/update
-        |
- [8] Create InstallPaths.AppDir(name) (must be empty)
-        |
- [9] PatchClient.PatchAsync(appDir) — downloads chunks, verifies manifest signature with descriptor.publicKey
-        |
- [10] Sanity check: descriptor.Exec[os] exists on disk
-        |
- [11] CreateMenuShortcut for each entry → record evidence
-      (sandboxed app → launchOverride "hina run <name> <entry>"; else direct binary)
-        |
- [12] HookExecutor.ApplyAsync in declared order → record HookEvidence
-        |
- [13] Cache descriptor FIRST via AtomicFile.WriteAllText, THEN commit registry entry.
-      A crash between the two leaves a cache with no registry row (harmless) rather
-      than a registry row with no cache (would break run/perms/update).
-        |
- [14] Release lock
-
- On any exception in [8]-[13]: InstallTransaction.RollbackAsync unwinds
- in reverse — hooks undone, shortcuts removed, AppDir deleted, registry untouched.
-```
+> 📊 Rendered: [Install flow](Diagrams.md#install-flow-installservice) in [Diagrams.md](Diagrams.md).
 
 ### Update Flow (Hina.PackageManager)
 
-```
- hina update [name]
-        |
- For each app (one or all):
-        |
- [1] Re-fetch descriptor from registry.descriptorUrl
-        |
- [2] Validate; verify signature against REGISTRY publicKey (pin)
-     A mismatch is a potential key-rotation attack → fail unless --rotate-key
-     (handled by ReinstallService, not UpdateService)
-        |
- [3] If descriptor.version == registry.installedVersion and not --force,
-     return AlreadyUpToDate
-        |
- [4] Compute diffs by stable identity:
-        hooksToAdd      = descriptor.postInstall  \  registry.executedHooks
-        hooksToRemove   = registry.executedHooks  \  descriptor.postInstall
-        entriesToAdd / entriesToRemove similarly (by entry.id)
-        |
- [5] Snapshot pre-update registry entry
-        |
- [5a] SandboxDiff.Compute(oldDescriptor.sandbox, newDescriptor.sandbox)
-      If it BROADENS access (new paths, host, ro→rw, new capability, or sandbox
-      dropped) and not --accept-new-permissions → fail BEFORE touching disk
-        |
- [6] PatchClient.PatchAsync(appDir, Backup=true)
-     On failure → PatchClient.RollbackAsync + restore registry snapshot
-        |
- [7] Apply hooksToRemove (Undo), entriesToRemove
- [8] Apply hooksToAdd, entriesToAdd
-        |
- [9] Update registry: installedVersion, lastUpdatedAt, hooks, entries
- [10] Refresh descriptor cache
-```
+> 📊 Rendered: [Update flow](Diagrams.md#update-flow-updateservice) in [Diagrams.md](Diagrams.md).
 
 ### Uninstall Flow (Hina.PackageManager)
 
-```
- hina uninstall <name>
-        |
- [1] LockManager.AcquireAsync
- [2] Load registry; missing app → exit 0 (idempotent)
- [3] For each entry in registry.executedHooks (REVERSE order):
-        HookExecutor.UndoAsync(evidence)            fail-soft
- [4] For each entry in registry.shellEntries:
-        Platform.RemoveMenuShortcut(evidence)        fail-soft
- [5] Delete AppDir recursively                       fail-soft
- [6] Delete DescriptorCache(name)                    fail-soft
- [7] Remove app from registry, write atomically
- [8] Release lock
-
- Critical: hook side-effects are read from the registry, NEVER from
- the live descriptor — a newer descriptor might list different hooks.
-```
+> 📊 Rendered: [Uninstall flow](Diagrams.md#uninstall-flow-uninstallservice) in [Diagrams.md](Diagrams.md).
 
 ### Run Flow (Hina.PackageManager)
 
 The launch chokepoint. A sandboxed app's shell shortcut runs `hina run` instead of
 the app binary, so the filesystem sandbox is installed before the app starts.
 
-```
- hina run <app> [entryId] [-- appArgs...]
-        |
- [1] Load registry; app missing → error
- [2] AppDir missing → error (suggest reinstall)
- [3] Read cached descriptor; missing/corrupt → error
-     (NEVER launch unsandboxed without the descriptor — that would silently drop isolation)
-        |
- [4] Resolve the entry's exec (entryId → entries[]; else entries[0]; else Exec[os])
-     Resolved exec missing on disk → error
-        |
- [5] Build the plan:
-        sandbox.Enabled → SandboxPlanner.Build(spec, app.UserGrants, appDir, SandboxEnv.FromSystem())
-        else            → SandboxPlan(Unrestricted: true)
-        |
- [6] SandboxLauncherFactory.Current(logger).Launch(execAbs, appArgs, plan, ct)
-     Linux+supported → Landlock installs the ruleset then execv's the app (app PID = hina PID)
-     else            → spawn + wait (warns once if scoping was requested but unenforceable)
-```
+> 📊 Rendered: [Run flow](Diagrams.md#run-flow-runcommand--the-launch-chokepoint) in [Diagrams.md](Diagrams.md).
 
 ### Permissions Flow (Hina.PackageManager)
 
-```
- hina perms                          → table of every app's permissions
- hina perms <app>                    → detail for one app
- hina perms <app> --grant <path>[:ro|:rw]   → add a runtime FsGrant   (takes the registry lock)
- hina perms <app> --revoke <path>           → remove a runtime FsGrant (takes the registry lock)
-```
+> 📊 Rendered: [Permissions flow](Diagrams.md#permissions-flow-hina-perms--verify) in [Diagrams.md](Diagrams.md).
 
 `AppPermissions.From(cachedDescriptor, registryRow)` folds the declared sandbox scope
 and the registry `UserGrants` into a flat view; `PermissionsFormatter` renders it.
@@ -525,110 +328,7 @@ manual sandbox probing.
 
 ## Class Diagram
 
-```
-+---------------------+        +----------------------+
-|    IPatchClient      |        |     IChunker         |
-|---------------------|        |----------------------|
-| + Config            |        | + ChunkAsync()       |
-| + CheckAsync()      |        +----------+-----------+
-| + PatchAsync()      |                   |
-| + VerifyAsync()     |          +--------+--------+
-| + RollbackAsync()   |          |                 |
-+----------+----------+   +------+------+   +------+-------+
-           |              | RsyncChunker|   | ContentDefined|
-           |              |             |   | Chunker       |
-+----------+----------+  +------+------+   +------+--------+
-|    PatchClient       |         |                 |
-|---------------------|         |                 |
-| - _hasher: IHasher  |         v                 v
-| - _http             |  +------+------+   +------+--------+
-| - _logger           |  | Rolling     |   | Gear hash     |
-| + Config            |  | Checksum    |   | boundary      |
-| + CheckAsync()      |  | (Adler32)   |   | detection     |
-| + PatchAsync()      |  +-------------+   +---------------+
-| + VerifyAsync()     |
-| + RollbackAsync()   |
-| - RsyncMatchLocal() |
-| - VerifyManifest()  |
-+---------+-----------+
-          |
-          | uses
-          v
-+---------+-----------+    +-------------------+
-|  HttpChunkClient    |--->|   RetryPolicy     |
-|---------------------|    |-------------------|
-| + GetManifestAsync()|    | - _maxRetries     |
-| + GetChunkAsync()   |    | - _baseDelayMs    |
-+---------------------+    | + ExecuteAsync()  |
-                           | + CalculateDelay()|
-                           | + IsTransient()   |
-                           +-------------------+
-
-+---------+-----------+    +-------------------+
-|     IHasher         |    |  ManifestSigner   |
-|---------------------|    |-------------------|
-| + AlgorithmId       |    | + AttachSignature |
-| + ComputeHashAsync()|    | + Verify()        |
-+----------+----------+    +-------------------+
-           |
-+----------+----------+    +-------------------+
-|   Sha256Hasher       |    |  BrotliCodec      |
-|---------------------|    |-------------------|
-| + AlgorithmId="sha256"|  | + Compress()      |
-| + ComputeHashAsync()|    | + Decompress()    |
-+---------------------+    +-------------------+
-
-+---------------------+    +-------------------+
-|  ManifestBuilder     |    | ChunkStoreWriter  |
-|---------------------|    |-------------------|
-| - _hasher           |    | - _hasher         |
-| + BuildAsync()      |    | - _chunkSize      |
-+---------------------+    | - _chunker        |
-                           | + WriteChunksAsync |
-+---------------------+    +-------------------+
-|   PatchJournal       |
-|---------------------|    +-------------------+
-| + Status            |    |  PatcherConfig    |
-| + CreatedUtc        |    |-------------------|
-| + Entries           |    | + BaseUrl         |
-| + Load()            |    | + Channel         |
-| + SaveAsync()       |    | + Concurrency     |
-+---------------------+    | + ChunkSize       |
-                           | + Verify, Backup  |
-+---------------------+    | + TrustedPublicKey|
-|   Manifest           |    | + MaxRetries      |
-|---------------------|    | + RetryBaseDelayMs|
-| + Version           |    | + ChunkingMode    |
-| + BuildId           |    | + MinChunkSize    |
-| + BaseUrl           |    | + MaxChunkSize    |
-| + Files             |    | + AvgChunkSize    |
-| + Signature         |    +-------------------+
-+---------------------+
-          |
-          | contains
-          v
-+---------------------+
-|   ManifestFile       |
-|---------------------|
-| + Path              |
-| + Size              |
-| + MTimeUtc          |
-| + FileHash          |
-| + ChunkSize         |
-| + Chunks            |
-+----------+----------+
-           |
-           | contains
-           v
-+----------+----------+
-|   ManifestChunk      |
-|---------------------|
-| + Index             |
-| + Weak (uint)       |
-| + Strong (string)   |
-| + Size              |
-+---------------------+
-```
+> 📊 Rendered: [Class diagram](Diagrams.md#class-diagram--core--patching) in [Diagrams.md](Diagrams.md).
 
 ---
 

--- a/docs/Diagrams.md
+++ b/docs/Diagrams.md
@@ -1,0 +1,562 @@
+# Diagrams
+
+The visual companion to [Architecture.md](Architecture.md): the project graph, class
+diagrams, every data-flow pipeline, and the sandbox / container-isolation flow per OS —
+all in [Mermaid](https://mermaid.js.org/) (GitHub renders these natively). This file is
+the single source of truth for diagrams; the prose docs link here.
+
+Sandbox state reflected below (current code): filesystem + network are **enforced on
+Linux (Landlock) and macOS (Seatbelt)**; **Windows is NoOp** (an unwired, experimental
+AppContainer backend exists — see [Windows-Sandbox-Resume.md](Windows-Sandbox-Resume.md)).
+
+## Table of contents
+
+- [System architecture](#system-architecture)
+- [CLI command routing](#cli-command-routing)
+- [Class diagram — Core / patching](#class-diagram--core--patching)
+- [Class diagram — PackageManager](#class-diagram--packagemanager)
+- [Class diagram — Sandbox](#class-diagram--sandbox)
+- [Pipelines](#pipelines) — Build, Client Patch, Rollback, Cleanup, Install, Update, Uninstall, Run, Permissions
+- [Sandbox / container isolation per OS](#sandbox--container-isolation-per-os)
+
+---
+
+## System architecture
+
+The five shipped projects plus two test projects and their references. `Hina.CLI`
+references both `Hina.PackageManager` (top-level commands) and `Hina.Core` directly
+(the `hina dev` patcher subcommands). `Hina.PackageManager` reuses
+`Hina.Core.PatchClient` for delta downloads — there is no parallel engine.
+
+```mermaid
+graph LR
+    CLI["Hina.CLI<br/>(NativeAOT console)"]
+    PM["Hina.PackageManager<br/>(library)"]
+    Core["Hina.Core<br/>(library: patch engine)"]
+    Builder["Hina.Builder<br/>(console)"]
+    Host["Hina.Host<br/>(ASP.NET static server)"]
+    CoreT["Hina.Core.Tests"]
+    PMT["Hina.PackageManager.Tests"]
+
+    CLI --> PM
+    CLI --> Core
+    PM --> Core
+    Builder --> Core
+    PMT --> PM
+    PMT --> Core
+    CoreT --> Core
+    Host -.->|"serves chunks/manifests"| Core
+
+    classDef ship fill:#dbeafe,stroke:#1e40af,color:#1e3a8a;
+    classDef test fill:#f3f4f6,stroke:#9ca3af,color:#374151;
+    class CLI,PM,Core,Builder,Host ship;
+    class CoreT,PMT test;
+```
+
+---
+
+## CLI command routing
+
+`Program.Main` parses global flags (`--verbose`, `--version`, `help`) then hands off to
+`CommandRouter`, which dispatches on the first arg to a command that calls into a
+`Hina.PackageManager` service (or `Hina.Core` for `hina dev`). Source:
+`Hina.CLI/Program.cs`, `Hina.CLI/CommandRouter.cs`, `Hina.CLI/Commands/*`.
+
+```mermaid
+flowchart TD
+    P["Program.Main(args)"] --> R{"CommandRouter<br/>dispatch on args[0]"}
+    R -->|install| INS["InstallService"]
+    R -->|update| UPD["UpdateService"]
+    R -->|reinstall| REI["ReinstallService"]
+    R -->|uninstall| UNI["UninstallService"]
+    R -->|run| RUN["RunCommand → SandboxPlanner + SandboxLauncherFactory"]
+    R -->|"perms / permissions / permessi"| PER["PermsCommand → AppPermissions / PermissionsFormatter"]
+    R -->|"verify / repair"| VER["RegistryVerifier"]
+    R -->|"list / info / which"| RO["read-only registry / descriptor cache"]
+    R -->|dev| DEV["DevCommand: check / patch / verify / rollback / cleanup / sign-descriptor / sandbox-run"]
+    DEV --> CoreEngine["Hina.Core.PatchClient / DescriptorSigner / SandboxLauncherFactory"]
+```
+
+---
+
+## Class diagram — Core / patching
+
+The patch engine in `Hina.Core`. `PatchClient` implements `IPatchClient`, drives an
+`IChunker` + `IHasher`, fetches via `HttpChunkClient` (with `RetryPolicy`), and journals
+backups in `PatchJournal`. `ManifestSigner` signs/verifies the `Manifest` tree.
+
+```mermaid
+classDiagram
+    class IPatchClient {
+        <<interface>>
+        +CheckAsync()
+        +PatchAsync()
+        +VerifyAsync()
+        +RollbackAsync()
+    }
+    class PatchClient {
+        -IHasher _hasher
+        -HttpChunkClient _http
+        -RsyncMatchLocal()
+        -VerifyManifest()
+    }
+    class IChunker {
+        <<interface>>
+        +ChunkAsync()
+    }
+    class RsyncChunker
+    class ContentDefinedChunker
+    class IHasher {
+        <<interface>>
+        +AlgorithmId
+        +ComputeHashAsync()
+    }
+    class Sha256Hasher
+    class HttpChunkClient {
+        +GetManifestAsync()
+        +GetChunkAsync()
+    }
+    class RetryPolicy {
+        +ExecuteAsync()
+        +IsTransient()
+    }
+    class PatchJournal {
+        +Status
+        +Entries
+    }
+    class Manifest {
+        +Version
+        +BuildId
+        +Files
+        +Signature
+    }
+    class ManifestFile
+    class ManifestChunk
+    class ManifestSigner {
+        +AttachSignature()
+        +Verify()
+    }
+
+    IPatchClient <|.. PatchClient
+    IChunker <|.. RsyncChunker
+    IChunker <|.. ContentDefinedChunker
+    IHasher <|.. Sha256Hasher
+    PatchClient --> IChunker : uses
+    PatchClient --> IHasher : uses
+    PatchClient --> HttpChunkClient : uses
+    PatchClient --> PatchJournal : journals
+    HttpChunkClient --> RetryPolicy : retries with
+    PatchClient ..> Manifest : matches against
+    Manifest "1" --> "*" ManifestFile : contains
+    ManifestFile "1" --> "*" ManifestChunk : contains
+    ManifestSigner ..> Manifest : signs / verifies
+```
+
+---
+
+## Class diagram — PackageManager
+
+The package-manager layer. The install/update/uninstall/reinstall services orchestrate
+`DescriptorFetcher`/`Validator`/`Signer`, the `RegistryStore`, the `HookExecutor`, and
+the per-OS `IPlatformIntegration`; `InstallTransaction` journals side-effects for
+rollback. The services reuse `Hina.Core.PatchClient` for the actual file delta.
+
+```mermaid
+classDiagram
+    class InstallService
+    class UpdateService
+    class UninstallService
+    class ReinstallService
+    class InstallTransaction {
+        +RollbackAsync()
+    }
+    class DescriptorFetcher
+    class DescriptorValidator
+    class DescriptorSigner
+    class AppDescriptor {
+        +Name
+        +Version
+        +Exec
+        +Entries
+        +PostInstall
+        +Sandbox
+    }
+    class RegistryStore {
+        +LoadAsync()
+        +SaveAsync()
+    }
+    class Registry
+    class InstalledApp {
+        +InstallPath
+        +ExecutedHooks
+        +ShellEntries
+        +UserGrants
+    }
+    class HookExecutor {
+        +ApplyAsync()
+        +UndoAsync()
+    }
+    class IPlatformIntegration {
+        <<interface>>
+        +CreateMenuShortcut()
+        +RegisterMimeType()
+        +InstallFont()
+    }
+    class LinuxPlatformIntegration
+    class MacOSPlatformIntegration
+    class WindowsPlatformIntegration
+    class PlatformIntegrationFactory
+
+    InstallService --> DescriptorFetcher : fetch
+    InstallService --> DescriptorValidator : validate
+    InstallService --> DescriptorSigner : verify
+    InstallService --> RegistryStore : commit
+    InstallService --> HookExecutor : apply
+    InstallService --> InstallTransaction : journals
+    UpdateService --> RegistryStore
+    UninstallService --> HookExecutor : undo
+    ReinstallService --> InstallService
+    ReinstallService --> UninstallService
+    DescriptorFetcher ..> AppDescriptor : produces
+    RegistryStore --> Registry
+    Registry "1" --> "*" InstalledApp
+    HookExecutor --> IPlatformIntegration : dispatches to
+    IPlatformIntegration <|.. LinuxPlatformIntegration
+    IPlatformIntegration <|.. MacOSPlatformIntegration
+    IPlatformIntegration <|.. WindowsPlatformIntegration
+    PlatformIntegrationFactory ..> IPlatformIntegration : selects per OS
+```
+
+---
+
+## Class diagram — Sandbox
+
+The sandbox subsystem mirrors `Platform/`: a per-OS `ISandboxLauncher` chosen by
+`SandboxLauncherFactory`. `SandboxPlanner` folds the descriptor scope + user grants into
+a `SandboxPlan` (resolving abstract `SandboxTokens` to absolute paths via `SandboxEnv` /
+`SandboxPaths`). `AppPermissions` / `PermissionsFormatter` drive `hina perms`;
+`SandboxDiff` drives the update-consent gate.
+
+```mermaid
+classDiagram
+    class ISandboxLauncher {
+        <<interface>>
+        +bool IsSupported
+        +int Launch(execAbs, appArgs, plan, ct)
+    }
+    class LinuxLandlockSandbox
+    class MacOsSandbox
+    class WindowsSandbox
+    class NoOpSandbox
+    class SandboxLauncherFactory {
+        +Current(logger) ISandboxLauncher
+    }
+    class MacOsSeatbeltProfile {
+        +Build(plan) string
+    }
+    class SandboxPlanner {
+        +Build(spec, grants, appDir, env) SandboxPlan
+    }
+    class SandboxPlan {
+        +bool Unrestricted
+        +IReadOnlyList~ResolvedFsRule~ Rules
+        +bool RestrictNetwork
+    }
+    class ResolvedFsRule {
+        +string Path
+        +bool CanWrite
+    }
+    class SandboxEnv
+    class SandboxPaths
+    class SandboxTokens
+    class AppPermissions
+    class PermissionsFormatter
+    class SandboxDiff {
+        +Compute(oldSpec, newSpec)
+    }
+
+    ISandboxLauncher <|.. LinuxLandlockSandbox
+    ISandboxLauncher <|.. MacOsSandbox
+    ISandboxLauncher <|.. WindowsSandbox
+    ISandboxLauncher <|.. NoOpSandbox
+    SandboxLauncherFactory ..> ISandboxLauncher : Linux→Landlock, macOS→MacOs, else NoOp
+    MacOsSandbox --> MacOsSeatbeltProfile : generates .sb
+    SandboxPlanner --> SandboxPlan : produces
+    SandboxPlan "1" --> "*" ResolvedFsRule
+    SandboxPlanner ..> SandboxPaths : resolves tokens
+    SandboxPaths ..> SandboxEnv : roots
+    SandboxPaths ..> SandboxTokens : closed set
+    ISandboxLauncher ..> SandboxPlan : consumes
+    AppPermissions ..> PermissionsFormatter : rendered by
+```
+
+---
+
+## Pipelines
+
+Faithful flowchart versions of the nine data-flow pipelines described in prose in
+[Architecture.md](Architecture.md). Step numbers match the prose.
+
+### Build pipeline (`Hina.Builder`)
+
+```mermaid
+flowchart TD
+    A["Input directory (app/game files)"] --> B["1. Enumerate files recursively"]
+    B --> C["2. Per file: chunk (IChunker)<br/>weak rolling + strong SHA-256 per chunk<br/>+ full-file SHA-256 → ManifestFile"]
+    C --> D["3. Assemble Manifest (Version, BaseUrl, BuildId, Files)"]
+    D --> E["4. Optional: Ed25519-sign canonical manifest bytes"]
+    E --> F["5. Write manifest.json"]
+    F --> G["6. Brotli-compress chunks → chunks/&lt;bucket&gt;/&lt;hash&gt;.chunk.br<br/>(bucket = first 2 hex of hash; dedup)"]
+    G --> H["Output: manifest.json + chunks/"]
+```
+
+### Client patch pipeline (`PatchClient`)
+
+```mermaid
+flowchart TD
+    A["1. Fetch manifest.json (retry w/ backoff)"] --> B["2. Verify Ed25519 signature (if pinned key)"]
+    B --> C{"3. Incomplete previous patch?<br/>(.hina/journal.json)"}
+    C -->|yes| C1["Rollback previous patch first"] --> D
+    C -->|no| D["4. Create new PatchJournal"]
+    D --> E["5. Per file: hash local"]
+    E --> F{"hash matches manifest?"}
+    F -->|yes| E
+    F -->|no| G["Rsync match: slide rolling checksum;<br/>confirm weak hits with strong hash"]
+    G --> H["Rebuild to .hina.tmp:<br/>matched chunks copied locally,<br/>missing chunks downloaded + Brotli-decompressed"]
+    H --> I["Verify rebuilt hash; backup → .hina.bak; swap into place"]
+    I --> E
+    E --> J{"all files done?"}
+    J -->|success| K["6. Mark journal Completed"]
+    J -->|failure| L["Rollback from backups; mark journal Failed"]
+```
+
+### Rollback flow
+
+```mermaid
+flowchart TD
+    A["1. Load .hina/journal.json"] --> B["2. Per entry: copy .hina.bak → original; delete .hina.bak"]
+    B --> C["3. Delete journal file"]
+```
+
+### Cleanup flow
+
+```mermaid
+flowchart TD
+    A["1. Recursively scan target dir"] --> B["2. Delete *.hina.tmp"]
+    B --> C["3. Delete *.hina.bak"]
+    C --> D["4. Delete .hina/journal.json"]
+```
+
+### Install flow (`InstallService`)
+
+```mermaid
+flowchart TD
+    S["hina install &lt;url-to-hina.app.json&gt;"] --> A1["1. DescriptorFetcher.FetchAsync (5 MB cap, 30s)"]
+    A1 --> A2["2. DescriptorParser.Parse"]
+    A2 --> A3["3. DescriptorValidator.Validate<br/>(name / SemVer / HTTPS / no traversal / entry refs)"]
+    A3 --> A4["4. DescriptorSigner.Verify vs descriptor.publicKey"]
+    A4 --> A5["5. TOFU prompt: publisher + Ed25519 fingerprint"]
+    A5 --> A6["6. LockManager.AcquireAsync"]
+    A6 --> A7{"7. already installed?"}
+    A7 -->|yes| A7x["abort → suggest reinstall/update"]
+    A7 -->|no| A8["8. Create empty AppDir"]
+    A8 --> A9["9. PatchClient.PatchAsync (verifies manifest sig)"]
+    A9 --> A10["10. Sanity: Exec[os] exists on disk"]
+    A10 --> A11["11. CreateMenuShortcut per entry<br/>(sandboxed → launchOverride 'hina run'; else binary)"]
+    A11 --> A12["12. HookExecutor.ApplyAsync in order → HookEvidence"]
+    A12 --> A13["13. Cache descriptor (AtomicFile) THEN commit registry"]
+    A13 --> A14["14. Release lock"]
+    A8 -.->|"exception in 8-13"| RB["InstallTransaction.RollbackAsync<br/>(unwind in reverse; registry untouched)"]
+    A13 -.->|exception| RB
+```
+
+### Update flow (`UpdateService`)
+
+```mermaid
+flowchart TD
+    S["hina update [name]"] --> B1["1. Re-fetch descriptor from registry.descriptorUrl"]
+    B1 --> B2["2. Validate + verify sig vs REGISTRY pinned key<br/>(mismatch = possible key rotation → fail, needs reinstall --rotate-key)"]
+    B2 --> B3{"3. version unchanged and not --force?"}
+    B3 -->|yes| B3x["AlreadyUpToDate"]
+    B3 -->|no| B4["4. Diff hooks + entries by stable identity (add / remove)"]
+    B4 --> B5["5. Snapshot pre-update registry row"]
+    B5 --> B5a{"5a. SandboxDiff broadens access<br/>and not --accept-new-permissions?"}
+    B5a -->|yes| B5x["fail BEFORE touching disk"]
+    B5a -->|no| B6["6. PatchClient.PatchAsync (Backup=true)<br/>fail → Rollback + restore registry snapshot"]
+    B6 --> B7["7. Apply removals (hooks Undo, entries)"]
+    B7 --> B8["8. Apply additions (hooks, entries)"]
+    B8 --> B9["9. Update registry (version, hooks, entries)"]
+    B9 --> B10["10. Refresh descriptor cache"]
+```
+
+### Uninstall flow (`UninstallService`)
+
+```mermaid
+flowchart TD
+    S["hina uninstall &lt;name&gt;"] --> C1["1. LockManager.AcquireAsync"]
+    C1 --> C2{"2. app present?"}
+    C2 -->|no| C2x["exit 0 (idempotent)"]
+    C2 -->|yes| C3["3. HookExecutor.UndoAsync per hook, REVERSE order (fail-soft)"]
+    C3 --> C4["4. Platform.RemoveMenuShortcut per entry (fail-soft)"]
+    C4 --> C5["5. Delete AppDir (fail-soft)"]
+    C5 --> C6["6. Delete descriptor cache (fail-soft)"]
+    C6 --> C7["7. Remove from registry, write atomically"]
+    C7 --> C8["8. Release lock"]
+```
+
+> Hook side-effects are read from the **registry**, never the live descriptor (a newer
+> descriptor might list different hooks).
+
+### Run flow (`RunCommand` — the launch chokepoint)
+
+```mermaid
+flowchart TD
+    S["hina run &lt;app&gt; [entryId] [-- appArgs]"] --> D1["1-2. Load registry; AppDir present?"]
+    D1 --> D3["3. Read cached descriptor<br/>(missing/corrupt → error; NEVER launch unsandboxed without it)"]
+    D3 --> D4["4. Resolve exec (entryId → entries[]; else entries[0]; else Exec[os])"]
+    D4 --> D5{"5. sandbox.Enabled?"}
+    D5 -->|yes| D5a["SandboxPlanner.Build(spec, UserGrants, appDir, SandboxEnv.FromSystem())"]
+    D5 -->|no| D5b["SandboxPlan(Unrestricted: true)"]
+    D5a --> D6["6. SandboxLauncherFactory.Current(logger).Launch(...)"]
+    D5b --> D6
+    D6 --> OS["per-OS backend (see below)"]
+```
+
+### Permissions flow (`hina perms` / `verify`)
+
+```mermaid
+flowchart TD
+    P1["hina perms"] --> T["table of every app's permissions"]
+    P2["hina perms &lt;app&gt;"] --> Dt["detail for one app"]
+    P3["hina perms &lt;app&gt; --grant &lt;path&gt;[:ro|:rw]"] --> G["add runtime FsGrant (registry lock)"]
+    P4["hina perms &lt;app&gt; --revoke &lt;path&gt;"] --> Rv["remove runtime FsGrant (registry lock)"]
+    T --- AP["AppPermissions.From(cachedDescriptor, registryRow)<br/>→ PermissionsFormatter<br/>(filesystem enforced; other caps 'declared — not enforced')"]
+    Dt --- AP
+    V["hina verify [--repair] [--deep]"] --> RV["RegistryVerifier: orphans + local integrity<br/>(--repair prunes; --deep hashes vs manifest)"]
+```
+
+---
+
+## Sandbox / container isolation per OS
+
+How a sandboxed app launches and gets isolated. The shell shortcut runs
+`hina run <app> <entry>` instead of the binary, so Hina builds the plan and installs
+the sandbox **before** the app starts.
+
+### Master launch + isolate flow
+
+```mermaid
+flowchart TD
+    SC["Shell shortcut / hina run &lt;app&gt; &lt;entry&gt;"] --> DESC["Load cached descriptor"]
+    DESC --> EN{"sandbox.Enabled?"}
+    EN -->|no| UNR["SandboxPlan(Unrestricted)"]
+    EN -->|yes| PLAN["SandboxPlanner.Build"]
+    PLAN --> P1["fold: declared FsRules + user FsGrants + always-ro app dir"]
+    P1 --> P2["resolve tokens via SandboxEnv / SandboxPaths<br/>(app, home, xdg-documents, xdg-download, xdg-config, tmp, host)"]
+    P2 --> P3["host → Unrestricted; duplicate path → rw wins"]
+    P3 --> SP["SandboxPlan { Unrestricted, Rules[], RestrictNetwork }"]
+    UNR --> SP
+    SP --> F{"SandboxLauncherFactory.Current"}
+    F -->|"Linux + Landlock supported"| LX["LinuxLandlockSandbox"]
+    F -->|macOS| MAC["MacOsSandbox"]
+    F -->|"Windows / unsupported / old kernel"| NOP["NoOpSandbox"]
+    LX --> LXD["see Linux detail"]
+    MAC --> MACD["see macOS detail"]
+    NOP --> NOPD["see Windows detail"]
+```
+
+### Linux — Landlock (enforced)
+
+Applies the ruleset to `hina` itself, then `execv`s the app, which inherits the
+restrictions — the sandboxed app's PID **is** hina's. Any failure warns and execs
+unsandboxed; it never blocks a launch.
+
+```mermaid
+flowchart TD
+    A["LinuxLandlockSandbox.Launch"] --> B{"plan.Unrestricted or ABI unsupported?"}
+    B -->|yes| Bx["execv app directly (warn if scope was requested)"]
+    B -->|no| C["Probe Landlock ABI"]
+    C --> D["Build ruleset: deny every fs access right the ABI knows"]
+    D --> E["Grant resolved plan paths + SystemRuntimePaths<br/>(loader/libc/dev nodes so the app can start)"]
+    E --> N{"RestrictNetwork and ABI ≥ 4?"}
+    N -->|yes| N1["handle TCP bind+connect with no allow rules → denied"]
+    N -->|no| N2["network not restricted (logged on old ABI)"]
+    N1 --> F["prctl(NO_NEW_PRIVS)"]
+    N2 --> F
+    F --> G["landlock_restrict_self"]
+    G --> H["execv app — inherits ruleset (app PID = hina PID)"]
+```
+
+### macOS — Seatbelt / sandbox-exec (enforced)
+
+Generates a Seatbelt profile from the plan and launches the app as a **child** under
+`sandbox-exec -f`, so the temp profile can be cleaned up after exit.
+
+```mermaid
+flowchart TD
+    A["MacOsSandbox.Launch"] --> B{"plan.Unrestricted or no sandbox-exec?"}
+    B -->|yes| Bx["spawn app directly"]
+    B -->|no| C["Canonicalize plan paths (realpath; /tmp,/var,/etc → /private/...)"]
+    C --> D["MacOsSeatbeltProfile.Build → .sb:<br/>import bsd.sb, deny default, exec/fork,<br/>system read baseline, plan rules (ro→read, rw→+write),<br/>network unless RestrictNetwork"]
+    D --> E["Write temp .sb profile"]
+    E --> F["sandbox-exec -f &lt;profile&gt; &lt;exec&gt; — child process"]
+    F --> G["Wait for exit → delete temp profile"]
+```
+
+### Windows — NoOp today (AppContainer scaffold, unwired)
+
+The factory returns `NoOpSandbox` on Windows: the app runs unsandboxed with a one-time
+warning. The `WindowsSandbox` AppContainer backend exists but is **not selected** — its
+lowbox honored no runtime grant on CI (full investigation in
+[Windows-Sandbox-Resume.md](Windows-Sandbox-Resume.md)).
+
+```mermaid
+flowchart TD
+    A["SandboxLauncherFactory on Windows"] --> B["NoOpSandbox.Launch"]
+    B --> C["spawn app + wait (warn once if scope was requested)"]
+    A -.->|"NOT selected (experimental)"| X["WindowsSandbox.Launch (AppContainer)"]
+    X -.->|"dashed = unwired"| X1["CreateAppContainerProfile → container SID"]
+    X1 -.-> X2["Grant ACEs (container SID) on app dir + plan rules<br/>+ FILE_TRAVERSE on ancestors"]
+    X2 -.-> X3["CreateProcess + SECURITY_CAPABILITIES"]
+    X3 -.-> X4["BLOCKED: lowbox denies all granted access on CI<br/>→ kept NoOp until debugged on real Windows"]
+```
+
+### Shortcut routing per OS
+
+How the install-time shortcut is wired so launches route through `hina run` (and thus
+the sandbox) on the enforcing OSes.
+
+```mermaid
+flowchart LR
+    O["Sandboxed app installed"] --> L[".desktop (Linux)<br/>Exec = hina run &lt;app&gt; &lt;entry&gt;"]
+    O --> M[".app bundle (macOS)<br/>stub script: exec hina run ..."]
+    O --> W[".lnk (Windows)<br/>4-arg routing exists, but enforcement OFF<br/>→ points at the binary"]
+    L --> LE["Landlock enforced"]
+    M --> ME["Seatbelt enforced"]
+    W --> WE["NoOp (unsandboxed + warn)"]
+```
+
+### Sequence — one sandboxed launch
+
+```mermaid
+sequenceDiagram
+    actor User
+    participant Shell
+    participant Run as hina run
+    participant Planner as SandboxPlanner
+    participant Factory as SandboxLauncherFactory
+    participant Backend as ISandboxLauncher
+    participant App
+
+    User->>Shell: click shortcut
+    Shell->>Run: hina run <app> <entry>
+    Run->>Run: load cached descriptor, resolve exec
+    Run->>Planner: Build(spec, userGrants, appDir, env)
+    Planner-->>Run: SandboxPlan
+    Run->>Factory: Current(logger)
+    Factory-->>Run: backend for this OS
+    Run->>Backend: Launch(execAbs, args, plan, ct)
+    Note over Backend: Linux=Landlock+execv · macOS=sandbox-exec child · Windows=NoOp
+    Backend->>App: start under isolation
+    App-->>User: app window (scoped to granted paths)
+```

--- a/docs/Home.md
+++ b/docs/Home.md
@@ -7,6 +7,7 @@ Hina is an open-source cross-platform package manager and rsync-like patcher for
 ## Table of Contents
 
 - [Architecture](Architecture.md) -- Project structure, core library internals, package-manager layer, data flow, class diagrams, and design decisions.
+- [Diagrams](Diagrams.md) -- Rendered Mermaid diagrams: architecture graph, CLI routing, class diagrams, every pipeline, and the sandbox/container isolation flow per OS.
 - [Install Script](Install-Script.md) -- The `curl | bash` / `iwr | iex` one-liner: capabilities, env vars, atomic install + rollback, SHA-256 verification, existing-install menu (reinstall / clean / integrity / uninstall), and a flow diagram.
 - [Package Manager Guide](PackageManager-Guide.md) -- End-user CLI (`hina install/update/uninstall`), descriptor schema, whitelisted hooks, TOFU + signature chain, per-OS install paths.
 - [Configuration](Configuration.md) -- Complete reference for all configuration properties, file resolution, host config, and environment-specific examples.
@@ -32,7 +33,7 @@ Hina is an open-source cross-platform package manager and rsync-like patcher for
 - Cross-platform package manager: `hina install <url>` / `update` / `uninstall` / `list` on Windows, Linux, macOS
 - Whitelisted declarative hooks (PATH symlink, MIME, URL scheme, font, autostart), all user-scope (no admin)
 - Ed25519 signed descriptors with TOFU on first install and pinned-key verification on update
-- Optional [filesystem sandboxing](Security.md) for apps that opt in — enforced on Linux via Landlock (`hina run`), declared-but-not-enforced on macOS/Windows
+- Optional [filesystem sandboxing](Security.md) for apps that opt in — enforced on Linux (Landlock) and macOS (Seatbelt) via `hina run`, declared-but-not-enforced on Windows
 - [`hina perms`](Security.md) to inspect declared scope/capabilities and grant or revoke filesystem paths per app
 - Update [permission consent](Security.md): an update that broadens an app's sandbox is refused until `--accept-new-permissions`
 - Integrity tooling: `hina verify` checks installed files against the descriptor, `verify --deep` hash-verifies every file against the manifest (see [Troubleshooting](Troubleshooting.md))


### PR DESCRIPTION
Adds **`docs/Diagrams.md`** — the visual companion the docs were missing. Answers "were the diagrams lost?": no, they were never authored in Mermaid (Architecture.md had only ASCII; Install-Script.md had the one Mermaid block).

## What's in Diagrams.md (20 Mermaid diagrams, all validated with `mermaid-cli`)
- System architecture + project dependency graph
- CLI command routing
- Class diagrams: Core/patching, PackageManager, Sandbox
- All 9 data-flow pipelines (Build, Client Patch, Rollback, Cleanup, Install, Update, Uninstall, Run, Permissions)
- **Sandbox / container isolation per OS**: master launch+isolate flow → per-OS detail (Linux Landlock `execv`-inherit, macOS Seatbelt child, Windows NoOp + the dashed unwired AppContainer scaffold), shortcut routing per OS, and a launch sequence diagram

## Doc hygiene
- `Architecture.md`: the ASCII diagrams are replaced with one-line links into `Diagrams.md` (single source of truth, avoids drift); the **stale Sandbox prose** is corrected to the current reality (Linux+macOS enforced, Windows NoOp + experimental scaffold) and macOS/Windows backend rows added.
- `Home.md`: adds the Diagrams TOC entry; fixes the stale "macOS not enforced" line.
- All 12 `Architecture.md → Diagrams.md` anchor links verified to resolve.

Docs only — no code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)