### PR TITLE
feat(platform): per-platform variants with selective download

### DIFF
--- a/Hina.Builder.Tests/BuildCommandTests.cs
+++ b/Hina.Builder.Tests/BuildCommandTests.cs
@@ -1,0 +1,87 @@
+using System;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using Hina.Builder;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace Hina.Builder.Tests
+{
+    public sealed class BuildCommandTests : IDisposable
+    {
+        private readonly string _base;
+        private readonly string _input;
+        private readonly string _out;
+
+        public BuildCommandTests()
+        {
+            _base = Path.Combine(Path.GetTempPath(), "hina-build-" + Guid.NewGuid().ToString("N"));
+            _input = Path.Combine(_base, "in");
+            _out = Path.Combine(_base, "out");
+            Directory.CreateDirectory(_input);
+        }
+
+        public void Dispose()
+        {
+            try { Directory.Delete(_base, recursive: true); } catch { /* best-effort */ }
+        }
+
+        private BuildOptions Opts(string? platform) => new BuildOptions
+        {
+            Input = _input,
+            Output = _out,
+            BaseUrl = "https://patch.example.com/",
+            Version = "1.0.0",
+            ChunkingMode = "cdc",
+            Platform = platform
+        };
+
+        [Fact]
+        public async Task Build_WithPlatform_WritesPlatformManifest()
+        {
+            File.WriteAllText(Path.Combine(_input, "game"), "linux build payload");
+
+            int code = await BuildCommand.RunAsync(Opts("linux"), NullLogger.Instance, CancellationToken.None);
+
+            Assert.Equal(0, code);
+            Assert.True(File.Exists(Path.Combine(_out, "manifest.linux.json")));
+            Assert.False(File.Exists(Path.Combine(_out, "manifest.json")));
+            Assert.True(Directory.Exists(Path.Combine(_out, "chunks")));
+        }
+
+        [Fact]
+        public async Task Build_TwoVariants_ShareOneChunkStore()
+        {
+            // Same content in both variant inputs → the shared chunk store dedupes it.
+            File.WriteAllText(Path.Combine(_input, "common.dat"), "shared asset bytes");
+            await BuildCommand.RunAsync(Opts("linux"), NullLogger.Instance, CancellationToken.None);
+
+            string input2 = Path.Combine(_base, "in2");
+            Directory.CreateDirectory(input2);
+            File.WriteAllText(Path.Combine(input2, "common.dat"), "shared asset bytes");
+            int code = await BuildCommand.RunAsync(new BuildOptions
+            {
+                Input = input2,
+                Output = _out,
+                BaseUrl = "https://patch.example.com/",
+                Version = "1.0.0",
+                ChunkingMode = "cdc",
+                Platform = "windows-x64"
+            }, NullLogger.Instance, CancellationToken.None);
+
+            Assert.Equal(0, code);
+            Assert.True(File.Exists(Path.Combine(_out, "manifest.linux.json")));
+            Assert.True(File.Exists(Path.Combine(_out, "manifest.windows-x64.json")));
+            // One shared chunks/ dir under the single output.
+            Assert.True(Directory.Exists(Path.Combine(_out, "chunks")));
+        }
+
+        [Fact]
+        public async Task Build_InvalidPlatformToken_ReturnsUsageError()
+        {
+            File.WriteAllText(Path.Combine(_input, "game"), "x");
+            int code = await BuildCommand.RunAsync(Opts("solaris-sparc"), NullLogger.Instance, CancellationToken.None);
+            Assert.Equal(2, code);
+        }
+    }
+}

--- a/Hina.Builder.Tests/InitCommandTests.cs
+++ b/Hina.Builder.Tests/InitCommandTests.cs
@@ -100,6 +100,63 @@ namespace Hina.Builder.Tests
             Assert.Empty(Directory.GetFiles(_payload, "*.key.b64", SearchOption.AllDirectories));
         }
 
+        private void WriteBin(string relDir, string name, byte[] magic)
+        {
+            string dir = Path.Combine(_payload, relDir);
+            Directory.CreateDirectory(dir);
+            byte[] body = new byte[64];
+            Array.Copy(magic, body, magic.Length);
+            File.WriteAllBytes(Path.Combine(dir, name), body);
+        }
+
+        [Fact]
+        public async Task Init_MultiVariantSubdirs_WritesPlatformsAndPerVariantManifests()
+        {
+            // Per-platform subdirs named by token; each holds one OS's executable.
+            WriteBin("windows-x64", "Game.exe", new byte[] { 0x4D, 0x5A, 0x90, 0x00 });   // PE
+            WriteBin("macos-arm64", "Game", new byte[] { 0xCF, 0xFA, 0xED, 0xFE });        // Mach-O
+            WriteBin("linux", "game", new byte[] { 0x7F, 0x45, 0x4C, 0x46 });              // ELF
+
+            ScriptedPrompt script = new ScriptedPrompt(
+                asks: new[]
+                {
+                    "mygame", "My Game", "1.2.3", "Acme", "A fun game", "",
+                    "https://patch.example.com/",
+                    _out                              // output folder
+                },
+                confirms: new[]
+                {
+                    true, true, true,   // use detected exec for each of the 3 variants
+                    true,               // sandbox
+                    true,               // internet
+                    true                // generate key
+                },
+                chooses: new[] { 1 });
+
+            int code = await InitCommand.RunAsync(
+                new[] { "init", "--input", _payload }, script, NullLogger.Instance, CancellationToken.None);
+
+            Assert.Equal(0, code);
+
+            AppDescriptor d = DescriptorParser.Parse(
+                await File.ReadAllTextAsync(Path.Combine(_payload, "hina.app.json")));
+
+            Assert.Equal(3, d.Platforms.Count);
+            Assert.Empty(d.Exec.Windows ?? "");   // legacy exec map left empty
+            Assert.Contains(d.Platforms, p => p.Os == "windows" && p.Arch == "x64" && p.Exec == "Game.exe");
+            Assert.Contains(d.Platforms, p => p.Os == "macos" && p.Arch == "arm64" && p.Exec == "Game");
+            Assert.Contains(d.Platforms, p => p.Os == "linux" && p.Arch == null && p.Exec == "game");
+            Assert.NotNull(d.DescriptorSignature);
+            Assert.True(DescriptorValidator.Validate(d).IsValid);
+
+            // One manifest per variant, shared chunk store, all outside the payload.
+            string patch = Path.Combine(_out, "patch");
+            Assert.True(File.Exists(Path.Combine(patch, "manifest.windows-x64.json")));
+            Assert.True(File.Exists(Path.Combine(patch, "manifest.macos-arm64.json")));
+            Assert.True(File.Exists(Path.Combine(patch, "manifest.linux.json")));
+            Assert.True(Directory.Exists(Path.Combine(patch, "chunks")));
+        }
+
         [Fact]
         public async Task Init_ReRun_UsesExistingDescriptorAsDefaults()
         {

--- a/Hina.Builder/BuildCommand.cs
+++ b/Hina.Builder/BuildCommand.cs
@@ -26,8 +26,14 @@ namespace Hina.Builder
         public int MaxChunk { get; init; } = 64 * 1024;
         public int AvgChunk { get; init; } = 8192;
 
+        // Variant token (e.g. "windows-x64", "linux") for a multi-platform app. When set, the
+        // manifest is written as manifest.<token>.json into the same --out (shared chunk store),
+        // so each variant's build dedupes common chunks against the others.
+        public string? Platform { get; init; }
+
         public static BuildOptions FromArgs(string[] args) => new BuildOptions
         {
+            Platform = Args.GetArgValue(args, "--platform"),
             Input = Args.GetArgValue(args, "--input") ?? string.Empty,
             Output = Args.GetArgValue(args, "--out") ?? string.Empty,
             BaseUrl = Args.GetArgValue(args, "--base") ?? string.Empty,
@@ -49,6 +55,17 @@ namespace Hina.Builder
             {
                 logger.LogError("Missing required args: --input, --out, --base");
                 return 2;
+            }
+
+            string manifestName = "manifest.json";
+            if (!string.IsNullOrEmpty(options.Platform))
+            {
+                if (!IsValidPlatformToken(options.Platform))
+                {
+                    logger.LogError("Invalid --platform '{Token}'. Expected <os>[-<arch>], os ∈ windows|macos|linux, arch ∈ x64|arm64|x86|arm.", options.Platform);
+                    return 2;
+                }
+                manifestName = $"manifest.{options.Platform}.json";
             }
 
             DirectoryInfo inputDir = new DirectoryInfo(options.Input);
@@ -84,11 +101,11 @@ namespace Hina.Builder
             }
 
             outputDir.Create();
-            await ManifestSerializer.WriteAsync(manifest, Path.Combine(outputDir.FullName, "manifest.json"), ct);
+            await ManifestSerializer.WriteAsync(manifest, Path.Combine(outputDir.FullName, manifestName), ct);
             await chunkWriter.WriteChunksAsync(inputDir, chunkDir, ct);
 
             logger.LogInformation("Build complete");
-            logger.LogInformation("Manifest: {ManifestPath}", Path.Combine(outputDir.FullName, "manifest.json"));
+            logger.LogInformation("Manifest: {ManifestPath}", Path.Combine(outputDir.FullName, manifestName));
             logger.LogInformation("Chunks: {ChunkDir}", chunkDir.FullName);
             return 0;
         }
@@ -97,6 +114,20 @@ namespace Hina.Builder
         {
             // Ensure base URL is safe for Uri combination.
             return url.EndsWith("/") ? url : url + "/";
+        }
+
+        // <os>[-<arch>]; os ∈ {windows,macos,linux}, arch ∈ {x64,arm64,x86,arm}. Shares the closed
+        // sets with DescriptorValidator so the build token and the descriptor's platforms[] agree.
+        private static bool IsValidPlatformToken(string token)
+        {
+            int dash = token.IndexOf('-');
+            string os = dash < 0 ? token : token.Substring(0, dash);
+            string? arch = dash < 0 ? null : token.Substring(dash + 1);
+            if (!Hina.PackageManager.Descriptor.DescriptorValidator.KnownOs.Contains(os))
+            {
+                return false;
+            }
+            return arch == null || Hina.PackageManager.Descriptor.DescriptorValidator.KnownArch.Contains(arch);
         }
     }
 }

--- a/Hina.Builder/Init/DescriptorScaffolder.cs
+++ b/Hina.Builder/Init/DescriptorScaffolder.cs
@@ -16,6 +16,9 @@ namespace Hina.Builder.Init
         public string Channel { get; init; } = "stable";
         public string PublicKey { get; init; } = string.Empty;
         public ExecMap Exec { get; init; } = new ExecMap();
+        // Multi-platform variants. When non-empty the descriptor ships per-variant manifests and
+        // the legacy Exec map is left empty.
+        public List<PlatformVariant> Platforms { get; init; } = new List<PlatformVariant>();
         public List<ShellEntry> Entries { get; init; } = new List<ShellEntry>();
         public SandboxSpec? Sandbox { get; init; }
         public bool AllowInsecure { get; init; }
@@ -41,6 +44,7 @@ namespace Hina.Builder.Init
                 Channel = a.Channel,
                 PublicKey = a.PublicKey,
                 Exec = a.Exec,
+                Platforms = a.Platforms,
                 Entries = a.Entries,
                 Sandbox = a.Sandbox
             };

--- a/Hina.Builder/Init/InitCommand.cs
+++ b/Hina.Builder/Init/InitCommand.cs
@@ -48,12 +48,31 @@ namespace Hina.Builder.Init
             string baseUrl = prompt.Ask("Patch server base URL (where you'll host the files)", defaults.BaseUrl);
             bool allowInsecure = baseUrl.StartsWith("http://", StringComparison.OrdinalIgnoreCase);
 
-            // --- executables → exec map (+ entries when single-OS) ---
-            (ExecMap exec, List<ShellEntry> entries) = CollectExecutables(prompt, detected, input, name, displayName, logger);
-            if (exec.Windows == null && exec.Linux == null && exec.Macos == null)
+            // --- executables: per-variant subdirs (multi-platform) OR a single payload ---
+            ExecMap exec = new ExecMap();
+            List<ShellEntry> entries = new List<ShellEntry>();
+            List<PlatformVariant> platforms = new List<PlatformVariant>();
+            List<VariantDir> variantDirs = DetectVariantDirs(input);
+
+            if (variantDirs.Count > 0)
             {
-                logger.LogError("No executable was selected; cannot build a descriptor. Aborting.");
-                return 1;
+                Console.WriteLine();
+                Console.WriteLine($"Detected {variantDirs.Count} platform variant folder(s); building one manifest per variant.");
+                platforms = CollectVariants(prompt, variantDirs, logger);
+                if (platforms.Count == 0)
+                {
+                    logger.LogError("No executable was found in any variant folder; aborting.");
+                    return 1;
+                }
+            }
+            else
+            {
+                (exec, entries) = CollectExecutables(prompt, detected, input, name, displayName, logger);
+                if (exec.Windows == null && exec.Linux == null && exec.Macos == null)
+                {
+                    logger.LogError("No executable was selected; cannot build a descriptor. Aborting.");
+                    return 1;
+                }
             }
 
             // --- sandbox (plain-language questions) ---
@@ -95,6 +114,7 @@ namespace Hina.Builder.Init
                     Channel = defaults.Channel,
                     PublicKey = publicKeyB64,
                     Exec = exec,
+                    Platforms = platforms,
                     Entries = entries,
                     Sandbox = sandbox,
                     AllowInsecure = allowInsecure
@@ -122,21 +142,47 @@ namespace Hina.Builder.Init
             File.WriteAllText(descriptorPath, DescriptorParser.Serialize(descriptor, indented: true));
             logger.LogInformation("Wrote signed descriptor: {Path}", descriptorPath);
 
-            // --- build manifest + chunks ---
+            // --- build manifest(s) + chunks ---
+            // Multi-variant: one manifest per variant into a SHARED chunk store (dedup across
+            // variants). Single payload: one manifest.json from the whole folder.
             string patchDir = Path.Combine(outDir, "patch");
-            int buildCode = await BuildCommand.RunAsync(new BuildOptions
+            if (variantDirs.Count > 0)
             {
-                Input = input.FullName,
-                Output = patchDir,
-                BaseUrl = baseUrl,
-                Version = version,
-                SignKeyPath = keyPath,
-                ChunkingMode = "cdc"
-            }, logger, ct);
-            if (buildCode != 0)
+                foreach (VariantDir vd in variantDirs)
+                {
+                    int code = await BuildCommand.RunAsync(new BuildOptions
+                    {
+                        Input = vd.Dir.FullName,
+                        Output = patchDir,
+                        BaseUrl = baseUrl,
+                        Version = version,
+                        SignKeyPath = keyPath,
+                        ChunkingMode = "cdc",
+                        Platform = vd.Token
+                    }, logger, ct);
+                    if (code != 0)
+                    {
+                        logger.LogError("Build step failed for variant {Token} (descriptor written; fix and re-run `build`).", vd.Token);
+                        return code;
+                    }
+                }
+            }
+            else
             {
-                logger.LogError("Build step failed (the descriptor was written; fix the issue and re-run `build`).");
-                return buildCode;
+                int buildCode = await BuildCommand.RunAsync(new BuildOptions
+                {
+                    Input = input.FullName,
+                    Output = patchDir,
+                    BaseUrl = baseUrl,
+                    Version = version,
+                    SignKeyPath = keyPath,
+                    ChunkingMode = "cdc"
+                }, logger, ct);
+                if (buildCode != 0)
+                {
+                    logger.LogError("Build step failed (the descriptor was written; fix the issue and re-run `build`).");
+                    return buildCode;
+                }
             }
 
             PrintNextSteps(descriptor, descriptorPath, patchDir, baseUrl);
@@ -256,6 +302,82 @@ namespace Hina.Builder.Init
                 case TargetOs.Macos: exec.Macos = rel; break;
             }
         }
+
+        // ---- per-variant subdir layout ----
+
+        private sealed class VariantDir
+        {
+            public string Token { get; init; } = string.Empty;   // "windows-x64", "linux", ...
+            public string Os { get; init; } = string.Empty;
+            public string? Arch { get; init; }
+            public DirectoryInfo Dir { get; init; } = null!;
+        }
+
+        // Immediate subdirs whose NAME is a valid platform token (os[-arch]) are treated as
+        // per-platform variant folders. None ⇒ single-payload mode.
+        private static List<VariantDir> DetectVariantDirs(DirectoryInfo input)
+        {
+            List<VariantDir> result = new List<VariantDir>();
+            foreach (DirectoryInfo sub in input.EnumerateDirectories())
+            {
+                string token = sub.Name;
+                int dash = token.IndexOf('-');
+                string os = dash < 0 ? token : token.Substring(0, dash);
+                string? arch = dash < 0 ? null : token.Substring(dash + 1);
+                if (!DescriptorValidator.KnownOs.Contains(os))
+                {
+                    continue;
+                }
+                if (arch != null && !DescriptorValidator.KnownArch.Contains(arch))
+                {
+                    continue;
+                }
+                result.Add(new VariantDir { Token = token, Os = os, Arch = arch, Dir = sub });
+            }
+            return result;
+        }
+
+        private static List<PlatformVariant> CollectVariants(IPrompt prompt, List<VariantDir> variantDirs, ILogger logger)
+        {
+            List<PlatformVariant> platforms = new List<PlatformVariant>();
+            foreach (VariantDir vd in variantDirs)
+            {
+                IReadOnlyList<DetectedExecutable> detected = ExecutableDetector.Detect(vd.Dir);
+                DetectedExecutable? best = null;
+                foreach (DetectedExecutable d in detected)
+                {
+                    if (OsString(d.Os) == vd.Os) { best = d; break; }
+                }
+                best ??= detected.Count > 0 ? detected[0] : null;
+
+                string exec;
+                if (best != null && prompt.Confirm($"[{vd.Token}] use '{best.RelPath}' as the executable?", true))
+                {
+                    exec = best.RelPath;
+                }
+                else
+                {
+                    exec = prompt.Ask($"[{vd.Token}] path to the executable (relative to {vd.Token}/, blank = skip)", "");
+                    if (string.IsNullOrWhiteSpace(exec))
+                    {
+                        logger.LogWarning("No executable for variant {Token}; skipping it.", vd.Token);
+                        continue;
+                    }
+                    exec = exec.Replace('\\', '/').Trim();
+                }
+
+                platforms.Add(new PlatformVariant { Os = vd.Os, Arch = vd.Arch, Exec = exec });
+            }
+            return platforms;
+        }
+
+        private static string OsString(TargetOs os) => os switch
+        {
+            TargetOs.Windows => "windows",
+            TargetOs.Linux => "linux",
+            TargetOs.Macos => "macos",
+            _ => "unknown"
+        };
 
         // ---- sandbox ----
 

--- a/Hina.Builder/Program.cs
+++ b/Hina.Builder/Program.cs
@@ -54,7 +54,8 @@ namespace Hina.Builder
             Console.WriteLine("  hina-builder init [--input <dir>]");
             Console.WriteLine("      Interactive wizard: scans the folder, asks a few questions, and generates a");
             Console.WriteLine("      signed hina.app.json plus the manifest/chunk store ready to host.");
-            Console.WriteLine("  hina-builder build --input <dir> --out <dir> --base <url> [--version v] [--chunk 65536] [--chunking fixed|cdc] [--min-chunk 2048] [--max-chunk 65536] [--avg-chunk 8192] [--sign-key key.b64] [-v|--verbose]");
+            Console.WriteLine("  hina-builder build --input <dir> --out <dir> --base <url> [--platform <os[-arch]>] [--version v] [--chunk 65536] [--chunking fixed|cdc] [--min-chunk 2048] [--max-chunk 65536] [--avg-chunk 8192] [--sign-key key.b64] [-v|--verbose]");
+            Console.WriteLine("      --platform writes manifest.<token>.json (one per variant) into a shared chunk store.");
             Console.WriteLine("  hina-builder keygen [--out <dir>] [--name <prefix>]");
         }
     }

--- a/Hina.CLI/Commands/RunCommand.cs
+++ b/Hina.CLI/Commands/RunCommand.cs
@@ -4,6 +4,7 @@ using System.IO;
 using System.Runtime.InteropServices;
 using System.Threading.Tasks;
 using Hina.PackageManager.Descriptor;
+using Hina.PackageManager.Install;
 using Hina.PackageManager.Registry;
 using Hina.PackageManager.Sandbox;
 using Microsoft.Extensions.Logging;
@@ -71,7 +72,7 @@ namespace Hina.CLI.Commands
                 return 1;
             }
 
-            string? execRel = ResolveExecRel(desc, entryId, out string? err);
+            string? execRel = ResolveExecRel(desc, entryId, app.Platform, out string? err);
             if (execRel == null)
             {
                 ctx.Logger.LogError("{Error}", err);
@@ -92,7 +93,7 @@ namespace Hina.CLI.Commands
             return launcher.Launch(execAbs, appArgs, plan, ctx.Ct);
         }
 
-        private static string? ResolveExecRel(AppDescriptor desc, string? entryId, out string? err)
+        private static string? ResolveExecRel(AppDescriptor desc, string? entryId, string? installedPlatform, out string? err)
         {
             err = null;
             if (entryId != null)
@@ -108,17 +109,11 @@ namespace Hina.CLI.Commands
             {
                 return desc.Entries[0].Exec;
             }
-            string? fromMap = OsExec(desc.Exec);
-            if (fromMap == null) err = "app defines no entry or executable for this OS.";
-            return fromMap;
-        }
-
-        private static string? OsExec(ExecMap exec)
-        {
-            if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux)) return exec.Linux;
-            if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX)) return exec.Macos;
-            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows)) return exec.Windows;
-            return null;
+            // No shell entry: resolve via the installed platform variant (or the legacy OS exec
+            // map for single-manifest apps).
+            string? fromVariant = PlatformResolver.ForInstalledToken(desc, installedPlatform).ExecRelative;
+            if (fromVariant == null) err = "app defines no entry or executable for this platform.";
+            return fromVariant;
         }
     }
 }

--- a/Hina.Core.Tests/HttpChunkClientTests.cs
+++ b/Hina.Core.Tests/HttpChunkClientTests.cs
@@ -68,6 +68,48 @@ namespace Hina.Core.Tests
             Assert.Equal("http://cdn.test.com/manifest.beta.json", capturedUri!.ToString());
         }
 
+        [Fact]
+        public async Task GetManifestAsync_StablePlatform_UsesPlatformInFilename()
+        {
+            string json = JsonSerializer.Serialize(new Manifest.Manifest { Version = "1.0.0" });
+            Uri? capturedUri = null;
+            var handler = new FakeHandler((req, ct) =>
+            {
+                capturedUri = req.RequestUri;
+                return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
+                {
+                    Content = new StringContent(json, Encoding.UTF8, "application/json")
+                });
+            });
+            using var http = new HttpClient(handler);
+            var client = new HttpChunkClient(http);
+
+            await client.GetManifestAsync(new Uri("http://cdn.test.com/"), "stable", "macos-arm64", CancellationToken.None);
+
+            Assert.Equal("http://cdn.test.com/manifest.macos-arm64.json", capturedUri!.ToString());
+        }
+
+        [Fact]
+        public async Task GetManifestAsync_ChannelAndPlatform_UsesBothInFilename()
+        {
+            string json = JsonSerializer.Serialize(new Manifest.Manifest { Version = "2.0.0" });
+            Uri? capturedUri = null;
+            var handler = new FakeHandler((req, ct) =>
+            {
+                capturedUri = req.RequestUri;
+                return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
+                {
+                    Content = new StringContent(json, Encoding.UTF8, "application/json")
+                });
+            });
+            using var http = new HttpClient(handler);
+            var client = new HttpChunkClient(http);
+
+            await client.GetManifestAsync(new Uri("http://cdn.test.com/"), "beta", "windows-x64", CancellationToken.None);
+
+            Assert.Equal("http://cdn.test.com/manifest.beta.windows-x64.json", capturedUri!.ToString());
+        }
+
         private static string Sha256Hex(byte[] data) =>
             Convert.ToHexStringLower(System.Security.Cryptography.SHA256.HashData(data));
 

--- a/Hina.Core/Configuration/PatcherConfig.cs
+++ b/Hina.Core/Configuration/PatcherConfig.cs
@@ -7,6 +7,10 @@ namespace Hina.Core.Configuration
     {
         public Uri BaseUrl { get; set; } = new Uri("http://localhost/");
         public string Channel { get; set; } = "stable";
+
+        // Variant token (e.g. "macos-arm64") for a multi-platform app, selecting which
+        // manifest.<platform>.json to fetch. Null ⇒ legacy single-manifest app.
+        public string? Platform { get; set; }
         public int Concurrency { get; set; } = 4;
         public int ChunkSize { get; set; } = 64 * 1024;
         public bool Verify { get; set; } = true;

--- a/Hina.Core/Net/HttpChunkClient.cs
+++ b/Hina.Core/Net/HttpChunkClient.cs
@@ -34,11 +34,23 @@ namespace Hina.Core.Net
         }
 
         public async Task<Manifest.Manifest> GetManifestAsync(Uri baseUrl, string channel, CancellationToken ct)
+            => await GetManifestAsync(baseUrl, channel, platform: null, ct);
+
+        public async Task<Manifest.Manifest> GetManifestAsync(Uri baseUrl, string channel, string? platform, CancellationToken ct)
         {
-            // Allow per-channel manifest naming.
-            string fileName = channel.Equals("stable", StringComparison.OrdinalIgnoreCase)
-                ? "manifest.json"
-                : $"manifest.{channel}.json";
+            // Manifest naming: manifest[.<channel>][.<platform>].json. The channel segment is
+            // dropped for "stable"; the platform segment is present only for multi-variant apps,
+            // so a legacy single-manifest app on the stable channel stays "manifest.json".
+            string fileName = "manifest";
+            if (!channel.Equals("stable", StringComparison.OrdinalIgnoreCase))
+            {
+                fileName += $".{channel}";
+            }
+            if (!string.IsNullOrEmpty(platform))
+            {
+                fileName += $".{platform}";
+            }
+            fileName += ".json";
 
             Uri manifestUrl = new Uri(baseUrl, fileName);
 

--- a/Hina.Core/Patching/PatchClient.cs
+++ b/Hina.Core/Patching/PatchClient.cs
@@ -58,7 +58,7 @@ namespace Hina.Core.Patching
         public async Task<CheckResult> CheckAsync(string rootDir, CancellationToken ct)
         {
             _logger.LogInformation("Checking for updates in {RootDir}", rootDir);
-            Manifest.Manifest manifest = await _http.GetManifestAsync(Config.BaseUrl, Config.Channel, ct);
+            Manifest.Manifest manifest = await _http.GetManifestAsync(Config.BaseUrl, Config.Channel, Config.Platform, ct);
             VerifyManifestOrThrow(manifest);
             // Patch every file listed in the manifest.
             foreach (ManifestFile file in manifest.Files)
@@ -88,7 +88,7 @@ namespace Hina.Core.Patching
         public async Task<PatchResult> PatchAsync(string rootDir, CancellationToken ct)
         {
             _logger.LogInformation("Starting patch in {RootDir}", rootDir);
-            Manifest.Manifest manifest = await _http.GetManifestAsync(Config.BaseUrl, Config.Channel, ct);
+            Manifest.Manifest manifest = await _http.GetManifestAsync(Config.BaseUrl, Config.Channel, Config.Platform, ct);
             VerifyManifestOrThrow(manifest);
             PatchResult result = new PatchResult { Success = true };
 
@@ -293,7 +293,7 @@ namespace Hina.Core.Patching
         public async Task<VerifyResult> VerifyAsync(string rootDir, CancellationToken ct)
         {
             _logger.LogInformation("Verifying files in {RootDir}", rootDir);
-            Manifest.Manifest manifest = await _http.GetManifestAsync(Config.BaseUrl, Config.Channel, ct);
+            Manifest.Manifest manifest = await _http.GetManifestAsync(Config.BaseUrl, Config.Channel, Config.Platform, ct);
             VerifyManifestOrThrow(manifest);
             VerifyResult result = new VerifyResult { Success = true };
 

--- a/Hina.PackageManager.Tests/DescriptorValidatorPlatformsTests.cs
+++ b/Hina.PackageManager.Tests/DescriptorValidatorPlatformsTests.cs
@@ -1,0 +1,74 @@
+using System.Collections.Generic;
+using System.Linq;
+using Hina.Core.Crypto;
+using Hina.PackageManager.Descriptor;
+
+namespace Hina.PackageManager.Tests
+{
+    public sealed class DescriptorValidatorPlatformsTests
+    {
+        private static AppDescriptor Base(List<PlatformVariant> platforms) => new AppDescriptor
+        {
+            Name = "mygame",
+            DisplayName = "My Game",
+            Version = "1.0.0",
+            Publisher = "Acme",
+            Channel = "stable",
+            BaseUrl = "https://patch.example.com/",
+            PublicKey = KeyGenerator.GenerateEd25519().PublicKeyBase64,
+            Exec = new ExecMap(),       // no legacy exec map; platforms are authoritative
+            Platforms = platforms
+        };
+
+        [Fact]
+        public void PlatformsOnly_NoExecMap_IsValid()
+        {
+            AppDescriptor d = Base(new List<PlatformVariant>
+            {
+                new PlatformVariant { Os = "windows", Arch = "x64", Exec = "Game.exe" },
+                new PlatformVariant { Os = "macos", Arch = "arm64", Exec = "G.app/Contents/MacOS/G" },
+                new PlatformVariant { Os = "linux", Exec = "game" }
+            });
+            Assert.True(DescriptorValidator.Validate(d).IsValid);
+        }
+
+        [Fact]
+        public void UnknownOs_IsRejected()
+        {
+            AppDescriptor d = Base(new List<PlatformVariant> { new PlatformVariant { Os = "solaris", Exec = "g" } });
+            Assert.Contains(DescriptorValidator.Validate(d).Errors, e => e.Contains("os"));
+        }
+
+        [Fact]
+        public void UnknownArch_IsRejected()
+        {
+            AppDescriptor d = Base(new List<PlatformVariant> { new PlatformVariant { Os = "linux", Arch = "riscv", Exec = "g" } });
+            Assert.Contains(DescriptorValidator.Validate(d).Errors, e => e.Contains("arch"));
+        }
+
+        [Fact]
+        public void DuplicateOsArch_IsRejected()
+        {
+            AppDescriptor d = Base(new List<PlatformVariant>
+            {
+                new PlatformVariant { Os = "macos", Arch = "x64", Exec = "a" },
+                new PlatformVariant { Os = "macos", Arch = "x64", Exec = "b" }
+            });
+            Assert.Contains(DescriptorValidator.Validate(d).Errors, e => e.Contains("duplicates"));
+        }
+
+        [Fact]
+        public void AbsoluteExec_IsRejected()
+        {
+            AppDescriptor d = Base(new List<PlatformVariant> { new PlatformVariant { Os = "linux", Exec = "/usr/bin/game" } });
+            Assert.False(DescriptorValidator.Validate(d).IsValid);
+        }
+
+        [Fact]
+        public void NoExecMapAndNoPlatforms_IsRejected()
+        {
+            AppDescriptor d = Base(new List<PlatformVariant>());
+            Assert.Contains(DescriptorValidator.Validate(d).Errors, e => e.Contains("platforms"));
+        }
+    }
+}

--- a/Hina.PackageManager.Tests/PlatformResolverTests.cs
+++ b/Hina.PackageManager.Tests/PlatformResolverTests.cs
@@ -1,0 +1,79 @@
+using System.Collections.Generic;
+using Hina.PackageManager.Descriptor;
+using Hina.PackageManager.Install;
+using Hina.PackageManager.Platform;
+
+namespace Hina.PackageManager.Tests
+{
+    public sealed class PlatformResolverTests
+    {
+        // Legacy app: no platforms[], just the OS exec map → single manifest (null token).
+        [Fact]
+        public void Legacy_UsesExecMap_NullToken()
+        {
+            AppDescriptor d = new AppDescriptor
+            {
+                Exec = new ExecMap { Windows = "g.exe", Linux = "g", Macos = "g.app" }
+            };
+            PlatformResolution r = PlatformResolver.ForCurrentMachine(d);
+            Assert.Null(r.ManifestToken);
+            Assert.False(r.NoBuildForPlatform);
+            // Exec resolves to the current OS's entry (whatever this test host is).
+            Assert.NotNull(r.ExecRelative);
+        }
+
+        // Multi-variant app with an OS-only variant for the current OS always resolves.
+        [Fact]
+        public void Multi_OsOnlyForCurrentOs_Resolves()
+        {
+            AppDescriptor d = new AppDescriptor
+            {
+                Platforms = new List<PlatformVariant>
+                {
+                    new PlatformVariant { Os = PlatformToken.CurrentOs(), Exec = "game" }
+                }
+            };
+            PlatformResolution r = PlatformResolver.ForCurrentMachine(d);
+            Assert.Equal(PlatformToken.CurrentOs(), r.ManifestToken);
+            Assert.Equal("game", r.ExecRelative);
+        }
+
+        [Fact]
+        public void Multi_NoVariantForOs_FlagsNoBuild()
+        {
+            // A descriptor that only ships an OS that is NOT the test host.
+            string otherOs = PlatformToken.CurrentOs() == "linux" ? "windows" : "linux";
+            AppDescriptor d = new AppDescriptor
+            {
+                Platforms = new List<PlatformVariant> { new PlatformVariant { Os = otherOs, Exec = "g" } }
+            };
+            PlatformResolution r = PlatformResolver.ForCurrentMachine(d);
+            Assert.True(r.NoBuildForPlatform);
+        }
+
+        [Fact]
+        public void ForInstalledToken_ExactToken_ResolvesThatVariant()
+        {
+            AppDescriptor d = new AppDescriptor
+            {
+                Platforms = new List<PlatformVariant>
+                {
+                    new PlatformVariant { Os = "macos", Arch = "x64", Exec = "x64app" },
+                    new PlatformVariant { Os = "macos", Arch = "arm64", Exec = "armapp" }
+                }
+            };
+            PlatformResolution r = PlatformResolver.ForInstalledToken(d, "macos-x64");
+            Assert.Equal("macos-x64", r.ManifestToken);
+            Assert.Equal("x64app", r.ExecRelative);
+        }
+
+        [Fact]
+        public void ForInstalledToken_LegacyEmptyToken_UsesExecMap()
+        {
+            AppDescriptor d = new AppDescriptor { Exec = new ExecMap { Linux = "g", Macos = "g", Windows = "g.exe" } };
+            PlatformResolution r = PlatformResolver.ForInstalledToken(d, "");
+            Assert.Null(r.ManifestToken);
+            Assert.NotNull(r.ExecRelative);
+        }
+    }
+}

--- a/Hina.PackageManager.Tests/PlatformSelectorTests.cs
+++ b/Hina.PackageManager.Tests/PlatformSelectorTests.cs
@@ -1,0 +1,104 @@
+using System.Collections.Generic;
+using Hina.PackageManager.Descriptor;
+using Hina.PackageManager.Platform;
+
+namespace Hina.PackageManager.Tests
+{
+    public sealed class PlatformSelectorTests
+    {
+        private static List<PlatformVariant> Variants(params (string os, string? arch)[] specs)
+        {
+            List<PlatformVariant> list = new List<PlatformVariant>();
+            foreach ((string os, string? arch) in specs)
+            {
+                list.Add(new PlatformVariant { Os = os, Arch = arch, Exec = "app" });
+            }
+            return list;
+        }
+
+        [Fact]
+        public void ExactMatch_Wins()
+        {
+            var sel = PlatformSelector.Select(Variants(("macos", "x64"), ("macos", "arm64")), "macos", "arm64");
+            Assert.NotNull(sel);
+            Assert.Equal("arm64", sel!.Variant.Arch);
+            Assert.False(sel.UsedFallback);
+            Assert.Equal("macos-arm64", sel.Token);
+        }
+
+        [Fact]
+        public void OsOnlyVariant_MatchesAnyArch()
+        {
+            var sel = PlatformSelector.Select(Variants(("linux", null)), "linux", "arm64");
+            Assert.NotNull(sel);
+            Assert.Null(sel!.Variant.Arch);
+            Assert.False(sel.UsedFallback);
+            Assert.Equal("linux", sel.Token);
+        }
+
+        [Fact]
+        public void MacArm64_FallsBackToX64_WithFlag()
+        {
+            var sel = PlatformSelector.Select(Variants(("macos", "x64")), "macos", "arm64");
+            Assert.NotNull(sel);
+            Assert.Equal("x64", sel!.Variant.Arch);
+            Assert.True(sel.UsedFallback);
+            Assert.Equal("macos-x64", sel.Token);
+        }
+
+        [Fact]
+        public void WindowsArm64_FallsBackToX64()
+        {
+            var sel = PlatformSelector.Select(Variants(("windows", "x64")), "windows", "arm64");
+            Assert.NotNull(sel);
+            Assert.True(sel!.UsedFallback);
+        }
+
+        [Fact]
+        public void LinuxArm64_NoX64Fallback()
+        {
+            // Linux has no transparent x86-64 emulation, so an arm64 host gets no x64 fallback.
+            var sel = PlatformSelector.Select(Variants(("linux", "x64")), "linux", "arm64");
+            Assert.Null(sel);
+        }
+
+        [Fact]
+        public void NoVariantForOs_ReturnsNull()
+        {
+            var sel = PlatformSelector.Select(Variants(("windows", "x64")), "macos", "arm64");
+            Assert.Null(sel);
+        }
+
+        [Fact]
+        public void ExactPreferredOverFallback()
+        {
+            // Both an x64 and a native arm64 build exist → pick arm64, no fallback.
+            var sel = PlatformSelector.Select(Variants(("macos", "x64"), ("macos", "arm64")), "macos", "arm64");
+            Assert.False(sel!.UsedFallback);
+            Assert.Equal("arm64", sel.Variant.Arch);
+        }
+    }
+
+    public sealed class PlatformTokenTests
+    {
+        [Fact]
+        public void Token_OsOnly_OmitsArch()
+        {
+            Assert.Equal("linux", PlatformToken.Token("linux", null));
+            Assert.Equal("linux", PlatformToken.Token("linux", ""));
+        }
+
+        [Fact]
+        public void Token_OsArch_Joins()
+        {
+            Assert.Equal("macos-arm64", PlatformToken.Token("macos", "arm64"));
+        }
+
+        [Fact]
+        public void CurrentOsAndArch_AreNonEmpty()
+        {
+            Assert.False(string.IsNullOrEmpty(PlatformToken.CurrentOs()));
+            Assert.False(string.IsNullOrEmpty(PlatformToken.CurrentArch()));
+        }
+    }
+}

--- a/Hina.PackageManager/Descriptor/AppDescriptor.cs
+++ b/Hina.PackageManager/Descriptor/AppDescriptor.cs
@@ -23,6 +23,11 @@ namespace Hina.PackageManager.Descriptor
 
         public ExecMap Exec { get; set; } = new ExecMap();
 
+        // Per-platform variants. When non-empty, the app ships one manifest per (os[, arch]) over
+        // a shared chunk store and the client downloads only its matching variant; `Exec` (the
+        // legacy single-manifest map) is ignored. Empty ⇒ legacy single-manifest behavior.
+        public List<PlatformVariant> Platforms { get; set; } = new List<PlatformVariant>();
+
         public List<ShellEntry> Entries { get; set; } = new List<ShellEntry>();
         public List<HookAction> PostInstall { get; set; } = new List<HookAction>();
 

--- a/Hina.PackageManager/Descriptor/DescriptorParser.cs
+++ b/Hina.PackageManager/Descriptor/DescriptorParser.cs
@@ -64,6 +64,7 @@ namespace Hina.PackageManager.Descriptor
                 Channel = descriptor.Channel,
                 PublicKey = descriptor.PublicKey,
                 Exec = descriptor.Exec,
+                Platforms = descriptor.Platforms,
                 Entries = descriptor.Entries,
                 PostInstall = descriptor.PostInstall,
                 DescriptorSignature = null

--- a/Hina.PackageManager/Descriptor/DescriptorValidator.cs
+++ b/Hina.PackageManager/Descriptor/DescriptorValidator.cs
@@ -80,13 +80,16 @@ namespace Hina.PackageManager.Descriptor
 
             ValidateEd25519Key(descriptor.PublicKey, "publicKey", errors);
 
-            if (descriptor.Exec.Windows == null && descriptor.Exec.Linux == null && descriptor.Exec.Macos == null)
+            bool hasExecMap = descriptor.Exec.Windows != null || descriptor.Exec.Linux != null || descriptor.Exec.Macos != null;
+            bool hasPlatforms = descriptor.Platforms.Count > 0;
+            if (!hasExecMap && !hasPlatforms)
             {
-                errors.Add("exec must define at least one platform.");
+                errors.Add("exec must define at least one platform, or declare platforms[].");
             }
             ValidateRelativePath(descriptor.Exec.Windows, "exec.windows", errors);
             ValidateRelativePath(descriptor.Exec.Linux, "exec.linux", errors);
             ValidateRelativePath(descriptor.Exec.Macos, "exec.macos", errors);
+            ValidatePlatforms(descriptor.Platforms, errors);
 
             HashSet<string> entryIds = new HashSet<string>(StringComparer.Ordinal);
             for (int i = 0; i < descriptor.Entries.Count; i++)
@@ -143,6 +146,44 @@ namespace Hina.PackageManager.Descriptor
             ValidateSandbox(descriptor.Sandbox, errors);
 
             return new ValidationResult(errors);
+        }
+
+        // The closed sets a platforms[] entry may name. Kept here so the validator and the
+        // runtime selector agree on what's legal — unknown tokens are rejected (fail closed).
+        public static readonly IReadOnlySet<string> KnownOs = new HashSet<string>(StringComparer.Ordinal) { "windows", "macos", "linux" };
+        public static readonly IReadOnlySet<string> KnownArch = new HashSet<string>(StringComparer.Ordinal) { "x64", "arm64", "x86", "arm" };
+
+        private static void ValidatePlatforms(List<PlatformVariant> platforms, List<string> errors)
+        {
+            HashSet<string> seen = new HashSet<string>(StringComparer.Ordinal);
+            for (int i = 0; i < platforms.Count; i++)
+            {
+                PlatformVariant v = platforms[i];
+                string prefix = $"platforms[{i}]";
+
+                if (!KnownOs.Contains(v.Os))
+                {
+                    errors.Add($"{prefix}.os '{v.Os}' must be one of: {string.Join(", ", KnownOs)}.");
+                }
+                if (v.Arch != null && !KnownArch.Contains(v.Arch))
+                {
+                    errors.Add($"{prefix}.arch '{v.Arch}' must be one of: {string.Join(", ", KnownArch)} (or omitted).");
+                }
+                if (string.IsNullOrWhiteSpace(v.Exec))
+                {
+                    errors.Add($"{prefix}.exec is required.");
+                }
+                else
+                {
+                    ValidateRelativePath(v.Exec, $"{prefix}.exec", errors);
+                }
+
+                string key = v.Os + "/" + (v.Arch ?? "*");
+                if (!seen.Add(key))
+                {
+                    errors.Add($"{prefix} duplicates the (os, arch) pair '{key}'.");
+                }
+            }
         }
 
         private static void ValidateSandbox(SandboxSpec? sandbox, List<string> errors)

--- a/Hina.PackageManager/Descriptor/PlatformVariant.cs
+++ b/Hina.PackageManager/Descriptor/PlatformVariant.cs
@@ -1,0 +1,21 @@
+namespace Hina.PackageManager.Descriptor
+{
+    // One per-platform build of the app. A descriptor that lists `platforms` ships each OS/arch
+    // build as its own manifest (manifest.<os>[-<arch>].json) over a shared chunk store, so a
+    // client downloads ONLY the variant matching its machine instead of every platform's files.
+    //
+    // Os is required; Arch is optional — a variant with no Arch is the universal build for that
+    // OS. The client picks the most specific match (see PlatformSelector). Exec is the path to
+    // the executable, relative to THIS variant's root.
+    public sealed class PlatformVariant
+    {
+        // "windows" | "macos" | "linux".
+        public string Os { get; set; } = string.Empty;
+
+        // "x64" | "arm64" | "x86" | "arm", or null for "any architecture on this OS".
+        public string? Arch { get; set; }
+
+        // Executable path relative to the variant's install root.
+        public string Exec { get; set; } = string.Empty;
+    }
+}

--- a/Hina.PackageManager/Diagnostics/RegistryVerifier.cs
+++ b/Hina.PackageManager/Diagnostics/RegistryVerifier.cs
@@ -108,7 +108,7 @@ namespace Hina.PackageManager.Diagnostics
                 }
             }
 
-            Require(InstallService.ExecForCurrentOs(descriptor));
+            Require(PlatformResolver.ForInstalledToken(descriptor, app.Platform).ExecRelative);
             foreach (ShellEntry e in descriptor.Entries) Require(e.Exec);
         }
 

--- a/Hina.PackageManager/Install/InstallService.cs
+++ b/Hina.PackageManager/Install/InstallService.cs
@@ -155,9 +155,26 @@ namespace Hina.PackageManager.Install
                 Directory.CreateDirectory(appDir);
                 tx.RecordAppDirCreated(appDir);
 
-                // [10] Delta-fetch chunks into appDir.
+                // [9b] Resolve which platform variant this machine gets. For a multi-variant app
+                // this selects the manifest to fetch and the exec to run; for a legacy app it's
+                // the OS exec map and the single manifest.json.
+                PlatformResolution resolution = PlatformResolver.ForCurrentMachine(descriptor);
+                if (resolution.NoBuildForPlatform)
+                {
+                    throw new InvalidOperationException(
+                        $"'{descriptor.Name}' has no build for this platform ({PlatformToken.CurrentOs()}-{PlatformToken.CurrentArch()}).");
+                }
+                if (resolution.UsedFallback)
+                {
+                    _logger.LogWarning(
+                        "No native build for {Os}-{Arch}; installing the x64 build (it will run via Rosetta/emulation).",
+                        PlatformToken.CurrentOs(), PlatformToken.CurrentArch());
+                }
+                newApp.Platform = resolution.ManifestToken ?? string.Empty;
+
+                // [10] Delta-fetch chunks into appDir (only this variant's manifest).
                 PatcherConfig patchCfg = options.Network.ToPatchConfig(
-                    descriptor.BaseUrl, descriptor.Channel, descriptor.PublicKey, backup: false);
+                    descriptor.BaseUrl, descriptor.Channel, descriptor.PublicKey, backup: false, platform: resolution.ManifestToken);
                 IPatchClient patcher = _patchClientFactory(patchCfg);
                 PatchResult patchResult = await patcher.PatchAsync(appDir, ct);
                 if (!patchResult.Success)
@@ -165,8 +182,8 @@ namespace Hina.PackageManager.Install
                     throw new InvalidOperationException("PatchClient.PatchAsync reported failure.");
                 }
 
-                // [11] Sanity check: the per-OS exec exists on disk after patching.
-                string? execRelative = ExecForCurrentOs(descriptor);
+                // [11] Sanity check: the resolved exec exists on disk after patching.
+                string? execRelative = resolution.ExecRelative;
                 if (execRelative == null)
                 {
                     throw new InvalidOperationException("Descriptor has no exec entry for the current OS.");

--- a/Hina.PackageManager/Install/NetworkOptions.cs
+++ b/Hina.PackageManager/Install/NetworkOptions.cs
@@ -22,12 +22,13 @@ namespace Hina.PackageManager.Install
         // Single source of truth for descriptor + network → PatcherConfig. InstallService and
         // UpdateService share this so the mapping (and every field in it) can't drift; the only
         // per-call difference is whether backups are kept.
-        public PatcherConfig ToPatchConfig(string baseUrl, string channel, string trustedPublicKey, bool backup)
+        public PatcherConfig ToPatchConfig(string baseUrl, string channel, string trustedPublicKey, bool backup, string? platform = null)
         {
             return new PatcherConfig
             {
                 BaseUrl = new Uri(baseUrl),
                 Channel = channel,
+                Platform = platform,
                 TrustedPublicKey = trustedPublicKey,
                 Verify = true,
                 Backup = backup,

--- a/Hina.PackageManager/Install/PlatformResolver.cs
+++ b/Hina.PackageManager/Install/PlatformResolver.cs
@@ -1,0 +1,74 @@
+using Hina.PackageManager.Descriptor;
+using Hina.PackageManager.Platform;
+
+namespace Hina.PackageManager.Install
+{
+    // The outcome of mapping a descriptor to a concrete machine: which executable to run, which
+    // manifest to fetch, and whether a compatibility fallback was used. Unifies the multi-variant
+    // (descriptor.Platforms) and legacy (descriptor.Exec map) cases so install/update/run/verify
+    // all resolve the same way.
+    public sealed class PlatformResolution
+    {
+        // Executable path relative to the install dir, or null when the descriptor has none for
+        // this platform.
+        public string? ExecRelative { get; init; }
+
+        // Variant token selecting manifest.<token>.json, or null for a legacy single-manifest app
+        // (manifest.json).
+        public string? ManifestToken { get; init; }
+
+        // True when an x64 build was chosen for an arm64 host (Rosetta/emulation) — warn the user.
+        public bool UsedFallback { get; init; }
+
+        // True when the app is multi-variant but no variant can serve this OS/arch at all.
+        public bool NoBuildForPlatform { get; init; }
+    }
+
+    public static class PlatformResolver
+    {
+        // Install time: pick the best variant for the machine running Hina now.
+        public static PlatformResolution ForCurrentMachine(AppDescriptor descriptor)
+        {
+            if (descriptor.Platforms.Count == 0)
+            {
+                return new PlatformResolution { ExecRelative = InstallService.ExecForCurrentOs(descriptor), ManifestToken = null };
+            }
+
+            PlatformSelection? sel = PlatformSelector.Select(
+                descriptor.Platforms, PlatformToken.CurrentOs(), PlatformToken.CurrentArch());
+            if (sel == null)
+            {
+                return new PlatformResolution { NoBuildForPlatform = true };
+            }
+            return new PlatformResolution
+            {
+                ExecRelative = sel.Variant.Exec,
+                ManifestToken = sel.Token,
+                UsedFallback = sel.UsedFallback
+            };
+        }
+
+        // Update/verify/run time: stick to the variant that was installed (token from the
+        // registry) so an update fetches the same manifest. Falls back to a fresh selection if the
+        // app is legacy, the registry predates variants, or the variant disappeared from the
+        // descriptor.
+        public static PlatformResolution ForInstalledToken(AppDescriptor descriptor, string? installedToken)
+        {
+            if (descriptor.Platforms.Count == 0)
+            {
+                return new PlatformResolution { ExecRelative = InstallService.ExecForCurrentOs(descriptor), ManifestToken = null };
+            }
+            if (!string.IsNullOrEmpty(installedToken))
+            {
+                foreach (PlatformVariant v in descriptor.Platforms)
+                {
+                    if (PlatformToken.Token(v.Os, v.Arch) == installedToken)
+                    {
+                        return new PlatformResolution { ExecRelative = v.Exec, ManifestToken = installedToken };
+                    }
+                }
+            }
+            return ForCurrentMachine(descriptor);
+        }
+    }
+}

--- a/Hina.PackageManager/Install/UpdateService.cs
+++ b/Hina.PackageManager/Install/UpdateService.cs
@@ -202,9 +202,21 @@ namespace Hina.PackageManager.Install
                 foreach (string r in permDiff.Removed) _logger.LogInformation("  - {Removed}", r);
             }
 
-            // [6] PatchClient delta.
+            // [6] PatchClient delta — fetch the SAME variant the app was installed as.
+            PlatformResolution resolution = PlatformResolver.ForInstalledToken(descriptor, app.Platform);
+            if (resolution.NoBuildForPlatform)
+            {
+                return new UpdateResult
+                {
+                    Name = name,
+                    FromVersion = app.InstalledVersion,
+                    ToVersion = descriptor.Version,
+                    Status = UpdateStatus.Failed,
+                    Message = "The updated descriptor has no build for this platform."
+                };
+            }
             PatcherConfig patchCfg = options.Network.ToPatchConfig(
-                descriptor.BaseUrl, descriptor.Channel, descriptor.PublicKey, backup: true);
+                descriptor.BaseUrl, descriptor.Channel, descriptor.PublicKey, backup: true, platform: resolution.ManifestToken);
             IPatchClient patcher = _patchClientFactory(patchCfg);
 
             try
@@ -255,6 +267,7 @@ namespace Hina.PackageManager.Install
                 BaseUrl = descriptor.BaseUrl,
                 Channel = descriptor.Channel,
                 PublicKey = descriptor.PublicKey,
+                Platform = resolution.ManifestToken ?? string.Empty,
                 InstalledAt = app.InstalledAt,
                 LastUpdatedAt = DateTimeOffset.UtcNow,
                 ExecutedHooks = UpdateDiff.SurvivingHooks(app.ExecutedHooks, hooksToRemove),
@@ -508,6 +521,7 @@ namespace Hina.PackageManager.Install
             BaseUrl = src.BaseUrl,
             Channel = src.Channel,
             PublicKey = src.PublicKey,
+            Platform = src.Platform,
             InstalledAt = src.InstalledAt,
             LastUpdatedAt = src.LastUpdatedAt,
             ExecutedHooks = new List<HookEvidence>(src.ExecutedHooks),

--- a/Hina.PackageManager/Json/PackageManagerJsonContext.cs
+++ b/Hina.PackageManager/Json/PackageManagerJsonContext.cs
@@ -13,6 +13,7 @@ namespace Hina.PackageManager.Json
     [JsonSerializable(typeof(AutostartHook))]
     [JsonSerializable(typeof(ShellEntry))]
     [JsonSerializable(typeof(ExecMap))]
+    [JsonSerializable(typeof(PlatformVariant))]
     [JsonSerializable(typeof(SandboxSpec))]
     [JsonSerializable(typeof(FsRule))]
     [JsonSerializable(typeof(CapabilitySpec))]

--- a/Hina.PackageManager/Platform/PlatformSelector.cs
+++ b/Hina.PackageManager/Platform/PlatformSelector.cs
@@ -1,0 +1,57 @@
+using System.Collections.Generic;
+using Hina.PackageManager.Descriptor;
+
+namespace Hina.PackageManager.Platform
+{
+    // The variant chosen for a machine, plus whether a compatibility fallback was used (so the
+    // caller can warn the user that, e.g., an x64 build will run under Rosetta/emulation).
+    public sealed class PlatformSelection
+    {
+        public PlatformVariant Variant { get; }
+        public bool UsedFallback { get; }
+        public string Token => PlatformToken.Token(Variant.Os, Variant.Arch);
+
+        public PlatformSelection(PlatformVariant variant, bool usedFallback)
+        {
+            Variant = variant;
+            UsedFallback = usedFallback;
+        }
+    }
+
+    // Picks the best variant for a machine's (os, arch). Returns null when no variant can serve
+    // the OS at all — the caller turns that into a clean "no build for your platform" error.
+    public static class PlatformSelector
+    {
+        // An arm64 host can transparently run the x64 build: macOS via Rosetta 2, Windows via
+        // its x64 emulator. (Linux has no in-box transparent x86-64 emulation, so it's excluded.)
+        private static readonly IReadOnlyDictionary<string, string> ArchFallback =
+            new Dictionary<string, string> { ["arm64"] = "x64" };
+
+        public static PlatformSelection? Select(IReadOnlyList<PlatformVariant> platforms, string os, string arch)
+        {
+            // 1. Exact os + arch.
+            foreach (PlatformVariant v in platforms)
+            {
+                if (v.Os == os && v.Arch == arch) return new PlatformSelection(v, usedFallback: false);
+            }
+
+            // 2. OS-only variant (universal build for this OS).
+            foreach (PlatformVariant v in platforms)
+            {
+                if (v.Os == os && v.Arch == null) return new PlatformSelection(v, usedFallback: false);
+            }
+
+            // 3. Compatible-arch fallback (arm64 → x64) on the OSes that emulate it.
+            if (ArchFallback.TryGetValue(arch, out string? compatArch) && (os == "macos" || os == "windows"))
+            {
+                foreach (PlatformVariant v in platforms)
+                {
+                    if (v.Os == os && v.Arch == compatArch) return new PlatformSelection(v, usedFallback: true);
+                }
+            }
+
+            // 4. Nothing serves this OS/arch.
+            return null;
+        }
+    }
+}

--- a/Hina.PackageManager/Platform/PlatformToken.cs
+++ b/Hina.PackageManager/Platform/PlatformToken.cs
@@ -1,0 +1,30 @@
+using System.Runtime.InteropServices;
+
+namespace Hina.PackageManager.Platform
+{
+    // The current machine's platform identity and the token used to name a variant's manifest.
+    // os ∈ {windows, macos, linux}; arch ∈ {x64, arm64, x86, arm}. Token = "os" or "os-arch".
+    public static class PlatformToken
+    {
+        public static string CurrentOs()
+        {
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows)) return "windows";
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX)) return "macos";
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux)) return "linux";
+            return "unknown";
+        }
+
+        public static string CurrentArch() => RuntimeInformation.OSArchitecture switch
+        {
+            Architecture.X64 => "x64",
+            Architecture.Arm64 => "arm64",
+            Architecture.X86 => "x86",
+            Architecture.Arm => "arm",
+            _ => RuntimeInformation.OSArchitecture.ToString().ToLowerInvariant()
+        };
+
+        // Manifest token for a (resolved) variant: "os" when no arch, else "os-arch".
+        public static string Token(string os, string? arch)
+            => string.IsNullOrEmpty(arch) ? os : $"{os}-{arch}";
+    }
+}

--- a/Hina.PackageManager/Registry/Registry.cs
+++ b/Hina.PackageManager/Registry/Registry.cs
@@ -24,6 +24,12 @@ namespace Hina.PackageManager.Registry
         public string BaseUrl { get; set; } = string.Empty;
         public string Channel { get; set; } = "stable";
         public string PublicKey { get; set; } = string.Empty;
+
+        // Variant token installed (e.g. "macos-arm64") for a multi-platform app, so update/verify
+        // refetch the same manifest.<token>.json. Empty for legacy single-manifest apps. Additive
+        // and default-empty so older registries round-trip unchanged.
+        public string Platform { get; set; } = string.Empty;
+
         public DateTimeOffset InstalledAt { get; set; }
         public DateTimeOffset LastUpdatedAt { get; set; }
 

--- a/docs/Builder-Guide.md
+++ b/docs/Builder-Guide.md
@@ -99,6 +99,63 @@ the file in place (or to `--out <path>`). See the
 
 ---
 
+## Multi-platform packages (per-variant download)
+
+By default an app ships a single manifest listing every file, so a cross-platform build forces
+every user to download every OS's files. To let a client download **only** its own platform,
+ship one **variant** per `(os[, arch])` and the client fetches just that variant's manifest.
+
+**Publisher layout** — one subfolder per variant, named by its token `<os>[-<arch>]`
+(os ∈ `windows|macos|linux`, arch ∈ `x64|arm64|x86|arm`; omit arch for a build that works on
+any arch of that OS):
+
+```
+mygame-build/
+  windows-x64/   Game.exe + dll
+  macos-arm64/   MyGame.app/Contents/MacOS/MyGame
+  macos-x64/     MyGame.app/Contents/MacOS/MyGame
+  linux/         game + libs          # no arch ⇒ universal linux build
+```
+
+Build each variant into the **same** `--out` with `--platform <token>` — chunks are
+content-addressed, so the shared store dedupes assets common to multiple variants:
+
+```shell
+hina-builder build --input mygame-build/windows-x64 --platform windows-x64 --out patch --base https://patch.example.com/ --version 1.0.0 --sign-key keys/mygame.key.b64
+hina-builder build --input mygame-build/macos-arm64 --platform macos-arm64 --out patch --base https://patch.example.com/ --version 1.0.0 --sign-key keys/mygame.key.b64
+hina-builder build --input mygame-build/linux       --platform linux       --out patch --base https://patch.example.com/ --version 1.0.0 --sign-key keys/mygame.key.b64
+```
+
+**Host layout** (shared chunk store):
+
+```
+<baseUrl>/
+  manifest.windows-x64.json
+  manifest.macos-arm64.json
+  manifest.macos-x64.json
+  manifest.linux.json
+  chunks/<bucket>/<hash>.chunk.br
+```
+
+**Descriptor** — declare a `platforms` array; each `exec` is relative to that variant's root:
+
+```json
+"platforms": [
+  { "os": "windows", "arch": "x64",   "exec": "Game.exe" },
+  { "os": "macos",   "arch": "arm64", "exec": "MyGame.app/Contents/MacOS/MyGame" },
+  { "os": "macos",   "arch": "x64",   "exec": "MyGame.app/Contents/MacOS/MyGame" },
+  { "os": "linux",                    "exec": "game" }
+]
+```
+
+The client picks the most specific variant for its machine; if there's no native build for an
+arm64 host it falls back to the `x64` build (Rosetta on macOS, emulation on Windows) with a
+warning, and errors cleanly when no variant serves the OS. `hina-builder init` detects these
+subfolders automatically and builds every variant for you. Apps with no `platforms` keep the
+legacy single-manifest behavior.
+
+---
+
 ## build Command
 
 Scans a directory, chunks every file, and produces a manifest plus a chunk store.


### PR DESCRIPTION
## Problema

Un'app Hina spediva **un solo manifest** con TUTTI i file → un'app cross-platform faceva scaricare a ogni utente anche le build degli altri OS (e architetture). Spreco. Nessun concetto di arch.

## Soluzione

L'app dichiara **varianti per piattaforma** e il client scarica **solo** il manifest della sua macchina, su un **chunk store condiviso** content-addressed che deduplica gli asset comuni tra varianti. Deciso con l'utente: **os obbligatorio + arch opzionale**, **fallback compatibile** (arm64→x64 macOS Rosetta / Windows emulazione, con avviso), **full stack**, **backward-compatible**.

### Struttura

**Publisher** (un sottodir per variante, nome = token `<os>[-<arch>]`):
```
mygame-build/  windows-x64/  macos-arm64/  macos-x64/  linux/   # linux = universale (no arch)
```
**Host** (chunk store condiviso):
```
manifest.windows-x64.json  manifest.macos-arm64.json  manifest.linux.json  chunks/<bucket>/<hash>.chunk.br
```
**Descriptor**: nuovo `platforms[]` ({os, arch?, exec}); `exec` relativo alla root della variante.

### Implementazione (7 fasi)
1. Schema `PlatformVariant` + firma (`GetCanonicalBytes`) + validazione (os/arch noti, no dup, exec relativo).
2. `PlatformToken` (os/arch correnti) + `PlatformSelector` (esatto → os-only → fallback compatibile → null).
3. Naming manifest `manifest[.<channel>][.<platform>].json` via `HttpChunkClient`/`PatcherConfig`/`PatchClient`/`NetworkOptions`.
4. Client: `InstallService` seleziona + avvisa su fallback + salva `InstalledApp.Platform`; `Update`/`Verify`/`Run` risolvono via token installato (`PlatformResolver`); legacy → exec map.
5. Builder `build --platform <token>` → `manifest.<token>.json` in `--out` condiviso.
6. Wizard `init`: autodetect sottodir-variante (nome = token) → costruisce `platforms[]` e builda ogni variante.
7. Test + docs.

### Backward-compat
App legacy (solo `exec` map, nessun `platforms`) → comportamento invariato (`manifest.json`, scarica tutto). `InstalledApp.Platform` vuoto = legacy.

## Test
**511 verdi** (+27): `PlatformSelector`/`PlatformToken`, `PlatformResolver`, validazione descriptor `platforms`, naming URL manifest, builder `--platform`, init multi-variante e2e. Verifica manuale: due varianti buildate → due manifest + chunk store condiviso; token invalido rifiutato.

🤖 Generated with [Claude Code](https://claude.com/claude-code)