### PR TITLE
feat(builder): interactive `hina-builder init` wizard

### DIFF
--- a/Hina.Builder.Tests/DefaultsResolverTests.cs
+++ b/Hina.Builder.Tests/DefaultsResolverTests.cs
@@ -1,0 +1,91 @@
+using System;
+using System.IO;
+using Hina.Builder.Init;
+using Hina.PackageManager.Descriptor;
+
+namespace Hina.Builder.Tests
+{
+    public sealed class DefaultsResolverTests : IDisposable
+    {
+        private readonly string _root;
+
+        public DefaultsResolverTests()
+        {
+            _root = Path.Combine(Path.GetTempPath(), "hina-defaults-" + Guid.NewGuid().ToString("N"));
+            Directory.CreateDirectory(_root);
+        }
+
+        public void Dispose()
+        {
+            try { Directory.Delete(_root, recursive: true); } catch { /* best-effort */ }
+        }
+
+        [Theory]
+        [InlineData("My Cool Game", "my-cool-game")]
+        [InlineData("123Game", "app-123game")]
+        [InlineData("Foo__Bar", "foo-bar")]
+        public void Slugify_ProducesValidName(string input, string expected)
+        {
+            Assert.Equal(expected, DefaultsResolver.Slugify(input));
+        }
+
+        [Fact]
+        public void Resolve_NoFiles_UsesFolderSlug()
+        {
+            ScaffoldDefaults d = DefaultsResolver.Resolve(new DirectoryInfo(_root));
+            // Folder name is "hina-defaults-<guid>" → slug keeps it lowercase/dashed.
+            Assert.StartsWith("hina-defaults-", d.Name);
+            Assert.Equal("1.0.0", d.Version);
+        }
+
+        [Fact]
+        public void Resolve_Csproj_PreFillsFromMetadata()
+        {
+            File.WriteAllText(Path.Combine(_root, "Game.csproj"), """
+                <Project Sdk="Microsoft.NET.Sdk">
+                  <PropertyGroup>
+                    <AssemblyName>Neon Drift</AssemblyName>
+                    <Version>3.1</Version>
+                    <Authors>Pixel Co</Authors>
+                  </PropertyGroup>
+                </Project>
+                """);
+
+            ScaffoldDefaults d = DefaultsResolver.Resolve(new DirectoryInfo(_root));
+
+            Assert.Equal("neon-drift", d.Name);       // slugified
+            Assert.Equal("Neon Drift", d.DisplayName); // raw
+            Assert.Equal("3.1.0", d.Version);          // normalised to SemVer
+            Assert.Equal("Pixel Co", d.Publisher);
+        }
+
+        [Fact]
+        public void Resolve_ExistingDescriptor_TakesPriorityOverMetadata()
+        {
+            // csproj says one thing...
+            File.WriteAllText(Path.Combine(_root, "Game.csproj"), """
+                <Project Sdk="Microsoft.NET.Sdk">
+                  <PropertyGroup><AssemblyName>FromCsproj</AssemblyName><Version>9.9.9</Version></PropertyGroup>
+                </Project>
+                """);
+            // ...but an existing hina.app.json wins (re-run = edit).
+            AppDescriptor existing = new AppDescriptor
+            {
+                Name = "existing-app",
+                DisplayName = "Existing App",
+                Version = "4.5.6",
+                Publisher = "Prev Publisher",
+                BaseUrl = "https://prev.example/"
+            };
+            File.WriteAllText(Path.Combine(_root, "hina.app.json"), DescriptorParser.Serialize(existing));
+
+            ScaffoldDefaults d = DefaultsResolver.Resolve(new DirectoryInfo(_root));
+
+            Assert.Equal("existing-app", d.Name);
+            Assert.Equal("4.5.6", d.Version);
+            Assert.Equal("Prev Publisher", d.Publisher);
+            Assert.Equal("https://prev.example/", d.BaseUrl);
+            Assert.NotNull(d.Existing);
+        }
+    }
+}

--- a/Hina.Builder.Tests/DescriptorScaffolderTests.cs
+++ b/Hina.Builder.Tests/DescriptorScaffolderTests.cs
@@ -1,0 +1,89 @@
+using System.Collections.Generic;
+using Hina.Builder.Init;
+using Hina.Core.Crypto;
+using Hina.PackageManager.Descriptor;
+
+namespace Hina.Builder.Tests
+{
+    public sealed class DescriptorScaffolderTests
+    {
+        private static string FreshPublicKey()
+        {
+            (string _, string pub) = KeyGenerator.GenerateEd25519();
+            return pub;
+        }
+
+        private static ScaffoldAnswers ValidAnswers() => new ScaffoldAnswers
+        {
+            Name = "mygame",
+            DisplayName = "My Game",
+            Version = "1.0.0",
+            Publisher = "Acme",
+            Description = "A game",
+            BaseUrl = "https://patch.example.com/",
+            Channel = "stable",
+            PublicKey = FreshPublicKey(),
+            Exec = new ExecMap { Linux = "game" },
+            Entries = new List<ShellEntry>
+            {
+                new ShellEntry { Id = "mygame", Name = "My Game", Exec = "game" }
+            },
+            Sandbox = new SandboxAnswers { Enabled = true, NeedsNetwork = true, DataLocation = DataLocation.Config }.ToSpec()
+        };
+
+        [Fact]
+        public void Build_ValidAnswers_ProducesValidDescriptor()
+        {
+            AppDescriptor d = DescriptorScaffolder.Build(ValidAnswers());
+
+            Assert.Equal("mygame", d.Name);
+            Assert.Equal("game", d.Exec.Linux);
+            Assert.Single(d.Entries);
+            Assert.True(d.Sandbox!.Enabled);
+            // And it passes the canonical validator.
+            Assert.True(DescriptorValidator.Validate(d).IsValid);
+        }
+
+        [Fact]
+        public void Build_InvalidName_Throws()
+        {
+            ScaffoldAnswers a = ValidAnswers();
+            ScaffoldAnswers bad = new ScaffoldAnswers
+            {
+                Name = "Bad Name",          // spaces + uppercase → invalid
+                DisplayName = a.DisplayName,
+                Version = a.Version,
+                Publisher = a.Publisher,
+                Description = a.Description,
+                BaseUrl = a.BaseUrl,
+                Channel = a.Channel,
+                PublicKey = a.PublicKey,
+                Exec = a.Exec,
+                Entries = new List<ShellEntry>()
+            };
+
+            Assert.Throws<DescriptorValidationException>(() => DescriptorScaffolder.Build(bad));
+        }
+
+        [Fact]
+        public void Build_NoExec_Throws()
+        {
+            ScaffoldAnswers a = ValidAnswers();
+            ScaffoldAnswers noExec = new ScaffoldAnswers
+            {
+                Name = a.Name,
+                DisplayName = a.DisplayName,
+                Version = a.Version,
+                Publisher = a.Publisher,
+                Description = a.Description,
+                BaseUrl = a.BaseUrl,
+                Channel = a.Channel,
+                PublicKey = a.PublicKey,
+                Exec = new ExecMap(),       // none defined
+                Entries = new List<ShellEntry>()
+            };
+
+            Assert.Throws<DescriptorValidationException>(() => DescriptorScaffolder.Build(noExec));
+        }
+    }
+}

--- a/Hina.Builder.Tests/ExecutableDetectorTests.cs
+++ b/Hina.Builder.Tests/ExecutableDetectorTests.cs
@@ -1,0 +1,82 @@
+using System;
+using System.IO;
+using System.Linq;
+using Hina.Builder.Init;
+
+namespace Hina.Builder.Tests
+{
+    public sealed class ExecutableDetectorTests : IDisposable
+    {
+        private readonly string _root;
+
+        public ExecutableDetectorTests()
+        {
+            _root = Path.Combine(Path.GetTempPath(), "hina-detect-" + Guid.NewGuid().ToString("N"));
+            Directory.CreateDirectory(_root);
+        }
+
+        public void Dispose()
+        {
+            try { Directory.Delete(_root, recursive: true); } catch { /* best-effort */ }
+        }
+
+        private void Write(string rel, byte[] header)
+        {
+            string path = Path.Combine(_root, rel);
+            Directory.CreateDirectory(Path.GetDirectoryName(path)!);
+            byte[] body = new byte[64];
+            Array.Copy(header, body, header.Length);
+            File.WriteAllBytes(path, body);
+        }
+
+        private static readonly byte[] Pe = { 0x4D, 0x5A, 0x90, 0x00 };
+        private static readonly byte[] Elf = { 0x7F, 0x45, 0x4C, 0x46 };
+        private static readonly byte[] MachO = { 0xCF, 0xFA, 0xED, 0xFE };
+
+        [Fact]
+        public void Detect_ClassifiesByMagicBytes()
+        {
+            Write("game.exe", Pe);
+            Write("game", Elf);
+            Write("game-mac", MachO);
+            File.WriteAllText(Path.Combine(_root, "readme.txt"), "not an executable");
+
+            var found = ExecutableDetector.Detect(new DirectoryInfo(_root));
+
+            Assert.Contains(found, e => e.RelPath == "game.exe" && e.Os == TargetOs.Windows);
+            Assert.Contains(found, e => e.RelPath == "game" && e.Os == TargetOs.Linux);
+            Assert.Contains(found, e => e.RelPath == "game-mac" && e.Os == TargetOs.Macos);
+            Assert.DoesNotContain(found, e => e.RelPath == "readme.txt");
+        }
+
+        [Fact]
+        public void Detect_RanksMainExeAboveLibraries()
+        {
+            Write("mylib.dll", Pe);
+            Write("game.exe", Pe);
+
+            var found = ExecutableDetector.Detect(new DirectoryInfo(_root));
+
+            // .exe should rank ahead of the .dll library.
+            Assert.Equal("game.exe", found.First(e => e.Os == TargetOs.Windows).RelPath);
+            Assert.True(found.First(e => e.RelPath == "game.exe").Rank
+                        > found.First(e => e.RelPath == "mylib.dll").Rank);
+        }
+
+        [Fact]
+        public void Detect_RecognisesMacAppBundle()
+        {
+            string inner = Path.Combine("MyGame.app", "Contents", "MacOS", "MyGame");
+            Write(inner, MachO);
+
+            var found = ExecutableDetector.Detect(new DirectoryInfo(_root));
+
+            var bundle = found.FirstOrDefault(e => e.IsBundle);
+            Assert.NotNull(bundle);
+            Assert.Equal(TargetOs.Macos, bundle!.Os);
+            Assert.Equal("MyGame.app/Contents/MacOS/MyGame", bundle.RelPath);
+            // The inner Mach-O is not also listed as a separate plain candidate.
+            Assert.Single(found, e => e.Os == TargetOs.Macos);
+        }
+    }
+}

--- a/Hina.Builder.Tests/Hina.Builder.Tests.csproj
+++ b/Hina.Builder.Tests/Hina.Builder.Tests.csproj
@@ -1,0 +1,29 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="coverlet.collector" Version="6.0.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
+    <PackageReference Include="xunit" Version="2.5.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <!-- Hina.Builder is an Exe; referenced so tests can drive the init wizard internals. -->
+    <ProjectReference Include="..\Hina.Builder\Hina.Builder.csproj" />
+    <ProjectReference Include="..\Hina.PackageManager\Hina.PackageManager.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/Hina.Builder.Tests/InitCommandTests.cs
+++ b/Hina.Builder.Tests/InitCommandTests.cs
@@ -1,0 +1,147 @@
+using System;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using Hina.Builder.Init;
+using Hina.PackageManager.Descriptor;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace Hina.Builder.Tests
+{
+    public sealed class InitCommandTests : IDisposable
+    {
+        private readonly string _payload;
+        private readonly string _out;
+
+        public InitCommandTests()
+        {
+            string baseDir = Path.Combine(Path.GetTempPath(), "hina-init-" + Guid.NewGuid().ToString("N"));
+            _payload = Path.Combine(baseDir, "payload");
+            _out = Path.Combine(baseDir, "dist");
+            Directory.CreateDirectory(_payload);
+        }
+
+        public void Dispose()
+        {
+            try { Directory.Delete(Directory.GetParent(_payload)!.FullName, recursive: true); } catch { /* best-effort */ }
+        }
+
+        private void WriteElf(string name)
+        {
+            byte[] body = new byte[64];
+            byte[] elf = { 0x7F, 0x45, 0x4C, 0x46 };
+            Array.Copy(elf, body, elf.Length);
+            File.WriteAllBytes(Path.Combine(_payload, name), body);
+        }
+
+        // Full wizard run over a single-OS (Linux) payload. The scripted prompt answers each
+        // question in order; queues are per-method so they don't have to interleave.
+        private ScriptedPrompt SingleLinuxScript() => new ScriptedPrompt(
+            asks: new[]
+            {
+                "mygame",                        // app id
+                "My Game",                       // display name
+                "1.2.3",                         // version
+                "Acme",                          // publisher
+                "A fun game",                    // description
+                "",                              // homepage (none)
+                "https://patch.example.com/",    // base url
+                "",                              // windows exec (none)
+                "",                              // macos exec (none)
+                "",                              // launcher name (→ default "My Game")
+                "",                              // icon (none)
+                _out                             // output folder (keys + patch)
+            },
+            confirms: new[]
+            {
+                true,   // use 'game' as the linux executable
+                true,   // create a launcher
+                true,   // run in a sandbox
+                true,   // needs internet
+                true    // generate a key pair
+            },
+            chooses: new[] { 1 }); // data location → config
+
+        [Fact]
+        public async Task Init_SingleOsLinux_WritesSignedValidDescriptorAndPatch()
+        {
+            WriteElf("game");
+            File.WriteAllText(Path.Combine(_payload, "data.bin"), "some asset data");
+
+            int code = await InitCommand.RunAsync(
+                new[] { "init", "--input", _payload },
+                SingleLinuxScript(),
+                NullLogger.Instance,
+                CancellationToken.None);
+
+            Assert.Equal(0, code);
+
+            // Descriptor written into the project folder, signed and valid.
+            string descPath = Path.Combine(_payload, "hina.app.json");
+            Assert.True(File.Exists(descPath));
+            AppDescriptor d = DescriptorParser.Parse(await File.ReadAllTextAsync(descPath));
+
+            Assert.Equal("mygame", d.Name);
+            Assert.Equal("1.2.3", d.Version);
+            Assert.Equal("Acme", d.Publisher);
+            Assert.Equal("game", d.Exec.Linux);
+            Assert.Null(d.Exec.Windows);
+            Assert.Single(d.Entries);
+            Assert.Equal("game", d.Entries[0].Exec);
+            Assert.True(d.Sandbox!.Enabled);
+            Assert.True(d.Sandbox.Capabilities!.Network);
+            Assert.NotNull(d.DescriptorSignature);
+            Assert.True(DescriptorValidator.Validate(d).IsValid);
+
+            // Keys + patch written OUTSIDE the payload.
+            Assert.True(File.Exists(Path.Combine(_out, "patch", "manifest.json")));
+            Assert.True(Directory.Exists(Path.Combine(_out, "keys")));
+            // The private key must NOT be inside the shipped payload.
+            Assert.Empty(Directory.GetFiles(_payload, "*.key.b64", SearchOption.AllDirectories));
+        }
+
+        [Fact]
+        public async Task Init_ReRun_UsesExistingDescriptorAsDefaults()
+        {
+            WriteElf("game");
+
+            // First run creates hina.app.json in the payload.
+            int first = await InitCommand.RunAsync(
+                new[] { "init", "--input", _payload }, SingleLinuxScript(), NullLogger.Instance, CancellationToken.None);
+            Assert.Equal(0, first);
+
+            // Second run: press Enter on every text field (empty asks → defaults). The defaults
+            // must come from the existing descriptor (id "mygame", version "1.2.3", publisher
+            // "Acme"), proving re-run = edit. Still answer the new output-folder + key prompts.
+            ScriptedPrompt rerun = new ScriptedPrompt(
+                asks: new[]
+                {
+                    "", "", "", "", "", "", "",   // id, name, version, publisher, desc, homepage, baseurl
+                    "", "",                       // windows exec, macos exec
+                    "", "",                       // launcher name, icon
+                    _out                          // output folder
+                },
+                confirms: new[]
+                {
+                    true,   // use 'game' as linux exec
+                    true,   // create launcher
+                    true,   // sandbox
+                    true,   // internet
+                    true,   // (key already exists from first run → this confirm is unused, harmless)
+                    true    // overwrite existing hina.app.json
+                },
+                chooses: new[] { 1 });
+
+            int second = await InitCommand.RunAsync(
+                new[] { "init", "--input", _payload }, rerun, NullLogger.Instance, CancellationToken.None);
+            Assert.Equal(0, second);
+
+            AppDescriptor d = DescriptorParser.Parse(
+                await File.ReadAllTextAsync(Path.Combine(_payload, "hina.app.json")));
+            Assert.Equal("mygame", d.Name);
+            Assert.Equal("1.2.3", d.Version);
+            Assert.Equal("Acme", d.Publisher);
+            Assert.Equal("https://patch.example.com/", d.BaseUrl);
+        }
+    }
+}

--- a/Hina.Builder.Tests/ProjectMetadataReaderTests.cs
+++ b/Hina.Builder.Tests/ProjectMetadataReaderTests.cs
@@ -1,0 +1,83 @@
+using System;
+using System.IO;
+using Hina.Builder.Init;
+
+namespace Hina.Builder.Tests
+{
+    public sealed class ProjectMetadataReaderTests : IDisposable
+    {
+        private readonly string _root;
+
+        public ProjectMetadataReaderTests()
+        {
+            _root = Path.Combine(Path.GetTempPath(), "hina-meta-" + Guid.NewGuid().ToString("N"));
+            Directory.CreateDirectory(_root);
+        }
+
+        public void Dispose()
+        {
+            try { Directory.Delete(_root, recursive: true); } catch { /* best-effort */ }
+        }
+
+        [Fact]
+        public void Read_EmptyDir_IsEmpty()
+        {
+            Assert.True(ProjectMetadataReader.Read(new DirectoryInfo(_root)).IsEmpty);
+        }
+
+        [Fact]
+        public void Read_Csproj_ExtractsFields()
+        {
+            File.WriteAllText(Path.Combine(_root, "MyGame.csproj"), """
+                <Project Sdk="Microsoft.NET.Sdk">
+                  <PropertyGroup>
+                    <AssemblyName>SuperGame</AssemblyName>
+                    <Version>2.3.4</Version>
+                    <Authors>Acme Studios</Authors>
+                    <Description>A fun game</Description>
+                    <PackageProjectUrl>https://acme.example</PackageProjectUrl>
+                  </PropertyGroup>
+                </Project>
+                """);
+
+            ProjectMetadata m = ProjectMetadataReader.Read(new DirectoryInfo(_root));
+
+            Assert.Equal("SuperGame", m.Name);
+            Assert.Equal("2.3.4", m.Version);
+            Assert.Equal("Acme Studios", m.Publisher);
+            Assert.Equal("A fun game", m.Description);
+            Assert.Equal("https://acme.example", m.Homepage);
+        }
+
+        [Fact]
+        public void Read_PackageJson_ExtractsFields()
+        {
+            File.WriteAllText(Path.Combine(_root, "package.json"), """
+                { "name": "my-app", "version": "1.0.0", "description": "Desc",
+                  "author": "Jane Dev", "homepage": "https://jane.example" }
+                """);
+
+            ProjectMetadata m = ProjectMetadataReader.Read(new DirectoryInfo(_root));
+
+            Assert.Equal("my-app", m.Name);
+            Assert.Equal("1.0.0", m.Version);
+            Assert.Equal("Jane Dev", m.Publisher);
+            Assert.Equal("https://jane.example", m.Homepage);
+        }
+
+        [Fact]
+        public void Read_Godot_ExtractsName()
+        {
+            File.WriteAllText(Path.Combine(_root, "project.godot"), """
+                [application]
+                config/name="My Godot Game"
+                config/version="0.9.1"
+                """);
+
+            ProjectMetadata m = ProjectMetadataReader.Read(new DirectoryInfo(_root));
+
+            Assert.Equal("My Godot Game", m.Name);
+            Assert.Equal("0.9.1", m.Version);
+        }
+    }
+}

--- a/Hina.Builder.Tests/SandboxAnswersTests.cs
+++ b/Hina.Builder.Tests/SandboxAnswersTests.cs
@@ -1,0 +1,60 @@
+using System.Linq;
+using Hina.Builder.Init;
+using Hina.PackageManager.Descriptor;
+
+namespace Hina.Builder.Tests
+{
+    public sealed class SandboxAnswersTests
+    {
+        [Fact]
+        public void Disabled_ReturnsNull()
+        {
+            Assert.Null(new SandboxAnswers { Enabled = false }.ToSpec());
+        }
+
+        [Fact]
+        public void SelfOnly_NoNetwork_HasNoRulesOrCaps()
+        {
+            SandboxSpec? spec = new SandboxAnswers
+            {
+                Enabled = true,
+                NeedsNetwork = false,
+                DataLocation = DataLocation.SelfOnly
+            }.ToSpec();
+
+            Assert.NotNull(spec);
+            Assert.True(spec!.Enabled);
+            Assert.Empty(spec.Filesystem);
+            Assert.Null(spec.Capabilities);
+        }
+
+        [Fact]
+        public void ConfigWithNetwork_AddsTokenAndCapability()
+        {
+            SandboxSpec? spec = new SandboxAnswers
+            {
+                Enabled = true,
+                NeedsNetwork = true,
+                DataLocation = DataLocation.Config
+            }.ToSpec();
+
+            Assert.NotNull(spec);
+            FsRule rule = Assert.Single(spec!.Filesystem);
+            Assert.Equal(SandboxTokens.XdgConfig, rule.Path);
+            Assert.Equal("rw", rule.Access);
+            Assert.True(spec.Capabilities!.Network);
+        }
+
+        [Fact]
+        public void Anywhere_MapsToHostToken()
+        {
+            SandboxSpec? spec = new SandboxAnswers
+            {
+                Enabled = true,
+                DataLocation = DataLocation.Anywhere
+            }.ToSpec();
+
+            Assert.Equal(SandboxTokens.Host, spec!.Filesystem.Single().Path);
+        }
+    }
+}

--- a/Hina.Builder.Tests/ScriptedPrompt.cs
+++ b/Hina.Builder.Tests/ScriptedPrompt.cs
@@ -1,0 +1,37 @@
+using System.Collections.Generic;
+using Hina.Builder.Init;
+
+namespace Hina.Builder.Tests
+{
+    // Drives InitCommand without a console. Separate queues per method type — the wizard calls
+    // Ask/Confirm/Choose in a fixed order within each type, so tests don't have to interleave.
+    // Ask mirrors ConsolePrompt: an empty scripted answer means "pressed Enter" → returns def.
+    internal sealed class ScriptedPrompt : IPrompt
+    {
+        private readonly Queue<string> _asks;
+        private readonly Queue<bool> _confirms;
+        private readonly Queue<int> _chooses;
+
+        public ScriptedPrompt(
+            IEnumerable<string>? asks = null,
+            IEnumerable<bool>? confirms = null,
+            IEnumerable<int>? chooses = null)
+        {
+            _asks = new Queue<string>(asks ?? new List<string>());
+            _confirms = new Queue<bool>(confirms ?? new List<bool>());
+            _chooses = new Queue<int>(chooses ?? new List<int>());
+        }
+
+        public string Ask(string question, string? def)
+        {
+            string answer = _asks.Count > 0 ? _asks.Dequeue() : string.Empty;
+            return string.IsNullOrWhiteSpace(answer) ? (def ?? string.Empty) : answer.Trim();
+        }
+
+        public bool Confirm(string question, bool def)
+            => _confirms.Count > 0 ? _confirms.Dequeue() : def;
+
+        public int Choose(string question, IReadOnlyList<string> options, int defaultIndex)
+            => _chooses.Count > 0 ? _chooses.Dequeue() : defaultIndex;
+    }
+}

--- a/Hina.Builder/Args.cs
+++ b/Hina.Builder/Args.cs
@@ -1,0 +1,38 @@
+using System;
+
+namespace Hina.Builder
+{
+    // Tiny arg helpers shared by the builder commands. Kept deliberately minimal — the
+    // builder's flags are all `--name value` or boolean `--flag`.
+    internal static class Args
+    {
+        public static bool HasArg(string[] args, string name)
+        {
+            foreach (string arg in args)
+            {
+                if (string.Equals(arg, name, StringComparison.OrdinalIgnoreCase))
+                {
+                    return true;
+                }
+            }
+            return false;
+        }
+
+        public static string? GetArgValue(string[] args, string name)
+        {
+            for (int i = 0; i < args.Length - 1; i++)
+            {
+                if (string.Equals(args[i], name, StringComparison.OrdinalIgnoreCase))
+                {
+                    return args[i + 1];
+                }
+            }
+            return null;
+        }
+
+        public static int ParseInt(string? value, int fallback)
+        {
+            return int.TryParse(value, out int v) ? v : fallback;
+        }
+    }
+}

--- a/Hina.Builder/BuildCommand.cs
+++ b/Hina.Builder/BuildCommand.cs
@@ -1,0 +1,102 @@
+using System;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using Hina.Core.Chunking;
+using Hina.Core.Hashing;
+using Hina.Core.Manifest;
+using Hina.Core.Rsync;
+using Microsoft.Extensions.Logging;
+
+namespace Hina.Builder
+{
+    // `hina-builder build` — scans a directory, chunks every file, writes manifest + chunk store.
+    // Extracted from Program.Main so the init wizard can drive the same build path after it
+    // generates the descriptor.
+    internal sealed class BuildOptions
+    {
+        public string Input { get; init; } = string.Empty;
+        public string Output { get; init; } = string.Empty;
+        public string BaseUrl { get; init; } = string.Empty;
+        public string? SignKeyPath { get; init; }
+        public string Version { get; init; } = "0.0.0";
+        public int ChunkSize { get; init; } = 64 * 1024;
+        public string ChunkingMode { get; init; } = "fixed";
+        public int MinChunk { get; init; } = 2048;
+        public int MaxChunk { get; init; } = 64 * 1024;
+        public int AvgChunk { get; init; } = 8192;
+
+        public static BuildOptions FromArgs(string[] args) => new BuildOptions
+        {
+            Input = Args.GetArgValue(args, "--input") ?? string.Empty,
+            Output = Args.GetArgValue(args, "--out") ?? string.Empty,
+            BaseUrl = Args.GetArgValue(args, "--base") ?? string.Empty,
+            SignKeyPath = Args.GetArgValue(args, "--sign-key"),
+            Version = Args.GetArgValue(args, "--version") ?? "0.0.0",
+            ChunkSize = Args.ParseInt(Args.GetArgValue(args, "--chunk"), 64 * 1024),
+            ChunkingMode = Args.GetArgValue(args, "--chunking") ?? "fixed",
+            MinChunk = Args.ParseInt(Args.GetArgValue(args, "--min-chunk"), 2048),
+            MaxChunk = Args.ParseInt(Args.GetArgValue(args, "--max-chunk"), 64 * 1024),
+            AvgChunk = Args.ParseInt(Args.GetArgValue(args, "--avg-chunk"), 8192),
+        };
+    }
+
+    internal static class BuildCommand
+    {
+        public static async Task<int> RunAsync(BuildOptions options, ILogger logger, CancellationToken ct)
+        {
+            if (string.IsNullOrWhiteSpace(options.Input) || string.IsNullOrWhiteSpace(options.Output) || string.IsNullOrWhiteSpace(options.BaseUrl))
+            {
+                logger.LogError("Missing required args: --input, --out, --base");
+                return 2;
+            }
+
+            DirectoryInfo inputDir = new DirectoryInfo(options.Input);
+            DirectoryInfo outputDir = new DirectoryInfo(options.Output);
+            DirectoryInfo chunkDir = new DirectoryInfo(Path.Combine(outputDir.FullName, "chunks"));
+
+            IHasher hasher = new Sha256Hasher();
+            ManifestBuilder manifestBuilder = new ManifestBuilder(hasher);
+
+            IChunker chunker;
+            if (string.Equals(options.ChunkingMode, "cdc", StringComparison.OrdinalIgnoreCase))
+            {
+                chunker = new ContentDefinedChunker(hasher, options.MinChunk, options.MaxChunk, options.AvgChunk);
+                logger.LogInformation("Using content-defined chunking (min={Min}, max={Max}, avg={Avg})", options.MinChunk, options.MaxChunk, options.AvgChunk);
+            }
+            else
+            {
+                chunker = new RsyncChunker(options.ChunkSize, hasher);
+                logger.LogInformation("Using fixed-size chunking (size={Size})", options.ChunkSize);
+            }
+
+            ChunkStoreWriter chunkWriter = new ChunkStoreWriter(hasher, options.ChunkSize, chunker);
+
+            string normalizedBase = NormalizeBaseUrl(options.BaseUrl);
+            logger.LogInformation("Building manifest from {InputDir}", inputDir.FullName);
+            Manifest manifest = await manifestBuilder.BuildAsync(inputDir, new Uri(normalizedBase), options.ChunkSize, chunker, ct);
+            manifest.Version = options.Version;
+            if (!string.IsNullOrWhiteSpace(options.SignKeyPath))
+            {
+                byte[] privateKey = Convert.FromBase64String(File.ReadAllText(options.SignKeyPath).Trim());
+                ManifestSigner.AttachSignature(manifest, privateKey);
+                logger.LogInformation("Manifest signed with key from {KeyPath}", options.SignKeyPath);
+            }
+
+            outputDir.Create();
+            await ManifestSerializer.WriteAsync(manifest, Path.Combine(outputDir.FullName, "manifest.json"), ct);
+            await chunkWriter.WriteChunksAsync(inputDir, chunkDir, ct);
+
+            logger.LogInformation("Build complete");
+            logger.LogInformation("Manifest: {ManifestPath}", Path.Combine(outputDir.FullName, "manifest.json"));
+            logger.LogInformation("Chunks: {ChunkDir}", chunkDir.FullName);
+            return 0;
+        }
+
+        private static string NormalizeBaseUrl(string url)
+        {
+            // Ensure base URL is safe for Uri combination.
+            return url.EndsWith("/") ? url : url + "/";
+        }
+    }
+}

--- a/Hina.Builder/Hina.Builder.csproj
+++ b/Hina.Builder/Hina.Builder.csproj
@@ -6,6 +6,11 @@
 
   <ItemGroup>
     <ProjectReference Include="..\Hina.Core\Hina.Core.csproj" />
+    <ProjectReference Include="..\Hina.PackageManager\Hina.PackageManager.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <InternalsVisibleTo Include="Hina.Builder.Tests" />
   </ItemGroup>
 
   <PropertyGroup>

--- a/Hina.Builder/Init/DefaultsResolver.cs
+++ b/Hina.Builder/Init/DefaultsResolver.cs
@@ -1,0 +1,172 @@
+using System;
+using System.IO;
+using System.Text;
+using Hina.PackageManager.Descriptor;
+
+namespace Hina.Builder.Init
+{
+    // Pre-filled answers shown as [default] at each prompt. Built by merging, in priority
+    // order: an existing hina.app.json (re-run = edit) > project-file metadata > folder-name
+    // fallback. Null means "no good default; the wizard will ask without one".
+    internal sealed class ScaffoldDefaults
+    {
+        public string Name { get; init; } = string.Empty;
+        public string DisplayName { get; init; } = string.Empty;
+        public string Version { get; init; } = "1.0.0";
+        public string Publisher { get; init; } = string.Empty;
+        public string Description { get; init; } = string.Empty;
+        public string? Homepage { get; init; }
+        public string BaseUrl { get; init; } = string.Empty;
+        public string Channel { get; init; } = "stable";
+
+        // The full existing descriptor, when re-running over a hina.app.json. Lets the wizard
+        // reuse entries/sandbox/publicKey as defaults too.
+        public AppDescriptor? Existing { get; init; }
+    }
+
+    internal static class DefaultsResolver
+    {
+        public const string DescriptorFileName = "hina.app.json";
+
+        public static ScaffoldDefaults Resolve(DirectoryInfo root)
+        {
+            AppDescriptor? existing = TryLoadExisting(root);
+            ProjectMetadata meta = ProjectMetadataReader.Read(root);
+
+            string folderSlug = Slugify(root.Name);
+
+            string name = First(existing?.Name, Slugify(meta.Name), folderSlug);
+            string displayName = First(existing?.DisplayName, meta.Name, root.Name);
+            string version = First(existing?.Version, NormalizeVersion(meta.Version), "1.0.0");
+            string publisher = First(existing?.Publisher, meta.Publisher, "");
+            string description = First(existing?.Description, meta.Description, "");
+            string? homepage = FirstOrNull(existing?.Homepage, meta.Homepage);
+            string baseUrl = First(existing?.BaseUrl, "");
+            string channel = First(existing?.Channel, "stable");
+
+            return new ScaffoldDefaults
+            {
+                Name = name,
+                DisplayName = displayName,
+                Version = version,
+                Publisher = publisher,
+                Description = description,
+                Homepage = homepage,
+                BaseUrl = baseUrl,
+                Channel = channel,
+                Existing = existing
+            };
+        }
+
+        private static AppDescriptor? TryLoadExisting(DirectoryInfo root)
+        {
+            string path = Path.Combine(root.FullName, DescriptorFileName);
+            if (!File.Exists(path))
+            {
+                return null;
+            }
+            try
+            {
+                return DescriptorParser.Parse(File.ReadAllText(path));
+            }
+            catch (Exception)
+            {
+                // Corrupt/partial existing descriptor: ignore it as a source of defaults rather
+                // than failing the whole wizard.
+                return null;
+            }
+        }
+
+        private static string First(params string?[] candidates)
+        {
+            foreach (string? c in candidates)
+            {
+                if (!string.IsNullOrWhiteSpace(c))
+                {
+                    return c!.Trim();
+                }
+            }
+            return string.Empty;
+        }
+
+        private static string? FirstOrNull(params string?[] candidates)
+        {
+            foreach (string? c in candidates)
+            {
+                if (!string.IsNullOrWhiteSpace(c))
+                {
+                    return c!.Trim();
+                }
+            }
+            return null;
+        }
+
+        // Lowercase, spaces/underscores → '-', drop anything outside [a-z0-9-], collapse and trim
+        // dashes, ensure it starts with a letter so it satisfies the name regex
+        // (^[a-z][a-z0-9-]{1,63}$). Returns "" if nothing usable (the wizard then asks).
+        public static string Slugify(string? raw)
+        {
+            if (string.IsNullOrWhiteSpace(raw))
+            {
+                return string.Empty;
+            }
+            StringBuilder sb = new StringBuilder(raw.Length);
+            foreach (char ch in raw.Trim().ToLowerInvariant())
+            {
+                if (ch is >= 'a' and <= 'z' or >= '0' and <= '9')
+                {
+                    sb.Append(ch);
+                }
+                else if (ch == ' ' || ch == '_' || ch == '-' || ch == '.')
+                {
+                    sb.Append('-');
+                }
+            }
+            string s = sb.ToString().Trim('-');
+            while (s.Contains("--"))
+            {
+                s = s.Replace("--", "-");
+            }
+            if (s.Length == 0)
+            {
+                return string.Empty;
+            }
+            if (s[0] is < 'a' or > 'z')
+            {
+                s = "app-" + s;
+            }
+            return s.Length > 64 ? s.Substring(0, 64).Trim('-') : s;
+        }
+
+        // Coerce a metadata version into SemVer-ish (x.y.z). "1.0" → "1.0.0", "1" → "1.0.0".
+        // Returns null when it can't, so the next default ("1.0.0") applies.
+        private static string? NormalizeVersion(string? raw)
+        {
+            if (string.IsNullOrWhiteSpace(raw))
+            {
+                return null;
+            }
+            string v = raw.Trim();
+            string core = v;
+            int sep = v.IndexOfAny(new[] { '-', '+' });
+            if (sep >= 0)
+            {
+                core = v.Substring(0, sep);
+            }
+            string[] parts = core.Split('.');
+            foreach (string p in parts)
+            {
+                if (!int.TryParse(p, out _))
+                {
+                    return null;
+                }
+            }
+            return parts.Length switch
+            {
+                1 => $"{parts[0]}.0.0",
+                2 => $"{parts[0]}.{parts[1]}.0",
+                _ => v
+            };
+        }
+    }
+}

--- a/Hina.Builder/Init/DescriptorScaffolder.cs
+++ b/Hina.Builder/Init/DescriptorScaffolder.cs
@@ -1,0 +1,53 @@
+using System.Collections.Generic;
+using Hina.PackageManager.Descriptor;
+
+namespace Hina.Builder.Init
+{
+    // Everything the wizard collected, ready to assemble into a descriptor.
+    internal sealed class ScaffoldAnswers
+    {
+        public string Name { get; init; } = string.Empty;
+        public string DisplayName { get; init; } = string.Empty;
+        public string Version { get; init; } = string.Empty;
+        public string Publisher { get; init; } = string.Empty;
+        public string Description { get; init; } = string.Empty;
+        public string? Homepage { get; init; }
+        public string BaseUrl { get; init; } = string.Empty;
+        public string Channel { get; init; } = "stable";
+        public string PublicKey { get; init; } = string.Empty;
+        public ExecMap Exec { get; init; } = new ExecMap();
+        public List<ShellEntry> Entries { get; init; } = new List<ShellEntry>();
+        public SandboxSpec? Sandbox { get; init; }
+        public bool AllowInsecure { get; init; }
+    }
+
+    // Assembles a validated AppDescriptor from the wizard's answers. Pure: throws
+    // DescriptorValidationException (the same the rest of Hina uses) if the result is invalid,
+    // so the wizard can re-prompt instead of writing a broken descriptor.
+    internal static class DescriptorScaffolder
+    {
+        public static AppDescriptor Build(ScaffoldAnswers a)
+        {
+            AppDescriptor descriptor = new AppDescriptor
+            {
+                SchemaVersion = DescriptorValidator.CurrentSchemaVersion,
+                Name = a.Name,
+                DisplayName = a.DisplayName,
+                Version = a.Version,
+                Publisher = a.Publisher,
+                Description = a.Description,
+                Homepage = a.Homepage,
+                BaseUrl = a.BaseUrl,
+                Channel = a.Channel,
+                PublicKey = a.PublicKey,
+                Exec = a.Exec,
+                Entries = a.Entries,
+                Sandbox = a.Sandbox
+            };
+
+            ValidationContext ctx = new ValidationContext { AllowInsecure = a.AllowInsecure };
+            DescriptorValidator.Validate(descriptor, ctx).EnsureValid();
+            return descriptor;
+        }
+    }
+}

--- a/Hina.Builder/Init/ExecutableDetector.cs
+++ b/Hina.Builder/Init/ExecutableDetector.cs
@@ -1,0 +1,170 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+
+namespace Hina.Builder.Init
+{
+    internal enum TargetOs
+    {
+        Windows,
+        Linux,
+        Macos
+    }
+
+    // One executable candidate found in the build folder.
+    internal sealed class DetectedExecutable
+    {
+        public string RelPath { get; init; } = string.Empty;   // forward-slash, relative to the scan root
+        public TargetOs Os { get; init; }
+        public bool IsBundle { get; init; }                     // macOS .app
+        // Higher = more likely to be the real app entry (vs a bundled library).
+        public int Rank { get; init; }
+    }
+
+    // Classifies files by magic bytes (PE / ELF / Mach-O) and recognises macOS .app bundles,
+    // so the wizard can propose the executables instead of asking the user to type paths.
+    // Pure + no interactive I/O: feed it a directory, get a ranked list back.
+    internal static class ExecutableDetector
+    {
+        public static IReadOnlyList<DetectedExecutable> Detect(DirectoryInfo root)
+        {
+            List<DetectedExecutable> found = new List<DetectedExecutable>();
+            if (!root.Exists)
+            {
+                return found;
+            }
+
+            // macOS .app bundles first — once matched, skip their inner files so we don't also
+            // list the inner Mach-O as a separate candidate.
+            HashSet<string> consumed = new HashSet<string>(StringComparer.Ordinal);
+            foreach (DirectoryInfo dir in root.EnumerateDirectories("*.app", SearchOption.AllDirectories))
+            {
+                string? innerExec = FindBundleExec(dir);
+                string rel = ToRel(root, innerExec ?? dir.FullName);
+                found.Add(new DetectedExecutable { RelPath = rel, Os = TargetOs.Macos, IsBundle = true, Rank = 100 });
+                foreach (FileInfo f in dir.EnumerateFiles("*", SearchOption.AllDirectories))
+                {
+                    consumed.Add(f.FullName);
+                }
+            }
+
+            foreach (FileInfo file in root.EnumerateFiles("*", SearchOption.AllDirectories))
+            {
+                if (consumed.Contains(file.FullName))
+                {
+                    continue;
+                }
+                TargetOs? os = ClassifyByMagic(file.FullName);
+                if (os == null)
+                {
+                    continue;
+                }
+                found.Add(new DetectedExecutable
+                {
+                    RelPath = ToRel(root, file.FullName),
+                    Os = os.Value,
+                    IsBundle = false,
+                    Rank = RankFor(file.Name, os.Value, root)
+                });
+            }
+
+            // Best candidate first: higher rank, then shallower path, then shorter name.
+            return found
+                .OrderByDescending(e => e.Rank)
+                .ThenBy(e => e.RelPath.Count(c => c == '/'))
+                .ThenBy(e => e.RelPath.Length)
+                .ToList();
+        }
+
+        private static string? FindBundleExec(DirectoryInfo bundle)
+        {
+            string macOsDir = Path.Combine(bundle.FullName, "Contents", "MacOS");
+            if (!Directory.Exists(macOsDir))
+            {
+                return null;
+            }
+            // First Mach-O (or, failing that, first file) under Contents/MacOS is the bundle exec.
+            string[] files = Directory.GetFiles(macOsDir);
+            string? machO = files.FirstOrDefault(f => ClassifyByMagic(f) == TargetOs.Macos);
+            return machO ?? (files.Length > 0 ? files[0] : null);
+        }
+
+        private static TargetOs? ClassifyByMagic(string path)
+        {
+            byte[] head = new byte[4];
+            int read;
+            try
+            {
+                using FileStream fs = new FileStream(path, FileMode.Open, FileAccess.Read, FileShare.Read);
+                read = fs.Read(head, 0, 4);
+            }
+            catch (IOException)
+            {
+                return null;
+            }
+            catch (UnauthorizedAccessException)
+            {
+                return null;
+            }
+            if (read < 4)
+            {
+                return null;
+            }
+
+            // PE (Windows): "MZ"
+            if (head[0] == 0x4D && head[1] == 0x5A)
+            {
+                return TargetOs.Windows;
+            }
+            // ELF (Linux): 0x7F 'E' 'L' 'F'
+            if (head[0] == 0x7F && head[1] == 0x45 && head[2] == 0x4C && head[3] == 0x46)
+            {
+                return TargetOs.Linux;
+            }
+            // Mach-O (macOS): thin (BE/LE, 32/64) or fat/universal.
+            uint magic = (uint)((head[0] << 24) | (head[1] << 16) | (head[2] << 8) | head[3]);
+            if (magic == 0xFEEDFACE || magic == 0xFEEDFACF // big-endian 32/64
+                || magic == 0xCEFAEDFE || magic == 0xCFFAEDFE // little-endian 32/64
+                || magic == 0xCAFEBABE || magic == 0xCAFEBABF) // fat/universal
+            {
+                return TargetOs.Macos;
+            }
+            return null;
+        }
+
+        // Real app entries outrank bundled libraries. Libraries keep magic bytes too (a .so is
+        // ELF, a .dll is PE), so demote the usual library extensions.
+        private static int RankFor(string fileName, TargetOs os, DirectoryInfo root)
+        {
+            string ext = Path.GetExtension(fileName).ToLowerInvariant();
+            if (ext is ".dll" or ".so" or ".dylib" or ".a" or ".lib")
+            {
+                return 1;
+            }
+
+            int rank = 10;
+            if (os == TargetOs.Windows && ext == ".exe")
+            {
+                rank += 20;
+            }
+            if (os != TargetOs.Windows && ext.Length == 0)
+            {
+                // Unix executables usually have no extension.
+                rank += 20;
+            }
+            // Name matching the folder is very likely the main entry (e.g. MyGame/MyGame).
+            if (string.Equals(Path.GetFileNameWithoutExtension(fileName), root.Name, StringComparison.OrdinalIgnoreCase))
+            {
+                rank += 15;
+            }
+            return rank;
+        }
+
+        private static string ToRel(DirectoryInfo root, string fullPath)
+        {
+            string rel = Path.GetRelativePath(root.FullName, fullPath);
+            return rel.Replace('\\', '/');
+        }
+    }
+}

--- a/Hina.Builder/Init/IPrompt.cs
+++ b/Hina.Builder/Init/IPrompt.cs
@@ -1,0 +1,70 @@
+using System;
+using System.Collections.Generic;
+
+namespace Hina.Builder.Init
+{
+    // The wizard's only channel to the user. Abstracted so InitCommand can be driven by a
+    // scripted prompt in tests (no real console I/O).
+    internal interface IPrompt
+    {
+        // Free-text question. Empty input returns def (or "" if def is null).
+        string Ask(string question, string? def);
+
+        // Yes/no. Empty input returns def.
+        bool Confirm(string question, bool def);
+
+        // Pick one of options by number. Empty input returns defaultIndex.
+        int Choose(string question, IReadOnlyList<string> options, int defaultIndex);
+    }
+
+    // Real console implementation. Shows the default in brackets so "just press Enter" works
+    // for every prompt.
+    internal sealed class ConsolePrompt : IPrompt
+    {
+        public string Ask(string question, string? def)
+        {
+            string suffix = string.IsNullOrEmpty(def) ? "" : $" [{def}]";
+            Console.Write($"{question}{suffix}: ");
+            string? line = Console.ReadLine();
+            if (string.IsNullOrWhiteSpace(line))
+            {
+                return def ?? string.Empty;
+            }
+            return line.Trim();
+        }
+
+        public bool Confirm(string question, bool def)
+        {
+            string hint = def ? "[Y/n]" : "[y/N]";
+            Console.Write($"{question} {hint}: ");
+            string? line = Console.ReadLine();
+            if (string.IsNullOrWhiteSpace(line))
+            {
+                return def;
+            }
+            string v = line.Trim().ToLowerInvariant();
+            return v == "y" || v == "yes";
+        }
+
+        public int Choose(string question, IReadOnlyList<string> options, int defaultIndex)
+        {
+            Console.WriteLine(question);
+            for (int i = 0; i < options.Count; i++)
+            {
+                string marker = i == defaultIndex ? " (default)" : "";
+                Console.WriteLine($"  {i + 1}. {options[i]}{marker}");
+            }
+            Console.Write($"Choice [{defaultIndex + 1}]: ");
+            string? line = Console.ReadLine();
+            if (string.IsNullOrWhiteSpace(line))
+            {
+                return defaultIndex;
+            }
+            if (int.TryParse(line.Trim(), out int n) && n >= 1 && n <= options.Count)
+            {
+                return n - 1;
+            }
+            return defaultIndex;
+        }
+    }
+}

--- a/Hina.Builder/Init/InitCommand.cs
+++ b/Hina.Builder/Init/InitCommand.cs
@@ -1,0 +1,375 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Hina.PackageManager.Descriptor;
+using Microsoft.Extensions.Logging;
+
+namespace Hina.Builder.Init
+{
+    // `hina-builder init` — interactive wizard. Scans the app folder, asks a few questions with
+    // smart defaults, then writes a signed hina.app.json plus the manifest/chunk store.
+    //
+    // Outputs (descriptor, keys, patch store) are written to a directory OUTSIDE the scanned
+    // payload: the build manifest covers every file under --input, so writing the private key
+    // or the chunk store inside it would ship them to users. Keeping outputs out of the payload
+    // is a hard safety rule, not a preference.
+    internal static class InitCommand
+    {
+        // The non-interactive (redirected-stdin) guard lives in Program for the real run; tests
+        // drive this directly with a ScriptedPrompt, so it must not check the console here.
+        public static async Task<int> RunAsync(string[] args, IPrompt prompt, ILogger logger, CancellationToken ct)
+        {
+            string inputArg = Args.GetArgValue(args, "--input") ?? ".";
+            DirectoryInfo input = new DirectoryInfo(Path.GetFullPath(inputArg));
+            if (!input.Exists)
+            {
+                logger.LogError("Folder not found: {Dir}", input.FullName);
+                return 2;
+            }
+
+            Console.WriteLine();
+            Console.WriteLine($"Preparing a Hina package from: {input.FullName}");
+            Console.WriteLine("Press Enter to accept the [default] shown for each question.");
+            Console.WriteLine();
+
+            IReadOnlyList<DetectedExecutable> detected = ExecutableDetector.Detect(input);
+            ScaffoldDefaults defaults = DefaultsResolver.Resolve(input);
+
+            // --- metadata ---
+            string name = AskName(prompt, defaults.Name);
+            string displayName = prompt.Ask("Display name", NonEmpty(defaults.DisplayName, name));
+            string version = AskVersion(prompt, defaults.Version);
+            string publisher = prompt.Ask("Publisher", defaults.Publisher);
+            string description = prompt.Ask("Short description", defaults.Description);
+            string homepage = prompt.Ask("Homepage URL (optional)", defaults.Homepage ?? "");
+            string baseUrl = prompt.Ask("Patch server base URL (where you'll host the files)", defaults.BaseUrl);
+            bool allowInsecure = baseUrl.StartsWith("http://", StringComparison.OrdinalIgnoreCase);
+
+            // --- executables → exec map (+ entries when single-OS) ---
+            (ExecMap exec, List<ShellEntry> entries) = CollectExecutables(prompt, detected, input, name, displayName, logger);
+            if (exec.Windows == null && exec.Linux == null && exec.Macos == null)
+            {
+                logger.LogError("No executable was selected; cannot build a descriptor. Aborting.");
+                return 1;
+            }
+
+            // --- sandbox (plain-language questions) ---
+            SandboxSpec? sandbox = AskSandbox(prompt);
+
+            // --- output dir for keys + patch (outside the payload) ---
+            // The descriptor itself is written into the app folder (it's public + signed, safe to
+            // ship). The signing KEY and the patch store must live OUTSIDE the scanned payload, or
+            // the build manifest would bundle the private key and recurse into its own output.
+            string outDir = AskOutputDir(prompt, input);
+            if (IsInside(outDir, input.FullName))
+            {
+                logger.LogError("Keys/patch output must be OUTSIDE the app folder, or the private key and patch store would be shipped to users. Got: {Out}", outDir);
+                return 2;
+            }
+            Directory.CreateDirectory(outDir);
+
+            string? keyPath = FindOrGenerateKey(prompt, outDir, name, logger);
+            if (keyPath == null)
+            {
+                logger.LogError("No signing key available; aborting (a Hina package must be signed).");
+                return 1;
+            }
+            string publicKeyB64 = File.ReadAllText(PubKeyFor(keyPath)).Trim();
+
+            // --- assemble + validate ---
+            AppDescriptor descriptor;
+            try
+            {
+                descriptor = DescriptorScaffolder.Build(new ScaffoldAnswers
+                {
+                    Name = name,
+                    DisplayName = displayName,
+                    Version = version,
+                    Publisher = publisher,
+                    Description = description,
+                    Homepage = string.IsNullOrWhiteSpace(homepage) ? null : homepage,
+                    BaseUrl = baseUrl,
+                    Channel = defaults.Channel,
+                    PublicKey = publicKeyB64,
+                    Exec = exec,
+                    Entries = entries,
+                    Sandbox = sandbox,
+                    AllowInsecure = allowInsecure
+                });
+            }
+            catch (DescriptorValidationException ex)
+            {
+                logger.LogError("The answers don't form a valid descriptor:\n{Errors}", ex.Message);
+                return 1;
+            }
+
+            // --- summary + confirm ---
+            // Descriptor lives in the project/app folder so a re-run picks it up as defaults.
+            string descriptorPath = Path.Combine(input.FullName, DefaultsResolver.DescriptorFileName);
+            PrintSummary(descriptor, descriptorPath, outDir);
+            if (File.Exists(descriptorPath) && !prompt.Confirm($"Overwrite existing {descriptorPath}?", true))
+            {
+                Console.WriteLine("Aborted; nothing written.");
+                return 0;
+            }
+
+            // --- sign descriptor + write ---
+            byte[] privateKey = Convert.FromBase64String(File.ReadAllText(keyPath).Trim());
+            DescriptorSigner.AttachSignature(descriptor, privateKey);
+            File.WriteAllText(descriptorPath, DescriptorParser.Serialize(descriptor, indented: true));
+            logger.LogInformation("Wrote signed descriptor: {Path}", descriptorPath);
+
+            // --- build manifest + chunks ---
+            string patchDir = Path.Combine(outDir, "patch");
+            int buildCode = await BuildCommand.RunAsync(new BuildOptions
+            {
+                Input = input.FullName,
+                Output = patchDir,
+                BaseUrl = baseUrl,
+                Version = version,
+                SignKeyPath = keyPath,
+                ChunkingMode = "cdc"
+            }, logger, ct);
+            if (buildCode != 0)
+            {
+                logger.LogError("Build step failed (the descriptor was written; fix the issue and re-run `build`).");
+                return buildCode;
+            }
+
+            PrintNextSteps(descriptor, descriptorPath, patchDir, baseUrl);
+            return 0;
+        }
+
+        // ---- metadata prompts ----
+
+        private static string AskName(IPrompt prompt, string def)
+        {
+            while (true)
+            {
+                string raw = prompt.Ask("App id (lowercase, a-z 0-9 -)", def);
+                string slug = DefaultsResolver.Slugify(raw);
+                AppDescriptor probe = new AppDescriptor { Name = slug };
+                bool nameOk = DescriptorValidator.Validate(probe).Errors.All(e => !e.StartsWith("name "));
+                if (nameOk && slug.Length > 0)
+                {
+                    if (!string.Equals(slug, raw, StringComparison.Ordinal))
+                    {
+                        Console.WriteLine($"  → using '{slug}'");
+                    }
+                    return slug;
+                }
+                Console.WriteLine("  Invalid id. Use letters, digits and dashes; must start with a letter.");
+                def = slug;
+            }
+        }
+
+        private static string AskVersion(IPrompt prompt, string def)
+        {
+            while (true)
+            {
+                string v = prompt.Ask("Version (SemVer x.y.z)", def);
+                AppDescriptor probe = new AppDescriptor { Version = v };
+                if (DescriptorValidator.Validate(probe).Errors.All(e => !e.StartsWith("version ")))
+                {
+                    return v;
+                }
+                Console.WriteLine("  Not valid SemVer (expected x.y.z). Try again.");
+                def = "1.0.0";
+            }
+        }
+
+        // ---- executables ----
+
+        private static (ExecMap, List<ShellEntry>) CollectExecutables(
+            IPrompt prompt, IReadOnlyList<DetectedExecutable> detected, DirectoryInfo input,
+            string name, string displayName, ILogger logger)
+        {
+            ExecMap exec = new ExecMap();
+            List<DetectedExecutable> chosen = new List<DetectedExecutable>();
+
+            if (detected.Count > 0)
+            {
+                Console.WriteLine();
+                Console.WriteLine($"Found {detected.Count} executable candidate(s):");
+            }
+
+            foreach (TargetOs os in new[] { TargetOs.Windows, TargetOs.Linux, TargetOs.Macos })
+            {
+                DetectedExecutable? best = detected.FirstOrDefault(d => d.Os == os);
+                string label = os.ToString().ToLowerInvariant();
+                if (best != null)
+                {
+                    if (prompt.Confirm($"Use '{best.RelPath}' as the {label} executable?", true))
+                    {
+                        SetExec(exec, os, best.RelPath);
+                        chosen.Add(best);
+                        continue;
+                    }
+                }
+                string manual = prompt.Ask($"Path to the {label} executable (relative, blank = none)", "");
+                if (!string.IsNullOrWhiteSpace(manual))
+                {
+                    string rel = manual.Replace('\\', '/').Trim();
+                    SetExec(exec, os, rel);
+                    chosen.Add(new DetectedExecutable { RelPath = rel, Os = os });
+                }
+            }
+
+            // Entries (menu launchers) are not per-OS in the schema, so only create them for a
+            // single-OS package. Multi-OS packages rely on the exec map and skip entries.
+            List<ShellEntry> entries = new List<ShellEntry>();
+            int osCount = new[] { exec.Windows, exec.Linux, exec.Macos }.Count(p => p != null);
+            if (osCount == 1)
+            {
+                if (prompt.Confirm("Create a desktop / Start-menu launcher for this app?", true))
+                {
+                    string entryExec = exec.Windows ?? exec.Linux ?? exec.Macos!;
+                    string entryName = prompt.Ask("Launcher name", displayName);
+                    string icon = prompt.Ask("Icon path (relative, optional)", "");
+                    entries.Add(new ShellEntry
+                    {
+                        Id = name,
+                        Name = entryName,
+                        Exec = entryExec,
+                        Icon = string.IsNullOrWhiteSpace(icon) ? null : icon.Replace('\\', '/').Trim()
+                    });
+                }
+            }
+            else if (osCount > 1)
+            {
+                logger.LogInformation(
+                    "Multi-OS package: per-OS menu launchers aren't supported by the descriptor schema yet, so no launcher entry was added. The app still launches via the exec map / `hina run`.");
+            }
+
+            return (exec, entries);
+        }
+
+        private static void SetExec(ExecMap exec, TargetOs os, string rel)
+        {
+            switch (os)
+            {
+                case TargetOs.Windows: exec.Windows = rel; break;
+                case TargetOs.Linux: exec.Linux = rel; break;
+                case TargetOs.Macos: exec.Macos = rel; break;
+            }
+        }
+
+        // ---- sandbox ----
+
+        private static SandboxSpec? AskSandbox(IPrompt prompt)
+        {
+            Console.WriteLine();
+            if (!prompt.Confirm("Run the app in a filesystem sandbox? (recommended)", true))
+            {
+                return new SandboxAnswers { Enabled = false }.ToSpec();
+            }
+
+            bool network = prompt.Confirm("Does the app need internet access?", true);
+            int loc = prompt.Choose(
+                "Where does the app save its data?",
+                new[]
+                {
+                    "Only inside itself (no extra access)",
+                    "A config folder",
+                    "The Documents folder",
+                    "Anywhere on disk (full access)"
+                },
+                defaultIndex: 1);
+
+            DataLocation dataLocation = loc switch
+            {
+                1 => DataLocation.Config,
+                2 => DataLocation.Documents,
+                3 => DataLocation.Anywhere,
+                _ => DataLocation.SelfOnly
+            };
+
+            return new SandboxAnswers { Enabled = true, NeedsNetwork = network, DataLocation = dataLocation }.ToSpec();
+        }
+
+        // ---- output dir + keys ----
+
+        private static string AskOutputDir(IPrompt prompt, DirectoryInfo input)
+        {
+            // Default to a sibling so it's never inside the scanned payload.
+            string def = Path.GetFullPath(Path.Combine(input.FullName, "..", input.Name + "-hina-dist"));
+            string answer = prompt.Ask("Output folder for keys + patch store (must be outside the app folder)", def);
+            return Path.GetFullPath(answer);
+        }
+
+        // Looks for an existing <outDir>/keys/*.key.b64; offers to generate one if absent.
+        // Returns the private-key path, or null if the user declined and none exist.
+        private static string? FindOrGenerateKey(IPrompt prompt, string outDir, string name, ILogger logger)
+        {
+            string keysDir = Path.Combine(outDir, "keys");
+            if (Directory.Exists(keysDir))
+            {
+                string? existing = Directory.GetFiles(keysDir, "*.key.b64").FirstOrDefault();
+                if (existing != null && File.Exists(PubKeyFor(existing)))
+                {
+                    Console.WriteLine($"Using existing signing key: {existing}");
+                    return existing;
+                }
+            }
+
+            if (!prompt.Confirm("No signing key found. Generate a new Ed25519 key pair?", true))
+            {
+                return null;
+            }
+            (string priv, _) = KeygenCommand.Generate(keysDir, name, logger);
+            Console.WriteLine($"  Keep the private key secret: {priv}");
+            return priv;
+        }
+
+        private static string PubKeyFor(string privateKeyPath)
+            => privateKeyPath.EndsWith(".key.b64", StringComparison.Ordinal)
+                ? privateKeyPath[..^".key.b64".Length] + ".pub.b64"
+                : privateKeyPath + ".pub.b64";
+
+        // ---- output ----
+
+        private static void PrintSummary(AppDescriptor d, string descriptorPath, string outDir)
+        {
+            Console.WriteLine();
+            Console.WriteLine("Summary");
+            Console.WriteLine($"  id:         {d.Name}");
+            Console.WriteLine($"  name:       {d.DisplayName}");
+            Console.WriteLine($"  version:    {d.Version}");
+            Console.WriteLine($"  publisher:  {d.Publisher}");
+            Console.WriteLine($"  baseUrl:    {d.BaseUrl}");
+            Console.WriteLine($"  exec:       win={d.Exec.Windows ?? "-"}  linux={d.Exec.Linux ?? "-"}  macos={d.Exec.Macos ?? "-"}");
+            Console.WriteLine($"  launchers:  {d.Entries.Count}");
+            Console.WriteLine($"  sandbox:    {(d.Sandbox?.Enabled == true ? "on" : "off")}");
+            Console.WriteLine($"  descriptor: {descriptorPath}");
+            Console.WriteLine($"  keys+patch: {outDir}");
+            Console.WriteLine();
+        }
+
+        private static void PrintNextSteps(AppDescriptor d, string descriptorPath, string patchDir, string baseUrl)
+        {
+            Console.WriteLine();
+            Console.WriteLine("Done. Next steps:");
+            Console.WriteLine($"  1. Upload the patch store to your server so it's reachable at: {baseUrl}");
+            Console.WriteLine($"     (contents of: {patchDir})");
+            Console.WriteLine($"  2. Host the descriptor and share its URL, e.g. {baseUrl.TrimEnd('/')}/hina.app.json");
+            Console.WriteLine($"     (file: {descriptorPath})");
+            Console.WriteLine($"  3. Users install with:  hina install <url-to-hina.app.json>");
+            Console.WriteLine();
+        }
+
+        // ---- helpers ----
+
+        private static string NonEmpty(string preferred, string fallback)
+            => string.IsNullOrWhiteSpace(preferred) ? fallback : preferred;
+
+        private static bool IsInside(string child, string parent)
+        {
+            string c = Path.GetFullPath(child).TrimEnd(Path.DirectorySeparatorChar) + Path.DirectorySeparatorChar;
+            string p = Path.GetFullPath(parent).TrimEnd(Path.DirectorySeparatorChar) + Path.DirectorySeparatorChar;
+            return c.StartsWith(p, StringComparison.Ordinal);
+        }
+    }
+}

--- a/Hina.Builder/Init/ProjectMetadataReader.cs
+++ b/Hina.Builder/Init/ProjectMetadataReader.cs
@@ -1,0 +1,166 @@
+using System;
+using System.IO;
+using System.Linq;
+using System.Text.Json;
+using System.Text.RegularExpressions;
+using System.Xml.Linq;
+
+namespace Hina.Builder.Init
+{
+    // Best-effort metadata harvested from common project files, used to pre-fill the wizard's
+    // defaults so the publisher mostly presses Enter. Every field is optional; any parse
+    // failure fails soft to null (the wizard just won't have that default).
+    internal sealed class ProjectMetadata
+    {
+        public string? Name { get; set; }
+        public string? Version { get; set; }
+        public string? Publisher { get; set; }
+        public string? Description { get; set; }
+        public string? Homepage { get; set; }
+
+        public bool IsEmpty => Name == null && Version == null && Publisher == null
+            && Description == null && Homepage == null;
+    }
+
+    internal static class ProjectMetadataReader
+    {
+        public static ProjectMetadata Read(DirectoryInfo root)
+        {
+            ProjectMetadata m = new ProjectMetadata();
+            if (!root.Exists)
+            {
+                return m;
+            }
+
+            // Order = priority. First non-null wins per field (Fill never overwrites).
+            TryCsproj(root, m);
+            TryPackageJson(root, m);
+            TryUnity(root, m);
+            TryGodot(root, m);
+            return m;
+        }
+
+        private static void Fill(ref string? field, string? value)
+        {
+            if (field == null && !string.IsNullOrWhiteSpace(value))
+            {
+                field = value!.Trim();
+            }
+        }
+
+        private static void TryCsproj(DirectoryInfo root, ProjectMetadata m)
+        {
+            FileInfo? csproj = root.EnumerateFiles("*.csproj", SearchOption.TopDirectoryOnly).FirstOrDefault();
+            if (csproj == null)
+            {
+                return;
+            }
+            try
+            {
+                XDocument doc = XDocument.Load(csproj.FullName);
+                string? Prop(string name) => doc.Descendants()
+                    .FirstOrDefault(e => e.Name.LocalName == name)?.Value;
+
+                string? name = m.Name; Fill(ref name, Prop("AssemblyName") ?? Prop("Title") ?? Prop("Product")); m.Name = name;
+                string? version = m.Version; Fill(ref version, Prop("Version")); m.Version = version;
+                string? publisher = m.Publisher; Fill(ref publisher, Prop("Authors") ?? Prop("Company")); m.Publisher = publisher;
+                string? description = m.Description; Fill(ref description, Prop("Description")); m.Description = description;
+                string? homepage = m.Homepage; Fill(ref homepage, Prop("PackageProjectUrl") ?? Prop("RepositoryUrl")); m.Homepage = homepage;
+            }
+            catch (Exception)
+            {
+                // fail soft — leave whatever we already had
+            }
+        }
+
+        private static void TryPackageJson(DirectoryInfo root, ProjectMetadata m)
+        {
+            string path = Path.Combine(root.FullName, "package.json");
+            if (!File.Exists(path))
+            {
+                return;
+            }
+            try
+            {
+                using JsonDocument doc = JsonDocument.Parse(File.ReadAllText(path));
+                JsonElement r = doc.RootElement;
+                string? Str(string prop) => r.TryGetProperty(prop, out JsonElement e) && e.ValueKind == JsonValueKind.String ? e.GetString() : null;
+
+                string? author = Str("author");
+                if (author == null && r.TryGetProperty("author", out JsonElement ae) && ae.ValueKind == JsonValueKind.Object
+                    && ae.TryGetProperty("name", out JsonElement an) && an.ValueKind == JsonValueKind.String)
+                {
+                    author = an.GetString();
+                }
+
+                string? name = m.Name; Fill(ref name, Str("name")); m.Name = name;
+                string? version = m.Version; Fill(ref version, Str("version")); m.Version = version;
+                string? publisher = m.Publisher; Fill(ref publisher, author); m.Publisher = publisher;
+                string? description = m.Description; Fill(ref description, Str("description")); m.Description = description;
+                string? homepage = m.Homepage; Fill(ref homepage, Str("homepage")); m.Homepage = homepage;
+            }
+            catch (Exception)
+            {
+                // fail soft
+            }
+        }
+
+        private static void TryUnity(DirectoryInfo root, ProjectMetadata m)
+        {
+            string path = Path.Combine(root.FullName, "ProjectSettings", "ProjectSettings.asset");
+            if (!File.Exists(path))
+            {
+                return;
+            }
+            try
+            {
+                string text = File.ReadAllText(path);
+                string? name = m.Name; Fill(ref name, YamlScalar(text, "productName")); m.Name = name;
+                string? publisher = m.Publisher; Fill(ref publisher, YamlScalar(text, "companyName")); m.Publisher = publisher;
+                string? version = m.Version; Fill(ref version, YamlScalar(text, "bundleVersion")); m.Version = version;
+            }
+            catch (Exception)
+            {
+                // fail soft
+            }
+        }
+
+        private static void TryGodot(DirectoryInfo root, ProjectMetadata m)
+        {
+            string path = Path.Combine(root.FullName, "project.godot");
+            if (!File.Exists(path))
+            {
+                return;
+            }
+            try
+            {
+                string text = File.ReadAllText(path);
+                string? name = m.Name; Fill(ref name, IniQuoted(text, "config/name")); m.Name = name;
+                string? version = m.Version; Fill(ref version, IniQuoted(text, "config/version")); m.Version = version;
+                string? description = m.Description; Fill(ref description, IniQuoted(text, "config/description")); m.Description = description;
+            }
+            catch (Exception)
+            {
+                // fail soft
+            }
+        }
+
+        // `  key: value` (Unity's YAML-ish asset). Returns the trimmed scalar, unquoted.
+        private static string? YamlScalar(string text, string key)
+        {
+            Match mm = Regex.Match(text, @"(?m)^\s*" + Regex.Escape(key) + @":\s*(.+?)\s*$");
+            if (!mm.Success)
+            {
+                return null;
+            }
+            return mm.Groups[1].Value.Trim().Trim('"');
+        }
+
+        // `key="value"` (Godot's INI-ish project file).
+        private static string? IniQuoted(string text, string key)
+        {
+            Match mm = Regex.Match(text, @"(?m)^\s*" + Regex.Escape(key) + @"\s*=\s*""(.*?)""\s*$");
+            return mm.Success ? mm.Groups[1].Value : null;
+        }
+    }
+}

--- a/Hina.Builder/Init/SandboxAnswers.cs
+++ b/Hina.Builder/Init/SandboxAnswers.cs
@@ -1,0 +1,57 @@
+using Hina.PackageManager.Descriptor;
+
+namespace Hina.Builder.Init
+{
+    // Where the app is allowed to write, expressed in plain language. Maps to sandbox fs tokens.
+    internal enum DataLocation
+    {
+        SelfOnly,   // only its own install dir (implicit) — no extra grant
+        Config,     // xdg-config
+        Documents,  // xdg-documents
+        Anywhere    // host (escape hatch)
+    }
+
+    // The handful of human answers the wizard collects about isolation, plus the translation
+    // into a SandboxSpec. Pure: no I/O, fully unit-testable.
+    internal sealed class SandboxAnswers
+    {
+        public bool Enabled { get; init; } = true;
+        public bool NeedsNetwork { get; init; }
+        public DataLocation DataLocation { get; init; } = DataLocation.SelfOnly;
+
+        // null when sandbox disabled (descriptor.Sandbox stays null ⇒ unsandboxed).
+        public SandboxSpec? ToSpec()
+        {
+            if (!Enabled)
+            {
+                return null;
+            }
+
+            SandboxSpec spec = new SandboxSpec { Enabled = true };
+
+            switch (DataLocation)
+            {
+                case DataLocation.Config:
+                    spec.Filesystem.Add(new FsRule { Path = SandboxTokens.XdgConfig, Access = "rw" });
+                    break;
+                case DataLocation.Documents:
+                    spec.Filesystem.Add(new FsRule { Path = SandboxTokens.XdgDocuments, Access = "rw" });
+                    break;
+                case DataLocation.Anywhere:
+                    spec.Filesystem.Add(new FsRule { Path = SandboxTokens.Host, Access = "rw" });
+                    break;
+                case DataLocation.SelfOnly:
+                default:
+                    // App install dir is always implicitly granted ro+exec; nothing to add.
+                    break;
+            }
+
+            if (NeedsNetwork)
+            {
+                spec.Capabilities = new CapabilitySpec { Network = true };
+            }
+
+            return spec;
+        }
+    }
+}

--- a/Hina.Builder/KeygenCommand.cs
+++ b/Hina.Builder/KeygenCommand.cs
@@ -1,0 +1,37 @@
+using System.IO;
+using Hina.Core.Crypto;
+using Microsoft.Extensions.Logging;
+
+namespace Hina.Builder
+{
+    // `hina-builder keygen` — generates an Ed25519 key pair for signing manifests and
+    // descriptors. Extracted from Program so the init wizard can offer to generate keys
+    // when none are present.
+    internal static class KeygenCommand
+    {
+        // Generates a key pair under outDir as <name>.key.b64 / <name>.pub.b64 and returns
+        // the two paths so callers (the wizard) can reuse them for signing.
+        public static (string PrivatePath, string PublicPath) Generate(string outDir, string name, ILogger logger)
+        {
+            Directory.CreateDirectory(outDir);
+            (string PrivateKeyBase64, string PublicKeyBase64) pair = KeyGenerator.GenerateEd25519();
+
+            string privPath = Path.Combine(outDir, $"{name}.key.b64");
+            string pubPath = Path.Combine(outDir, $"{name}.pub.b64");
+
+            File.WriteAllText(privPath, pair.PrivateKeyBase64);
+            File.WriteAllText(pubPath, pair.PublicKeyBase64);
+
+            logger.LogInformation("Key pair generated: {PrivateKeyPath}, {PublicKeyPath}", privPath, pubPath);
+            return (privPath, pubPath);
+        }
+
+        public static int Run(string[] args, ILogger logger)
+        {
+            string outDir = Args.GetArgValue(args, "--out") ?? ".";
+            string name = Args.GetArgValue(args, "--name") ?? "hina";
+            Generate(outDir, name, logger);
+            return 0;
+        }
+    }
+}

--- a/Hina.Builder/Program.cs
+++ b/Hina.Builder/Program.cs
@@ -1,11 +1,7 @@
 using System;
-using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
-using Hina.Core.Chunking;
-using Hina.Core.Hashing;
-using Hina.Core.Manifest;
-using Hina.Core.Rsync;
+using Hina.Builder.Init;
 using Microsoft.Extensions.Logging;
 
 namespace Hina.Builder
@@ -14,13 +10,13 @@ namespace Hina.Builder
     {
         private static async Task<int> Main(string[] args)
         {
-            if (args.Length == 0 || HasArg(args, "--help") || HasArg(args, "help"))
+            if (args.Length == 0 || Args.HasArg(args, "--help") || Args.HasArg(args, "help"))
             {
                 PrintHelp();
                 return 0;
             }
 
-            bool verbose = HasArg(args, "--verbose") || HasArg(args, "-v");
+            bool verbose = Args.HasArg(args, "--verbose") || Args.HasArg(args, "-v");
 
             using ILoggerFactory loggerFactory = LoggerFactory.Create(builder =>
             {
@@ -31,136 +27,35 @@ namespace Hina.Builder
             ILogger logger = loggerFactory.CreateLogger("Hina.Builder");
 
             string command = args[0].ToLowerInvariant();
-            if (command == "keygen")
+            switch (command)
             {
-                return RunKeygen(args, logger);
+                case "build":
+                    return await BuildCommand.RunAsync(BuildOptions.FromArgs(args), logger, CancellationToken.None);
+                case "keygen":
+                    return KeygenCommand.Run(args, logger);
+                case "init":
+                    if (Console.IsInputRedirected)
+                    {
+                        logger.LogError("`init` is interactive and needs a terminal. In CI, use `build` + `hina dev sign-descriptor` instead.");
+                        return 2;
+                    }
+                    return await InitCommand.RunAsync(args, new ConsolePrompt(), logger, CancellationToken.None);
+                default:
+                    logger.LogError("Unknown command: {Command}", command);
+                    PrintHelp();
+                    return 2;
             }
-
-            if (command != "build")
-            {
-                logger.LogError("Unknown command: {Command}", command);
-                PrintHelp();
-                return 2;
-            }
-
-            string? input = GetArgValue(args, "--input");
-            string? output = GetArgValue(args, "--out");
-            string? baseUrl = GetArgValue(args, "--base");
-            string? signKeyPath = GetArgValue(args, "--sign-key");
-            string version = GetArgValue(args, "--version") ?? "0.0.0";
-            int chunkSize = ParseInt(GetArgValue(args, "--chunk"), 64 * 1024);
-            string chunkingMode = GetArgValue(args, "--chunking") ?? "fixed";
-            int minChunk = ParseInt(GetArgValue(args, "--min-chunk"), 2048);
-            int maxChunk = ParseInt(GetArgValue(args, "--max-chunk"), 64 * 1024);
-            int avgChunk = ParseInt(GetArgValue(args, "--avg-chunk"), 8192);
-
-            if (string.IsNullOrWhiteSpace(input) || string.IsNullOrWhiteSpace(output) || string.IsNullOrWhiteSpace(baseUrl))
-            {
-                logger.LogError("Missing required args: --input, --out, --base");
-                return 2;
-            }
-
-            DirectoryInfo inputDir = new DirectoryInfo(input);
-            DirectoryInfo outputDir = new DirectoryInfo(output);
-            DirectoryInfo chunkDir = new DirectoryInfo(Path.Combine(outputDir.FullName, "chunks"));
-
-            IHasher hasher = new Sha256Hasher();
-            ManifestBuilder builder2 = new ManifestBuilder(hasher);
-
-            IChunker chunker;
-            if (string.Equals(chunkingMode, "cdc", StringComparison.OrdinalIgnoreCase))
-            {
-                chunker = new ContentDefinedChunker(hasher, minChunk, maxChunk, avgChunk);
-                logger.LogInformation("Using content-defined chunking (min={Min}, max={Max}, avg={Avg})", minChunk, maxChunk, avgChunk);
-            }
-            else
-            {
-                chunker = new RsyncChunker(chunkSize, hasher);
-                logger.LogInformation("Using fixed-size chunking (size={Size})", chunkSize);
-            }
-
-            ChunkStoreWriter chunkWriter = new ChunkStoreWriter(hasher, chunkSize, chunker);
-
-            string normalizedBase = NormalizeBaseUrl(baseUrl);
-            logger.LogInformation("Building manifest from {InputDir}", inputDir.FullName);
-            Manifest manifest = await builder2.BuildAsync(inputDir, new Uri(normalizedBase), chunkSize, chunker, CancellationToken.None);
-            manifest.Version = version;
-            if (!string.IsNullOrWhiteSpace(signKeyPath))
-            {
-                byte[] privateKey = Convert.FromBase64String(File.ReadAllText(signKeyPath).Trim());
-                ManifestSigner.AttachSignature(manifest, privateKey);
-                logger.LogInformation("Manifest signed with key from {KeyPath}", signKeyPath);
-            }
-
-            outputDir.Create();
-            await ManifestSerializer.WriteAsync(manifest, Path.Combine(outputDir.FullName, "manifest.json"), CancellationToken.None);
-            await chunkWriter.WriteChunksAsync(inputDir, chunkDir, CancellationToken.None);
-
-            logger.LogInformation("Build complete");
-            logger.LogInformation("Manifest: {ManifestPath}", Path.Combine(outputDir.FullName, "manifest.json"));
-            logger.LogInformation("Chunks: {ChunkDir}", chunkDir.FullName);
-            return 0;
-        }
-
-        private static int ParseInt(string? value, int fallback)
-        {
-            return int.TryParse(value, out int v) ? v : fallback;
         }
 
         private static void PrintHelp()
         {
             Console.WriteLine("Hina Builder");
             Console.WriteLine("Usage:");
+            Console.WriteLine("  hina-builder init [--input <dir>]");
+            Console.WriteLine("      Interactive wizard: scans the folder, asks a few questions, and generates a");
+            Console.WriteLine("      signed hina.app.json plus the manifest/chunk store ready to host.");
             Console.WriteLine("  hina-builder build --input <dir> --out <dir> --base <url> [--version v] [--chunk 65536] [--chunking fixed|cdc] [--min-chunk 2048] [--max-chunk 65536] [--avg-chunk 8192] [--sign-key key.b64] [-v|--verbose]");
             Console.WriteLine("  hina-builder keygen [--out <dir>] [--name <prefix>]");
-        }
-
-        private static bool HasArg(string[] args, string name)
-        {
-            foreach (string arg in args)
-            {
-                if (string.Equals(arg, name, StringComparison.OrdinalIgnoreCase))
-                {
-                    return true;
-                }
-            }
-            return false;
-        }
-
-        private static string? GetArgValue(string[] args, string name)
-        {
-            for (int i = 0; i < args.Length - 1; i++)
-            {
-                if (string.Equals(args[i], name, StringComparison.OrdinalIgnoreCase))
-                {
-                    return args[i + 1];
-                }
-            }
-            return null;
-        }
-
-        private static int RunKeygen(string[] args, ILogger logger)
-        {
-            string? outDir = GetArgValue(args, "--out") ?? ".";
-            string name = GetArgValue(args, "--name") ?? "hina";
-
-            Directory.CreateDirectory(outDir);
-            var pair = Hina.Core.Crypto.KeyGenerator.GenerateEd25519();
-
-            string privPath = Path.Combine(outDir, $"{name}.key.b64");
-            string pubPath = Path.Combine(outDir, $"{name}.pub.b64");
-
-            File.WriteAllText(privPath, pair.PrivateKeyBase64);
-            File.WriteAllText(pubPath, pair.PublicKeyBase64);
-
-            logger.LogInformation("Key pair generated: {PrivateKeyPath}, {PublicKeyPath}", privPath, pubPath);
-            return 0;
-        }
-
-        private static string NormalizeBaseUrl(string url)
-        {
-            // Ensure base URL is safe for Uri combination.
-            return url.EndsWith("/") ? url : url + "/";
         }
     }
 }

--- a/Hina.sln
+++ b/Hina.sln
@@ -19,6 +19,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Hina.PackageManager.Tests",
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Hina.CLI.Tests", "Hina.CLI.Tests\Hina.CLI.Tests.csproj", "{A502024E-7AAA-4928-9F36-4FF7BA6F396B}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Hina.Builder.Tests", "Hina.Builder.Tests\Hina.Builder.Tests.csproj", "{CA436D7B-4F84-4E9B-B7D1-A5A0F0948FBD}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -125,6 +127,18 @@ Global
 		{A502024E-7AAA-4928-9F36-4FF7BA6F396B}.Release|x64.Build.0 = Release|Any CPU
 		{A502024E-7AAA-4928-9F36-4FF7BA6F396B}.Release|x86.ActiveCfg = Release|Any CPU
 		{A502024E-7AAA-4928-9F36-4FF7BA6F396B}.Release|x86.Build.0 = Release|Any CPU
+		{CA436D7B-4F84-4E9B-B7D1-A5A0F0948FBD}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{CA436D7B-4F84-4E9B-B7D1-A5A0F0948FBD}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{CA436D7B-4F84-4E9B-B7D1-A5A0F0948FBD}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{CA436D7B-4F84-4E9B-B7D1-A5A0F0948FBD}.Debug|x64.Build.0 = Debug|Any CPU
+		{CA436D7B-4F84-4E9B-B7D1-A5A0F0948FBD}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{CA436D7B-4F84-4E9B-B7D1-A5A0F0948FBD}.Debug|x86.Build.0 = Debug|Any CPU
+		{CA436D7B-4F84-4E9B-B7D1-A5A0F0948FBD}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{CA436D7B-4F84-4E9B-B7D1-A5A0F0948FBD}.Release|Any CPU.Build.0 = Release|Any CPU
+		{CA436D7B-4F84-4E9B-B7D1-A5A0F0948FBD}.Release|x64.ActiveCfg = Release|Any CPU
+		{CA436D7B-4F84-4E9B-B7D1-A5A0F0948FBD}.Release|x64.Build.0 = Release|Any CPU
+		{CA436D7B-4F84-4E9B-B7D1-A5A0F0948FBD}.Release|x86.ActiveCfg = Release|Any CPU
+		{CA436D7B-4F84-4E9B-B7D1-A5A0F0948FBD}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/docs/Builder-Guide.md
+++ b/docs/Builder-Guide.md
@@ -6,13 +6,48 @@ The Hina Builder (`Hina.Builder`) generates a manifest and chunk store from a di
 
 ## Commands
 
-The builder supports two commands: `build` and `keygen`.
+The builder supports three commands: `init`, `build`, and `keygen`.
 
 ```
+hina-builder init    [--input <dir>]
 hina-builder build   --input <dir> --out <dir> --base <url> [options]
 hina-builder keygen  [--out <dir>] [--name <prefix>]
 hina-builder --help
 ```
+
+---
+
+## init Command (recommended starting point)
+
+`init` is an interactive wizard: run it in (or point it at) your application folder and it
+does the whole publisher setup for you — no need to hand-write `hina.app.json` or remember the
+`build`/`keygen`/`sign-descriptor` sequence.
+
+```shell
+dotnet run --project Hina.Builder -- init --input ./build
+```
+
+What it does:
+
+1. **Scans** the folder and detects executable candidates by magic bytes (PE → Windows,
+   ELF → Linux, Mach-O / `.app` bundle → macOS), then asks you to confirm each one.
+2. **Pre-fills every answer** with a smart `[default]` — just press Enter to accept. Defaults
+   come from an existing `hina.app.json` (re-running `init` edits it) or, failing that, from
+   your project files (`.csproj`, `package.json`, Unity `ProjectSettings.asset`, Godot
+   `project.godot`).
+3. Asks a few plain-language **sandbox** questions ("does it need internet?", "where does it
+   save data?") and translates them into the descriptor's sandbox block.
+4. Generates an **Ed25519 key pair** if you don't have one, then writes a **signed
+   `hina.app.json`** into the app folder and runs **`build`** to produce the manifest + chunk
+   store.
+
+Output layout: the signed `hina.app.json` is written into the app folder (it's public and safe
+to ship), while the **signing keys and the patch store are written to a separate folder OUTSIDE
+the app folder** — the build manifest covers every file under `--input`, so keeping the private
+key out of it is mandatory.
+
+`init` is interactive and refuses to run with redirected stdin (CI). In a pipeline, use the
+scriptable `build` + `hina dev sign-descriptor` commands instead.
 
 ---
 


### PR DESCRIPTION
## Cosa

Pubblicare un'app/gioco con Hina era macchinoso: scrivere a mano `hina.app.json` (exec map per-OS, entries, sandbox), generare le chiavi, lanciare `build`, firmare il descriptor — più comandi e parecchia sintassi. `hina-builder init` lo riduce a **un solo wizard interattivo** lanciato nella cartella dell'app.

```shell
dotnet run --project Hina.Builder -- init --input ./build
```

## Comportamento

- **Detection eseguibili** per magic bytes: PE→windows, ELF→linux, Mach-O/`.app`→macos. Conferma uno a uno.
- **Tutto con default smart**: ogni domanda mostra un `[default]` — basta premere Invio. I default vengono da un `hina.app.json` esistente (re-run = modifica) oppure dai file di progetto (`.csproj`, `package.json`, Unity, Godot).
- **Sandbox a domande umane**: "serve internet?", "dove salva i dati?" → tradotte in `SandboxSpec` (token + capabilities).
- **Chiavi**: se assenti genera una coppia Ed25519; poi scrive un `hina.app.json` **firmato** e lancia `build`.

## Sicurezza

Il descriptor (pubblico, firmato) va nella cartella dell'app; **chiave privata e patch store vengono scritti FUORI dal payload scansionato** — il manifest di build copre ogni file sotto `--input`, quindi la chiave privata non deve mai stare lì. Verificato da test (`*.key.b64` assente dal payload).

## Architettura (logica pura + shell sottile, tutto testato)

- `build`/`keygen` estratti da `Program.Main` in `BuildCommand`/`KeygenCommand`; `Program` ora è solo dispatch.
- Classi pure nuove: `ExecutableDetector`, `ProjectMetadataReader`, `DefaultsResolver`, `DescriptorScaffolder`, `SandboxAnswers`. Riuso di `DescriptorValidator`/`DescriptorSigner`/`DescriptorParser` (Hina.PackageManager) e `KeyGenerator`/`ManifestSigner` (Hina.Core).
- Prompting dietro `IPrompt` (`ConsolePrompt` reale, `ScriptedPrompt` per i test); `init` rifiuta stdin redirected (CI) e rimanda a `build` + `sign-descriptor`.
- Nuovo progetto `Hina.Builder.Tests` (+22 test), incluso un run end-to-end del wizard.
- `Hina.Builder` ora referenzia `Hina.PackageManager` per i tipi descriptor.

## Test

484 test verdi (+22). Verifica manuale: dispatch, guard non-interattivo, regressione `build`/`keygen`, help.

🤖 Generated with [Claude Code](https://claude.com/claude-code)