### PR TITLE
release: v1.3.1 (help fix)

### DIFF
--- a/Hina.PackageManager/Install/HinaVersion.cs
+++ b/Hina.PackageManager/Install/HinaVersion.cs
@@ -12,7 +12,7 @@ namespace Hina.PackageManager.Install
         // Single source of truth for the running version. The release tag MUST equal
         // "v" + this value (release.yml verifies it), so `hina version`, `hina check-update`,
         // and the published GitHub tag never drift.
-        public const string Current = "1.3.0";
+        public const string Current = "1.3.1";
 
         // True if running version >= required minimum. Both sides parsed as SemVer
         // major.minor.patch; pre-release / build-metadata suffix is tolerated but

--- a/docs/Changelog.md
+++ b/docs/Changelog.md
@@ -4,6 +4,13 @@ All notable changes to Hina are documented in this file.
 
 ---
 
+## v1.3.1 — help fix
+
+- `hina` with no args now lists the sandbox-era verbs **run**, **perms**, and
+  **repair** in the main help (they were missing from `Help.PrintMain`).
+
+---
+
 ## v1.3.0 — macOS & network enforcement, tech debt, Windows investigation
 
 Builds on the v1.2.0 sandbox (Linux/Landlock, filesystem-only) by enforcing on a


### PR DESCRIPTION
Patch: bump 1.3.0 → **1.3.1**. Ships the help fix (PR #11 — run/perms/repair now listed) in the published artifacts. Merge → tag v1.3.1 → release.yml.

🤖 Generated with [Claude Code](https://claude.com/claude-code)