### PR TITLE
fix: handle 5 user-triggerable edge cases (uninstall leak, silent CLI input, corrupt registry)

### DIFF
--- a/Hina.CLI.Tests/ArgsTests.cs
+++ b/Hina.CLI.Tests/ArgsTests.cs
@@ -43,5 +43,29 @@ namespace Hina.CLI.Tests
             string[] args = { "update", "--jobs", "4" };
             Assert.Null(Args.FirstPositional(args, startIndex: 1));
         }
+
+        [Fact]
+        public void FirstUnknownFlag_DetectsTypo()
+        {
+            // `--allow-insecue` is a typo of `--allow-insecure`; it must be surfaced, not
+            // silently ignored (a dropped `--allow-insecure` would change security behavior).
+            var known = new System.Collections.Generic.HashSet<string>(System.StringComparer.OrdinalIgnoreCase)
+            {
+                "--allow-insecure"
+            };
+            string[] args = { "install", "https://example.com/a.json", "--allow-insecue" };
+            Assert.Equal("--allow-insecue", Args.FirstUnknownFlag(args, known, startIndex: 1));
+        }
+
+        [Fact]
+        public void FirstUnknownFlag_AllKnown_ReturnsNull()
+        {
+            var known = new System.Collections.Generic.HashSet<string>(System.StringComparer.OrdinalIgnoreCase)
+            {
+                "--allow-insecure", "--retries"
+            };
+            string[] args = { "install", "https://example.com/a.json", "--allow-insecure", "--retries", "3" };
+            Assert.Null(Args.FirstUnknownFlag(args, known, startIndex: 1));
+        }
     }
 }

--- a/Hina.CLI.Tests/CommandRouterTests.cs
+++ b/Hina.CLI.Tests/CommandRouterTests.cs
@@ -36,6 +36,25 @@ namespace Hina.CLI.Tests
 
         private Task<int> Dispatch(params string[] args) => CommandRouter.DispatchAsync(Ctx(), args);
 
+        private async Task SeedApp(string name)
+        {
+            InstallPaths paths = InstallPaths.ForRoot(_root);
+            Registry registry = new Registry();
+            registry.Apps[name] = new InstalledApp
+            {
+                Name = name,
+                InstalledVersion = "1.0.0",
+                InstallPath = Path.Combine(paths.AppsRoot, name),
+                DescriptorUrl = "https://example.com/hina.app.json",
+                BaseUrl = "https://example.com",
+                Channel = "stable",
+                PublicKey = "AAAA",
+                InstalledAt = DateTimeOffset.UnixEpoch,
+                LastUpdatedAt = DateTimeOffset.UnixEpoch
+            };
+            await new RegistryStore(paths.RegistryFile).SaveAsync(registry);
+        }
+
         [Fact]
         public async Task UnknownCommand_ReturnsUsageError()
         {
@@ -152,6 +171,23 @@ namespace Hina.CLI.Tests
         public async Task Perms_UnknownApp_ReturnsNotFound()
         {
             Assert.Equal(1, await Dispatch("perms", "ghost"));
+        }
+
+        [Fact]
+        public async Task Perms_GrantFlagWithoutValue_ReturnsUsageError()
+        {
+            // `hina perms <app> --grant` (no path) previously fell through to the read-only
+            // detail view and silently dropped the mutation. It must be a usage error.
+            await SeedApp("demo");
+            Assert.Equal(2, await Dispatch("perms", "demo", "--grant"));
+        }
+
+        [Fact]
+        public async Task Uninstall_UnknownFlag_ReturnsUsageError()
+        {
+            // `uninstall` takes no flags; a typo must be rejected, not silently ignored
+            // (which would otherwise exit 0 as "was not installed").
+            Assert.Equal(2, await Dispatch("uninstall", "ghost", "--bogus"));
         }
 
         [Fact]

--- a/Hina.CLI.Tests/NetworkArgsTests.cs
+++ b/Hina.CLI.Tests/NetworkArgsTests.cs
@@ -1,0 +1,39 @@
+using System;
+using Hina.CLI.Commands;
+using Hina.PackageManager.Install;
+using Xunit;
+
+namespace Hina.CLI.Tests
+{
+    // A network-tuning flag passed with a bad value used to be silently dropped and the engine
+    // default used instead — `--retries 0`, `--retries -5`, `--retries abc` all looked honored
+    // while doing nothing. NetworkArgs now fails loudly when a flag is present but not a
+    // positive integer; an absent flag still falls back to the default.
+    public sealed class NetworkArgsTests
+    {
+        [Fact]
+        public void FromArgs_FlagAbsent_UsesDefault()
+        {
+            NetworkOptions defaults = new NetworkOptions();
+            NetworkOptions opts = NetworkArgs.FromArgs(new[] { "install", "https://e.com/a.json" });
+            Assert.Equal(defaults.MaxRetries, opts.MaxRetries);
+        }
+
+        [Fact]
+        public void FromArgs_ValidRetries_IsHonored()
+        {
+            NetworkOptions opts = NetworkArgs.FromArgs(new[] { "install", "https://e.com/a.json", "--retries", "5" });
+            Assert.Equal(5, opts.MaxRetries);
+        }
+
+        [Theory]
+        [InlineData("abc")]
+        [InlineData("0")]
+        [InlineData("-5")]
+        public void FromArgs_InvalidRetries_Throws(string value)
+        {
+            Assert.Throws<FormatException>(() =>
+                NetworkArgs.FromArgs(new[] { "install", "https://e.com/a.json", "--retries", value }));
+        }
+    }
+}

--- a/Hina.CLI/Args.cs
+++ b/Hina.CLI/Args.cs
@@ -11,7 +11,8 @@ namespace Hina.CLI
             new(StringComparer.OrdinalIgnoreCase)
             {
                 "--in", "--key", "--out", "--dir", "--base", "--config", "--pubkey",
-                "--channel", "--jobs", "--retries", "--connect-timeout", "--request-timeout"
+                "--channel", "--jobs", "--retries", "--connect-timeout", "--request-timeout",
+                "--grant", "--revoke"
             };
 
         public static bool HasFlag(string[] args, string name)
@@ -28,6 +29,21 @@ namespace Hina.CLI
             for (int i = 0; i < args.Length - 1; i++)
             {
                 if (string.Equals(args[i], name, StringComparison.OrdinalIgnoreCase)) return args[i + 1];
+            }
+            return null;
+        }
+
+        // First token that looks like a flag (starts with '-') but isn't in the known set.
+        // Lets a command reject typos (e.g. `--allow-insecue`) instead of silently ignoring
+        // them — a silently-dropped `--allow-insecure` would change security behavior with no
+        // diagnostic. Value tokens of valued flags don't start with '-', so they're skipped here.
+        public static string? FirstUnknownFlag(string[] args, System.Collections.Generic.HashSet<string> known, int startIndex = 0)
+        {
+            for (int i = startIndex; i < args.Length; i++)
+            {
+                string a = args[i];
+                if (!a.StartsWith("-", StringComparison.Ordinal)) continue;
+                if (!known.Contains(a)) return a;
             }
             return null;
         }

--- a/Hina.CLI/Commands/InstallCommand.cs
+++ b/Hina.CLI/Commands/InstallCommand.cs
@@ -7,6 +7,15 @@ namespace Hina.CLI.Commands
 {
     internal static class InstallCommand
     {
+        // Flags `hina install` accepts. An unknown flag (typically a typo like
+        // `--allow-insecue`) is rejected rather than silently ignored — silently dropping
+        // `--allow-insecure` would flip security behavior with no diagnostic.
+        private static readonly System.Collections.Generic.HashSet<string> KnownFlags =
+            new(StringComparer.OrdinalIgnoreCase)
+            {
+                "--allow-insecure", "--retries", "--connect-timeout", "--request-timeout"
+            };
+
         public static async Task<int> RunAsync(CommandContext ctx, string[] args)
         {
             string? url = Args.FirstPositional(args, startIndex: 1);
@@ -19,6 +28,13 @@ namespace Hina.CLI.Commands
             if (!Uri.TryCreate(url, UriKind.Absolute, out Uri? descriptorUrl))
             {
                 ctx.Logger.LogError("'{Url}' is not a valid absolute URL.", url);
+                return 2;
+            }
+
+            string? unknownFlag = Args.FirstUnknownFlag(args, KnownFlags, startIndex: 1);
+            if (unknownFlag != null)
+            {
+                ctx.Logger.LogError("Unknown flag '{Flag}'. Usage: hina install <url> [--allow-insecure] [--retries N] [--connect-timeout SEC] [--request-timeout SEC]", unknownFlag);
                 return 2;
             }
 

--- a/Hina.CLI/Commands/NetworkArgs.cs
+++ b/Hina.CLI/Commands/NetworkArgs.cs
@@ -31,11 +31,18 @@ namespace Hina.CLI.Commands
         private static int ParseInt(string[] args, string flag, int fallback)
         {
             string? raw = Args.GetValue(args, flag);
-            if (raw != null && int.TryParse(raw, out int parsed) && parsed > 0)
+            // Flag absent → use the engine default. Flag PRESENT but not a positive integer →
+            // fail loudly: silently falling back to the default would make `--retries 0`,
+            // `--retries -5` or `--retries abc` look honored while the engine ignored them.
+            if (raw == null)
+            {
+                return fallback;
+            }
+            if (int.TryParse(raw, out int parsed) && parsed > 0)
             {
                 return parsed;
             }
-            return fallback;
+            throw new System.FormatException($"Invalid value for {flag}: '{raw}'. Expected a positive integer.");
         }
     }
 }

--- a/Hina.CLI/Commands/PermsCommand.cs
+++ b/Hina.CLI/Commands/PermsCommand.cs
@@ -24,6 +24,16 @@ namespace Hina.CLI.Commands
             string? grant = Args.GetValue(args, "--grant");
             string? revoke = Args.GetValue(args, "--revoke");
 
+            // A bare `--grant` / `--revoke` (flag present but no path, or an empty path) used to
+            // fall through to the read-only detail view, silently dropping the mutation the user
+            // asked for. Treat it as a usage error so the missing path is obvious.
+            if ((Args.HasFlag(args, "--grant") && string.IsNullOrWhiteSpace(grant))
+                || (Args.HasFlag(args, "--revoke") && string.IsNullOrWhiteSpace(revoke)))
+            {
+                ctx.Logger.LogError("Usage: hina perms <app> [--grant <path>[:ro|:rw]] [--revoke <path>]");
+                return 2;
+            }
+
             // No app (or the literal "list") and no mutation → overview table.
             if ((string.IsNullOrWhiteSpace(name) || name == "list") && grant == null && revoke == null)
             {

--- a/Hina.CLI/Commands/UninstallCommand.cs
+++ b/Hina.CLI/Commands/UninstallCommand.cs
@@ -7,12 +7,23 @@ namespace Hina.CLI.Commands
 {
     internal static class UninstallCommand
     {
+        private static readonly System.Collections.Generic.HashSet<string> NoFlags =
+            new(StringComparer.OrdinalIgnoreCase);
+
         public static async Task<int> RunAsync(CommandContext ctx, string[] args)
         {
             string? name = Args.FirstPositional(args, startIndex: 1);
             if (string.IsNullOrWhiteSpace(name))
             {
                 ctx.Logger.LogError("Usage: hina uninstall <name>");
+                return 2;
+            }
+
+            // uninstall takes no flags; reject typos instead of silently ignoring them.
+            string? unknownFlag = Args.FirstUnknownFlag(args, NoFlags, startIndex: 1);
+            if (unknownFlag != null)
+            {
+                ctx.Logger.LogError("Unknown flag '{Flag}'. Usage: hina uninstall <name>", unknownFlag);
                 return 2;
             }
 

--- a/Hina.CLI/Commands/UpdateCommand.cs
+++ b/Hina.CLI/Commands/UpdateCommand.cs
@@ -15,25 +15,32 @@ namespace Hina.CLI.Commands
             bool allowDowngrade = Args.HasFlag(args, "--allow-downgrade");
             bool acceptNewPerms = Args.HasFlag(args, "--accept-new-permissions");
 
-            int jobs = 4;
-            string? jobsArg = Args.GetValue(args, "--jobs");
-            if (jobsArg != null && int.TryParse(jobsArg, out int parsed) && parsed > 0)
-            {
-                jobs = parsed;
-            }
-
-            UpdateService service = ctx.NewUpdateService();
-            UpdateOptions options = new UpdateOptions
-            {
-                Force = force,
-                AllowDowngrade = allowDowngrade,
-                AcceptNewPermissions = acceptNewPerms,
-                MaxParallelism = jobs,
-                Network = NetworkArgs.FromArgs(args)
-            };
-
             try
             {
+                // --jobs absent → default 4. Present but not a positive integer → fail loudly
+                // rather than silently using 4 (see NetworkArgs for the same rule).
+                int jobs = 4;
+                string? jobsArg = Args.GetValue(args, "--jobs");
+                if (jobsArg != null)
+                {
+                    if (!int.TryParse(jobsArg, out int parsed) || parsed <= 0)
+                    {
+                        throw new FormatException($"Invalid value for --jobs: '{jobsArg}'. Expected a positive integer.");
+                    }
+                    jobs = parsed;
+                }
+
+                UpdateService service = ctx.NewUpdateService();
+                UpdateOptions options = new UpdateOptions
+                {
+                    Force = force,
+                    AllowDowngrade = allowDowngrade,
+                    AcceptNewPermissions = acceptNewPerms,
+                    MaxParallelism = jobs,
+                    Network = NetworkArgs.FromArgs(args)
+                };
+
+
                 if (string.IsNullOrWhiteSpace(name))
                 {
                     List<UpdateResult> results = await service.UpdateAllAsync(options, ctx.Ct);

--- a/Hina.PackageManager.Tests/RegistryStoreTests.cs
+++ b/Hina.PackageManager.Tests/RegistryStoreTests.cs
@@ -83,6 +83,24 @@ namespace Hina.PackageManager.Tests
             Assert.False(File.Exists(path + ".tmp"));
         }
 
+        [Theory]
+        [InlineData("{\"schemaVersion\":1,\"apps\":{\"demo\":")] // truncated mid-object
+        [InlineData("not json at all")]
+        [InlineData("{ this is broken }")]
+        public async Task Load_CorruptJson_ThrowsActionableError(string corrupt)
+        {
+            // A non-empty but unparseable registry must surface a clear, actionable error
+            // (not a raw JSON parser message and not a silent "nothing installed"), so the
+            // user knows the file is corrupt and how to recover.
+            string path = Path.Combine(_tempDir, "registry.json");
+            await File.WriteAllTextAsync(path, corrupt);
+
+            RegistryStore store = new RegistryStore(path);
+            RegistryCorruptException ex = Assert.Throws<RegistryCorruptException>(() => store.Load());
+            Assert.Contains("corrupt", ex.Message, StringComparison.OrdinalIgnoreCase);
+            Assert.Contains(path, ex.Message);
+        }
+
         [Fact]
         public async Task Load_FutureSchemaVersion_Throws()
         {

--- a/Hina.PackageManager.Tests/UninstallServiceTests.cs
+++ b/Hina.PackageManager.Tests/UninstallServiceTests.cs
@@ -53,6 +53,44 @@ namespace Hina.PackageManager.Tests
         }
 
         [Fact]
+        public async Task Uninstall_InstallDirRemovalFails_KeepsRegistryEntry()
+        {
+            // POSIX-only: we revoke write on the install dir so deleting its contents fails.
+            // On Windows there's no equivalent simple, reliable way to force the delete to
+            // throw without holding a file handle, so skip there.
+            if (OperatingSystem.IsWindows()) return;
+
+            InstallPaths paths = InstallPaths.ForRoot(_root);
+            string appDir = Path.Combine(_root, "locked-appdir");
+            Directory.CreateDirectory(appDir);
+            await File.WriteAllTextAsync(Path.Combine(appDir, "f.txt"), "x");
+            await Seed(paths, "demo", appDir);
+
+            // r-x only: the child file can't be unlinked, so Directory.Delete throws.
+            File.SetUnixFileMode(appDir,
+                UnixFileMode.UserRead | UnixFileMode.UserExecute);
+
+            try
+            {
+                UninstallResult result = await new UninstallService(paths, new FakePlatformIntegration())
+                    .UninstallAsync("demo", CancellationToken.None);
+
+                // The delete failed, so the dir is still on disk...
+                Assert.True(Directory.Exists(appDir));
+                // ...and the app must remain registered (not silently stranded as orphaned
+                // files with no registry pointer). Removal reported as not done.
+                Assert.False(result.Removed);
+                Assert.True(new RegistryStore(paths.RegistryFile).Load().Apps.ContainsKey("demo"));
+            }
+            finally
+            {
+                // Restore perms so the test root can be cleaned up.
+                File.SetUnixFileMode(appDir,
+                    UnixFileMode.UserRead | UnixFileMode.UserWrite | UnixFileMode.UserExecute);
+            }
+        }
+
+        [Fact]
         public async Task Uninstall_InstallPathIsDirectorySymlink_RemovesLinkNotTarget()
         {
             InstallPaths paths = InstallPaths.ForRoot(_root);

--- a/Hina.PackageManager/Install/UninstallService.cs
+++ b/Hina.PackageManager/Install/UninstallService.cs
@@ -81,6 +81,19 @@ namespace Hina.PackageManager.Install
             }
             catch (System.Exception ex) { _logger.LogDebug(ex, "Removal of install dir {Path} failed for {Name} (fail-soft).", app.InstallPath, name); }
 
+            // If the install dir is still there (delete failed: locked file on Windows, a
+            // read-only parent, missing permission), keep the registry row. Dropping it would
+            // strand the files on disk with nothing pointing at them — `verify`/`repair` only
+            // detect registered apps, so the leftovers would be invisible and unrecoverable by
+            // Hina. Keeping the row leaves the app listed and the uninstall retryable.
+            if (Directory.Exists(app.InstallPath))
+            {
+                _logger.LogWarning(
+                    "Uninstall: could not remove install directory {Path} for '{Name}'. The app is left registered so you can retry `hina uninstall {Name}` once the directory is free.",
+                    app.InstallPath, name, name);
+                return new UninstallResult { Name = name, Removed = false };
+            }
+
             try
             {
                 string descCache = _paths.DescriptorCache(name);

--- a/Hina.PackageManager/Registry/RegistryStore.cs
+++ b/Hina.PackageManager/Registry/RegistryStore.cs
@@ -17,6 +17,15 @@ namespace Hina.PackageManager.Registry
         public RegistrySchemaException(string message) : base(message) { }
     }
 
+    // Thrown when registry.json exists and is non-empty but isn't valid JSON (a partial
+    // write past the empty-file case, a hand-edit, or disk corruption). Carries an actionable
+    // message instead of a raw JSON parser error so the user knows the file — not Hina — is
+    // the problem and how to recover.
+    public sealed class RegistryCorruptException : Exception
+    {
+        public RegistryCorruptException(string message, Exception inner) : base(message, inner) { }
+    }
+
     // Reads and writes registry.json. Writes are atomic (tmp + fsync + rename) so a crash
     // mid-write leaves the previous good registry in place. Caller must hold a LockManager lock.
     public sealed class RegistryStore
@@ -75,7 +84,20 @@ namespace Hina.PackageManager.Registry
         // synthetic target+migrations while the production schema is still version 1.
         internal static Registry LoadFromJson(string json, int targetVersion, IReadOnlyList<RegistryMigration> migrations, ILogger logger, string path)
         {
-            JsonNode? node = JsonNode.Parse(json);
+            JsonNode? node;
+            try
+            {
+                node = JsonNode.Parse(json);
+            }
+            catch (JsonException ex)
+            {
+                // Non-empty but unparseable: a partial write past the empty case, a bad
+                // hand-edit, or disk corruption. Surface an actionable message rather than a
+                // raw parser error — Hina won't auto-delete the file (it records what's
+                // installed), so recovery is the user's call.
+                throw Corrupt(path, ex);
+            }
+
             if (node is JsonObject root)
             {
                 int version = ReadSchemaVersion(root);
@@ -87,18 +109,39 @@ namespace Hina.PackageManager.Registry
                 {
                     RegistryMigrator.Migrate(root, targetVersion, migrations);
                 }
-                return root.Deserialize(PackageManagerJsonContext.Default.Registry) ?? new Registry();
+                try
+                {
+                    return root.Deserialize(PackageManagerJsonContext.Default.Registry) ?? new Registry();
+                }
+                catch (JsonException ex)
+                {
+                    throw Corrupt(path, ex);
+                }
             }
 
             // Non-object / "null" JSON: defer to the source-gen deserializer (preserves the
             // prior behavior, including the higher-schema gate).
-            Registry r = JsonSerializer.Deserialize(json, PackageManagerJsonContext.Default.Registry) ?? new Registry();
+            Registry r;
+            try
+            {
+                r = JsonSerializer.Deserialize(json, PackageManagerJsonContext.Default.Registry) ?? new Registry();
+            }
+            catch (JsonException ex)
+            {
+                throw Corrupt(path, ex);
+            }
             if (r.SchemaVersion > targetVersion)
             {
                 throw NewerSchema(path, r.SchemaVersion, targetVersion);
             }
             return r;
         }
+
+        private static RegistryCorruptException Corrupt(string path, JsonException inner) =>
+            new RegistryCorruptException(
+                $"Registry at '{path}' is not valid JSON (corrupt or partially written). " +
+                "Back it up and remove it to start with an empty registry, or restore a known-good copy.",
+                inner);
 
         private static int ReadSchemaVersion(JsonObject root)
         {


### PR DESCRIPTION
## Caccia ai bug — casi utente non gestiti

Hunt for bugs / logic gaps an end user can trigger that were unhandled. 5 confirmed bugs, each with a red→green test. **462 tests green** (+13).

### Fixes

| # | Bug | User trigger | Before | After |
|---|-----|--------------|--------|-------|
| 1 | Uninstall leaves orphan dir | `uninstall` with locked/read-only install dir → delete fails | registry row removed anyway → files stranded on disk with no pointer; `verify`/`repair` only see registered apps, so leftovers invisible & unrecoverable | row kept (`Removed=false`) + warning; app stays listed, uninstall retryable |
| 2 | `perms <app> --grant` no path | forget the path | falls through to read-only detail, exit 0, mutation silently dropped | usage error exit 2 |
| 3 | Unknown/typo flags ignored | `install <url> --allow-insecue` | runs in **secure** mode while user believes the check is off; `uninstall x --bogus` → exit 0 | unknown flag rejected, exit 2 |
| 4 | Invalid numeric flag value | `--retries 0 / -5 / abc`, `--jobs abc` | silent fallback to engine default | fail loud, exit 2 |
| 5 | Corrupt `registry.json` | truncated / bad hand-edit (past the empty case) | raw `JsonException` on every command, user stuck | `RegistryCorruptException` with actionable message (file + recovery) |

Bug #3 is the sharpest: a security flag silently dropped.

### Notes
- All fixes verified end-to-end against the built CLI binary.
- Checked and found already-handled (no change): sandbox launchers (fail-soft, exit-code/signal passthrough), `PatchClient` concurrency `Math.Max(1,…)`, `UpdateService` parallelism `Math.Clamp(…,1,16)`.
- `--config` is dev-only; not wired to user `install`/`update`.

### Tests
+13 tests: `ArgsTests` (FirstUnknownFlag), `NetworkArgsTests` (new), `CommandRouterTests` (perms/uninstall), `UninstallServiceTests` (POSIX-guarded leak), `RegistryStoreTests` (corrupt JSON).

🤖 Generated with [Claude Code](https://claude.com/claude-code)