### PR TITLE
perf: patch hot path — incremental verify hash, pooled buffers, fewer copies

### DIFF
--- a/Hina.Core.Tests/PatchVerifyTests.cs
+++ b/Hina.Core.Tests/PatchVerifyTests.cs
@@ -1,0 +1,187 @@
+using System;
+using System.IO;
+using System.Net;
+using System.Net.Http;
+using System.Reflection;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Hina.Core.Chunking;
+using Hina.Core.Configuration;
+using Hina.Core.Hashing;
+using Hina.Core.Manifest;
+using Hina.Core.Net;
+using Hina.Core.Patching;
+using Xunit;
+
+namespace Hina.Core.Tests
+{
+    // Whole-file verification (PatcherConfig.Verify): the rebuilt file must hash to the
+    // manifest's FileHash regardless of how each chunk arrived (reused from local disk or
+    // downloaded), and a manifest whose FileHash disagrees with its own chunks must fail
+    // the patch even though every chunk passes its individual content-hash check.
+    public class PatchVerifyTests : IDisposable
+    {
+        private readonly string _tempRoot;
+        private readonly string _sourceDir;
+        private readonly string _buildOutputDir;
+        private readonly string _targetDir;
+        private readonly Uri _baseUrl = new Uri("http://test.local/");
+        private const int ChunkSize = 4096;
+
+        public PatchVerifyTests()
+        {
+            _tempRoot = Path.Combine(Path.GetTempPath(), "hina_verify_" + Guid.NewGuid().ToString("N"));
+            _sourceDir = Path.Combine(_tempRoot, "source");
+            _buildOutputDir = Path.Combine(_tempRoot, "build");
+            _targetDir = Path.Combine(_tempRoot, "target");
+            Directory.CreateDirectory(_sourceDir);
+            Directory.CreateDirectory(_buildOutputDir);
+            Directory.CreateDirectory(_targetDir);
+        }
+
+        public void Dispose()
+        {
+            try { if (Directory.Exists(_tempRoot)) Directory.Delete(_tempRoot, recursive: true); }
+            catch { /* best effort */ }
+        }
+
+        [Fact]
+        public async Task PatchAsync_VerifyEnabled_MixedMatchedAndDownloadedChunks_Succeeds()
+        {
+            // Target starts with the first half of the file intact, so the rebuild mixes
+            // rsync-matched chunks (copied from local disk) with downloaded ones — the verify
+            // hash must cover both paths.
+            string content = GenerateData(ChunkSize * 8);
+            CreateSourceFile("app.bin", content);
+            await RunBuildAsync();
+
+            string stale = content.Substring(0, ChunkSize * 4) + GenerateData(ChunkSize * 4, seed: 999);
+            await File.WriteAllTextAsync(Path.Combine(_targetDir, "app.bin"), stale);
+
+            PatchClient client = CreatePatchClient(verify: true);
+            PatchResult result = await client.PatchAsync(_targetDir, CancellationToken.None);
+
+            Assert.True(result.Success, $"Patch failed: {result.Message}");
+            Assert.Equal(content, await File.ReadAllTextAsync(Path.Combine(_targetDir, "app.bin")));
+        }
+
+        [Fact]
+        public async Task PatchAsync_VerifyEnabled_ManifestFileHashWrong_Fails()
+        {
+            // Every chunk is individually valid, but the manifest lies about the whole-file
+            // hash. Only the Verify pass can catch this.
+            CreateSourceFile("app.bin", GenerateData(ChunkSize * 4));
+            Manifest.Manifest manifest = await RunBuildAsync();
+
+            manifest.Files[0].FileHash = "sha256:" + new string('0', 64);
+            await ManifestSerializer.WriteAsync(manifest, Path.Combine(_buildOutputDir, "manifest.json"), CancellationToken.None);
+
+            PatchClient client = CreatePatchClient(verify: true);
+            PatchResult result = await client.PatchAsync(_targetDir, CancellationToken.None);
+
+            Assert.False(result.Success);
+            Assert.Contains("hash mismatch", result.Message, StringComparison.OrdinalIgnoreCase);
+        }
+
+        [Fact]
+        public async Task PatchAsync_VerifyDisabled_ManifestFileHashWrong_StillSucceeds()
+        {
+            // With Verify off the whole-file check is skipped by design (chunks are still
+            // individually hash-checked). Guards against the verify path running when disabled.
+            string content = GenerateData(ChunkSize * 4);
+            CreateSourceFile("app.bin", content);
+            Manifest.Manifest manifest = await RunBuildAsync();
+
+            manifest.Files[0].FileHash = "sha256:" + new string('0', 64);
+            await ManifestSerializer.WriteAsync(manifest, Path.Combine(_buildOutputDir, "manifest.json"), CancellationToken.None);
+
+            PatchClient client = CreatePatchClient(verify: false);
+            PatchResult result = await client.PatchAsync(_targetDir, CancellationToken.None);
+
+            Assert.True(result.Success, $"Patch failed: {result.Message}");
+            Assert.Equal(content, await File.ReadAllTextAsync(Path.Combine(_targetDir, "app.bin")));
+        }
+
+        // ---------- Helpers ----------
+
+        private void CreateSourceFile(string relativePath, string content)
+        {
+            string fullPath = Path.Combine(_sourceDir, relativePath.Replace('/', Path.DirectorySeparatorChar));
+            Directory.CreateDirectory(Path.GetDirectoryName(fullPath)!);
+            File.WriteAllText(fullPath, content);
+        }
+
+        private static string GenerateData(int length, int seed = 1234)
+        {
+            var sb = new StringBuilder(length);
+            Random rng = new Random(seed);
+            for (int i = 0; i < length; i++) sb.Append((char)('A' + rng.Next(0, 26)));
+            return sb.ToString();
+        }
+
+        private async Task<Manifest.Manifest> RunBuildAsync()
+        {
+            IHasher hasher = new Sha256Hasher();
+            ManifestBuilder builder = new ManifestBuilder(hasher);
+            ChunkStoreWriter chunkWriter = new ChunkStoreWriter(hasher, ChunkSize);
+
+            DirectoryInfo sourceDir = new DirectoryInfo(_sourceDir);
+            DirectoryInfo chunkDir = new DirectoryInfo(Path.Combine(_buildOutputDir, "chunks"));
+
+            Manifest.Manifest manifest = await builder.BuildAsync(sourceDir, _baseUrl, ChunkSize, CancellationToken.None);
+            manifest.Version = "1.0.0";
+
+            await ManifestSerializer.WriteAsync(manifest, Path.Combine(_buildOutputDir, "manifest.json"), CancellationToken.None);
+            await chunkWriter.WriteChunksAsync(sourceDir, chunkDir, CancellationToken.None);
+            return manifest;
+        }
+
+        private PatchClient CreatePatchClient(bool verify)
+        {
+            PatcherConfig config = new PatcherConfig
+            {
+                BaseUrl = _baseUrl,
+                Channel = "stable",
+                ChunkSize = ChunkSize,
+                Concurrency = 4,
+                Verify = verify,
+                Backup = false,
+                TrustedPublicKey = null
+            };
+
+            PatchClient client = new PatchClient(config);
+
+            var httpClient = new HttpClient(new ServeDirHandler(_buildOutputDir));
+            var httpChunkClient = new HttpChunkClient(httpClient);
+            FieldInfo? httpField = typeof(PatchClient).GetField("_http", BindingFlags.NonPublic | BindingFlags.Instance);
+            Assert.NotNull(httpField);
+            httpField!.SetValue(client, httpChunkClient);
+
+            return client;
+        }
+
+        // Serves manifest.json and chunks straight from the build output directory.
+        private sealed class ServeDirHandler : HttpMessageHandler
+        {
+            private readonly string _buildOutputDir;
+
+            public ServeDirHandler(string buildOutputDir)
+            {
+                _buildOutputDir = buildOutputDir;
+            }
+
+            protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+            {
+                string path = request.RequestUri!.AbsolutePath.TrimStart('/');
+                string localPath = Path.Combine(_buildOutputDir, path.Replace('/', Path.DirectorySeparatorChar));
+                if (!File.Exists(localPath))
+                {
+                    return new HttpResponseMessage(HttpStatusCode.NotFound);
+                }
+                byte[] data = await File.ReadAllBytesAsync(localPath, cancellationToken);
+                return new HttpResponseMessage(HttpStatusCode.OK) { Content = new ByteArrayContent(data) };
+            }
+        }
+    }
+}

--- a/Hina.Core/Compression/BrotliCodec.cs
+++ b/Hina.Core/Compression/BrotliCodec.cs
@@ -27,8 +27,13 @@ namespace Hina.Core.Compression
         // by orders of magnitude; without a cap a tiny ".chunk.br" could OOM the client before
         // any hash check runs. Throws InvalidDataException once the limit is exceeded.
         public static byte[] Decompress(byte[] data, long maxBytes = DefaultMaxDecompressedBytes)
+            => Decompress(data, 0, data.Length, maxBytes);
+
+        // Overload for callers holding the payload in a larger buffer (e.g. a MemoryStream's
+        // backing array) — avoids forcing them into a defensive ToArray() copy first.
+        public static byte[] Decompress(byte[] data, int index, int count, long maxBytes = DefaultMaxDecompressedBytes)
         {
-            using (var input = new MemoryStream(data))
+            using (var input = new MemoryStream(data, index, count))
             using (var bs = new BrotliStream(input, CompressionMode.Decompress))
             using (var output = new MemoryStream())
             {

--- a/Hina.Core/Net/HttpChunkClient.cs
+++ b/Hina.Core/Net/HttpChunkClient.cs
@@ -111,9 +111,13 @@ namespace Hina.Core.Net
 
             using Stream stream = await response.Content.ReadAsStreamAsync(ct);
             using CappedReadStream limited = new CappedReadStream(stream, compressedCap);
-            using MemoryStream buffer = new MemoryStream();
+            // Pre-size from Content-Length when the server provides one (EnsureWithinCap already
+            // rejected anything above the cap), and read the backing buffer directly instead of
+            // ToArray() — skips one full copy of every chunk.
+            int capacity = response.Content.Headers.ContentLength is long cl && cl > 0 ? (int)cl : 0;
+            using MemoryStream buffer = new MemoryStream(capacity);
             await limited.CopyToAsync(buffer, ct);
-            return DecompressAndVerify(buffer.ToArray(), hashOnly, maxBytes);
+            return DecompressAndVerify(buffer.GetBuffer(), (int)buffer.Length, hashOnly, maxBytes);
         }
 
         // A redirect that lands on http:// after we requested https:// pulls the payload over a
@@ -142,9 +146,9 @@ namespace Hina.Core.Net
         // decompressed bytes actually hash to that name, independent of the optional whole-file
         // verify pass (PatcherConfig.Verify) — so a corrupt/tampered chunk is rejected even when
         // whole-file verification is disabled, and the failure is localized for retry.
-        private static byte[] DecompressAndVerify(byte[] compressed, string expectedHashOnly, long maxBytes)
+        private static byte[] DecompressAndVerify(byte[] compressed, int compressedLength, string expectedHashOnly, long maxBytes)
         {
-            byte[] data = BrotliCodec.Decompress(compressed, maxBytes);
+            byte[] data = BrotliCodec.Decompress(compressed, 0, compressedLength, maxBytes);
 
             string actual = Convert.ToHexStringLower(System.Security.Cryptography.SHA256.HashData(data));
             if (!string.Equals(actual, expectedHashOnly, StringComparison.OrdinalIgnoreCase))

--- a/Hina.Core/Patching/PatchClient.cs
+++ b/Hina.Core/Patching/PatchClient.cs
@@ -143,12 +143,15 @@ namespace Hina.Core.Patching
                         _logger.LogDebug("Rsync matched {MatchCount}/{TotalChunks} chunks for {FilePath}", matches.Count, file.Chunks.Count, file.Path);
                     }
 
-                    // Open the local file once for the whole rebuild instead of per matched chunk.
-                    using FileStream? srcFs = matches.Count > 0 ? File.OpenRead(localPath) : null;
                     // Downloads run against a derived token so that on any failure we can cancel
                     // every in-flight chunk fetch and drain it — otherwise the tasks we started
                     // ahead of the write cursor would leak (open sockets, unobserved exceptions).
                     using CancellationTokenSource dl = CancellationTokenSource.CreateLinkedTokenSource(ct);
+                    // Open the local file once for the whole rebuild instead of per matched chunk.
+                    // The handle MUST be released before the File.Copy swap below: keeping it open
+                    // (even read-only, FileShare.Read) makes the overwrite of localPath fail with a
+                    // sharing violation — so srcFs's scope is this block, not the whole try.
+                    using (FileStream? srcFs = matches.Count > 0 ? File.OpenRead(localPath) : null)
                     using (FileStream outFs = File.Create(tempPath))
                     {
                         // Rebuild the file in manifest order, reusing local data when possible.

--- a/Hina.Core/Patching/PatchClient.cs
+++ b/Hina.Core/Patching/PatchClient.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Buffers;
 using System.Collections.Generic;
 using System.IO;
 using System.Net.Http;
@@ -151,8 +152,15 @@ namespace Hina.Core.Patching
                     // The handle MUST be released before the File.Copy swap below: keeping it open
                     // (even read-only, FileShare.Read) makes the overwrite of localPath fail with a
                     // sharing violation — so srcFs's scope is this block, not the whole try.
+                    // Whole-file verification hashes the bytes as they are written (both the
+                    // disk-copied and downloaded paths feed it), replacing a full re-read of
+                    // the temp file after the rebuild.
+                    string? rebuiltHash = null;
                     using (FileStream? srcFs = matches.Count > 0 ? File.OpenRead(localPath) : null)
                     using (FileStream outFs = File.Create(tempPath))
+                    using (IncrementalHash? verifyHash = Config.Verify
+                        ? IncrementalHash.CreateHash(HashAlgorithmName.SHA256)
+                        : null)
                     {
                         // Rebuild the file in manifest order, reusing local data when possible.
                         // Missing chunks are downloaded in parallel: we keep up to Config.Concurrency
@@ -190,7 +198,7 @@ namespace Hina.Core.Patching
                                 if (matches.TryGetValue(chunk.Index, out long offset))
                                 {
                                     // Reuse local data when a chunk matches.
-                                    CopyChunk(srcFs!, offset, chunk.Size, outFs);
+                                    CopyChunk(srcFs!, offset, chunk.Size, outFs, verifyHash);
                                 }
                                 else
                                 {
@@ -202,6 +210,7 @@ namespace Hina.Core.Patching
                                             $"Manifest chunk size {chunk.Size} is inconsistent with the {data.Length}-byte chunk content.");
                                     }
                                     await outFs.WriteAsync(data.AsMemory(0, chunk.Size), ct);
+                                    verifyHash?.AppendData(data, 0, chunk.Size);
                                 }
                             }
                         }
@@ -214,17 +223,18 @@ namespace Hina.Core.Patching
                             catch { /* faults/cancellations observed; the original error is what propagates */ }
                             throw;
                         }
+
+                        if (verifyHash != null)
+                        {
+                            rebuiltHash = "sha256:" + Hex.ToHexLower(verifyHash.GetHashAndReset());
+                        }
                     }
 
                     if (Config.Verify)
                     {
-                        using (FileStream fs = File.OpenRead(tempPath))
+                        if (!string.Equals(rebuiltHash, file.FileHash, StringComparison.OrdinalIgnoreCase))
                         {
-                            string hash = await _hasher.ComputeHashAsync(fs, ct);
-                            if (!string.Equals(hash, file.FileHash, StringComparison.OrdinalIgnoreCase))
-                            {
-                                throw new InvalidDataException("Hash mismatch after patch.");
-                            }
+                            throw new InvalidDataException("Hash mismatch after patch.");
                         }
                         _logger.LogDebug("Verification passed for {FilePath}", file.Path);
                     }
@@ -365,16 +375,24 @@ namespace Hina.Core.Patching
             return Task.CompletedTask;
         }
 
-        private static void CopyChunk(FileStream src, long offset, int size, FileStream output)
+        private static void CopyChunk(FileStream src, long offset, int size, FileStream output, IncrementalHash? verifyHash)
         {
-            byte[] buffer = new byte[size];
-            src.Seek(offset, SeekOrigin.Begin);
-            // ReadExactly: a single Read may return fewer bytes than requested. A matched
-            // rsync chunk always has `size` bytes available at `offset`, so a short read
-            // means a truncated/changed source — fail (caught upstream → rollback) rather
-            // than silently writing a short, corrupt chunk.
-            src.ReadExactly(buffer, 0, size);
-            output.Write(buffer, 0, size);
+            byte[] buffer = ArrayPool<byte>.Shared.Rent(size);
+            try
+            {
+                src.Seek(offset, SeekOrigin.Begin);
+                // ReadExactly: a single Read may return fewer bytes than requested. A matched
+                // rsync chunk always has `size` bytes available at `offset`, so a short read
+                // means a truncated/changed source — fail (caught upstream → rollback) rather
+                // than silently writing a short, corrupt chunk.
+                src.ReadExactly(buffer, 0, size);
+                output.Write(buffer, 0, size);
+                verifyHash?.AppendData(buffer, 0, size);
+            }
+            finally
+            {
+                ArrayPool<byte>.Shared.Return(buffer);
+            }
         }
 
         private async Task<Dictionary<int, long>> RsyncMatchLocalAsync(string localPath, ManifestFile file, CancellationToken ct)


### PR DESCRIPTION
## Summary
- **Incremental verify hash** — `PatchAsync` with `Verify=true` used to re-read the entire rebuilt temp file from disk to hash it; the hash is now computed while writing (covers both rsync-matched chunks copied from disk and downloaded chunks). Eliminates one full I/O pass per patched file.
- **Bugfix found by the new tests**: patching an existing file with rsync-matched chunks kept a read handle on the local file open across the atomic swap (`File.Copy` onto it), failing with a sharing violation. Existing fixtures were all smaller than one chunk, so the matcher never opened that handle. Fixed by scoping the handle to the rebuild block.
- **Pooled copy buffers** — `CopyChunk` rents from `ArrayPool` instead of allocating per chunk.
- **One less copy per chunk** — `HttpChunkClient` pre-sizes its buffer from Content-Length and decompresses straight from the MemoryStream backing array instead of `ToArray()`.

## Tests
New `PatchVerifyTests` (3): mixed matched+downloaded rebuild with verify, hostile manifest FileHash mismatch fails, verify-off skips the whole-file check. Suite: **514 green**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)