### PR TITLE
refactor: testable Hina.Host + test suite (fixes chunk serving 404)

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -8,6 +8,7 @@
 
   <ItemGroup>
     <PackageVersion Include="coverlet.collector" Version="6.0.0" />
+    <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.9" />
     <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="9.0.0" />
     <PackageVersion Include="Microsoft.Extensions.Logging.Console" Version="9.0.0" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />

--- a/Hina.Host.Tests/AccessStatsTests.cs
+++ b/Hina.Host.Tests/AccessStatsTests.cs
@@ -1,0 +1,64 @@
+namespace Hina.Host.Tests
+{
+    public class AccessStatsTests
+    {
+        [Fact]
+        public void RecordRequest_CountsTotalsAndTops()
+        {
+            var stats = new AccessStats();
+            stats.RecordRequest("1.2.3.4", "gameA", "/gameA/manifest.json");
+            stats.RecordRequest("1.2.3.4", "gameA", "/gameA/manifest.json");
+            stats.RecordRequest("5.6.7.8", "gameB", "/gameB/chunks/ab/x.chunk.br");
+
+            var snap = stats.Snapshot();
+
+            Assert.Equal(3, snap.TotalRequests);
+            Assert.Equal(0, snap.Rejections);
+            Assert.Equal("1.2.3.4", snap.TopIp);
+            Assert.Equal("gameA", snap.TopApp);
+            Assert.Equal("/gameA/manifest.json", snap.TopPath);
+        }
+
+        [Fact]
+        public void RecordRejection_CountsPerApp()
+        {
+            var stats = new AccessStats();
+            stats.RecordRejection("1.2.3.4", "gameA");
+            stats.RecordRejection("1.2.3.4", "gameA");
+
+            var snap = stats.Snapshot();
+
+            Assert.Equal(2, snap.Rejections);
+            Assert.Equal(2, snap.AppRejections["gameA"]);
+        }
+
+        [Fact]
+        public void ShouldLogAbuse_BelowThreshold_False()
+        {
+            var stats = new AccessStats();
+            stats.RecordRequest("1.2.3.4", "gameA", "/x");
+
+            Assert.False(stats.ShouldLogAbuse("1.2.3.4", "gameA", threshold: 5, out long count));
+            Assert.Equal(1, count);
+        }
+
+        [Fact]
+        public void ShouldLogAbuse_AtThreshold_TrueOnceThenSuppressed()
+        {
+            var stats = new AccessStats();
+            for (int i = 0; i < 5; i++) stats.RecordRequest("1.2.3.4", "gameA", "/x");
+
+            // First crossing logs; a second check inside the same minute is rate-limited.
+            Assert.True(stats.ShouldLogAbuse("1.2.3.4", "gameA", threshold: 5, out _));
+            Assert.False(stats.ShouldLogAbuse("1.2.3.4", "gameA", threshold: 5, out _));
+        }
+
+        [Fact]
+        public void ShouldLogAbuse_UnknownKey_False()
+        {
+            var stats = new AccessStats();
+            Assert.False(stats.ShouldLogAbuse("9.9.9.9", "nope", threshold: 1, out long count));
+            Assert.Equal(0, count);
+        }
+    }
+}

--- a/Hina.Host.Tests/Hina.Host.Tests.csproj
+++ b/Hina.Host.Tests/Hina.Host.Tests.csproj
@@ -1,0 +1,26 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="coverlet.collector" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="xunit" />
+    <PackageReference Include="xunit.runner.visualstudio" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <!-- Hina.Host is an Exe (top-level statements); referenced so the tests can boot it
+         in-process via WebApplicationFactory and reach internals (HostOptions, Routing…). -->
+    <ProjectReference Include="..\Hina.Host\Hina.Host.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/Hina.Host.Tests/HostEndpointsTests.cs
+++ b/Hina.Host.Tests/HostEndpointsTests.cs
@@ -1,0 +1,79 @@
+using System.Net;
+using Microsoft.AspNetCore.Mvc.Testing;
+
+namespace Hina.Host.Tests
+{
+    // Boots the real Hina.Host pipeline in-process (TestServer). The patch root is pointed
+    // at a temp directory via the legacy Patcher:Root setting, which HostOptions.Load reads
+    // from IConfiguration.
+    public class HostEndpointsTests : IDisposable
+    {
+        private readonly string _root;
+        private readonly WebApplicationFactory<Program> _factory;
+
+        public HostEndpointsTests()
+        {
+            _root = Path.Combine(Path.GetTempPath(), "hina_host_it_" + Guid.NewGuid().ToString("N"));
+            Directory.CreateDirectory(Path.Combine(_root, "chunks", "ab"));
+            File.WriteAllText(Path.Combine(_root, "manifest.json"), """{ "version": "1.0.0" }""");
+            File.WriteAllBytes(Path.Combine(_root, "chunks", "ab", "abcd.chunk.br"), new byte[] { 1, 2, 3 });
+
+            _factory = new WebApplicationFactory<Program>()
+                .WithWebHostBuilder(b => b.UseSetting("Patcher:Root", _root));
+        }
+
+        public void Dispose()
+        {
+            _factory.Dispose();
+            try { Directory.Delete(_root, recursive: true); } catch { /* best effort */ }
+        }
+
+        [Fact]
+        public async Task Health_ReturnsOk()
+        {
+            using var client = _factory.CreateClient();
+            var resp = await client.GetAsync("/health");
+            Assert.Equal(HttpStatusCode.OK, resp.StatusCode);
+        }
+
+        [Fact]
+        public async Task Stats_NonLoopbackCaller_Returns404()
+        {
+            // TestServer connections have no RemoteIpAddress, which must NOT pass the
+            // loopback-only gate.
+            using var client = _factory.CreateClient();
+            var resp = await client.GetAsync("/stats");
+            Assert.Equal(HttpStatusCode.NotFound, resp.StatusCode);
+        }
+
+        [Fact]
+        public async Task Manifest_IsServed_WithRevalidateCacheHeader()
+        {
+            using var client = _factory.CreateClient();
+            var resp = await client.GetAsync("/manifest.json");
+
+            Assert.Equal(HttpStatusCode.OK, resp.StatusCode);
+            string cache = resp.Headers.TryGetValues("Cache-Control", out var v) ? string.Join(",", v) : "";
+            Assert.Contains("must-revalidate", cache);
+        }
+
+        [Fact]
+        public async Task Chunk_IsServed_WithImmutableCacheHeader()
+        {
+            using var client = _factory.CreateClient();
+            var resp = await client.GetAsync("/chunks/ab/abcd.chunk.br");
+
+            Assert.Equal(HttpStatusCode.OK, resp.StatusCode);
+            string cache = resp.Headers.TryGetValues("Cache-Control", out var v) ? string.Join(",", v) : "";
+            Assert.Contains("immutable", cache);
+        }
+
+        [Fact]
+        public async Task MissingFile_Returns404()
+        {
+            using var client = _factory.CreateClient();
+            var resp = await client.GetAsync("/nope/missing.bin");
+            Assert.Equal(HttpStatusCode.NotFound, resp.StatusCode);
+        }
+    }
+}

--- a/Hina.Host.Tests/HostOptionsTests.cs
+++ b/Hina.Host.Tests/HostOptionsTests.cs
@@ -1,0 +1,101 @@
+using Microsoft.Extensions.Configuration;
+
+namespace Hina.Host.Tests
+{
+    public class HostOptionsTests : IDisposable
+    {
+        private readonly string _tempDir;
+
+        public HostOptionsTests()
+        {
+            _tempDir = Path.Combine(Path.GetTempPath(), "hina_hostopts_" + Guid.NewGuid().ToString("N"));
+            Directory.CreateDirectory(_tempDir);
+        }
+
+        public void Dispose()
+        {
+            try { Directory.Delete(_tempDir, recursive: true); } catch { /* best effort */ }
+        }
+
+        private static IConfiguration EmptyConfig() => new ConfigurationBuilder().Build();
+
+        [Fact]
+        public void Load_NoConfigNoArgs_UsesDefaults()
+        {
+            var opt = HostOptions.Load(Array.Empty<string>(), EmptyConfig());
+
+            Assert.Equal("patch", opt.Root);
+            Assert.Null(opt.Urls);
+            Assert.Equal(600, opt.RequestsPerMinutePerIp);
+            Assert.Equal(300, opt.AbuseThresholdPerMinute);
+            Assert.True(opt.StatsEnabled);
+            Assert.Empty(opt.Apps);
+        }
+
+        [Fact]
+        public void Load_FromJsonFile_ReadsAllFields()
+        {
+            string cfg = Path.Combine(_tempDir, "hina.host.json");
+            File.WriteAllText(cfg, """
+                {
+                  "root": "my-patches",
+                  "urls": "http://127.0.0.1:5001",
+                  "requestsPerMinutePerIp": 42,
+                  "abuseThresholdPerMinute": 21,
+                  "statsEnabled": false,
+                  "cors": ["https://a.example", "https://b.example"],
+                  "apps": { "gameA": "/srv/gameA" }
+                }
+                """);
+
+            var opt = HostOptions.Load(new[] { "--config", cfg }, EmptyConfig());
+
+            Assert.Equal("my-patches", opt.Root);
+            Assert.Equal("http://127.0.0.1:5001", opt.Urls);
+            Assert.Equal(42, opt.RequestsPerMinutePerIp);
+            Assert.Equal(21, opt.AbuseThresholdPerMinute);
+            Assert.False(opt.StatsEnabled);
+            Assert.Equal(2, opt.Cors.Count);
+            Assert.Equal("/srv/gameA", opt.Apps["gameA"]);
+        }
+
+        [Fact]
+        public void Load_CliFlags_OverrideJson()
+        {
+            string cfg = Path.Combine(_tempDir, "hina.host.json");
+            File.WriteAllText(cfg, """{ "root": "from-json", "requestsPerMinutePerIp": 42 }""");
+
+            var opt = HostOptions.Load(new[]
+            {
+                "--config", cfg,
+                "--root", "from-cli",
+                "--port", "1234",
+                "--rate-limit", "7",
+                "--no-stats"
+            }, EmptyConfig());
+
+            Assert.Equal("from-cli", opt.Root);
+            Assert.Equal("http://0.0.0.0:1234", opt.Urls);
+            Assert.Equal(7, opt.RequestsPerMinutePerIp);
+            Assert.False(opt.StatsEnabled);
+        }
+
+        [Fact]
+        public void Load_RateLimitZero_DisablesLimit()
+        {
+            var opt = HostOptions.Load(new[] { "--rate-limit", "0" }, EmptyConfig());
+            Assert.Equal(int.MaxValue, opt.RequestsPerMinutePerIp);
+        }
+
+        [Fact]
+        public void Load_LegacyPatcherRootSetting_OverridesDefault()
+        {
+            var config = new ConfigurationBuilder()
+                .AddInMemoryCollection(new Dictionary<string, string?> { ["Patcher:Root"] = "legacy-root" })
+                .Build();
+
+            var opt = HostOptions.Load(Array.Empty<string>(), config);
+            Assert.Equal("legacy-root", opt.Root);
+        }
+    }
+}

--- a/Hina.Host.Tests/RoutingTests.cs
+++ b/Hina.Host.Tests/RoutingTests.cs
@@ -1,0 +1,44 @@
+namespace Hina.Host.Tests
+{
+    public class RoutingTests
+    {
+        [Fact]
+        public void ExtractApp_NoAppsConfigured_ReturnsDefault()
+        {
+            var opt = new HostOptions();
+            Assert.Equal("default", Routing.ExtractApp("/anything/manifest.json", opt));
+        }
+
+        [Fact]
+        public void ExtractApp_KnownPrefix_ReturnsAppName()
+        {
+            var opt = new HostOptions();
+            opt.Apps["gameA"] = "/srv/gameA";
+            Assert.Equal("gameA", Routing.ExtractApp("/gameA/manifest.json", opt));
+        }
+
+        [Fact]
+        public void ExtractApp_KnownPrefix_IsCaseInsensitive()
+        {
+            var opt = new HostOptions();
+            opt.Apps["gameA"] = "/srv/gameA";
+            Assert.Equal("GAMEA", Routing.ExtractApp("/GAMEA/manifest.json", opt));
+        }
+
+        [Fact]
+        public void ExtractApp_UnknownPrefix_ReturnsUnknown()
+        {
+            var opt = new HostOptions();
+            opt.Apps["gameA"] = "/srv/gameA";
+            Assert.Equal("unknown", Routing.ExtractApp("/other/manifest.json", opt));
+        }
+
+        [Fact]
+        public void ExtractApp_RootPath_WithApps_ReturnsUnknown()
+        {
+            var opt = new HostOptions();
+            opt.Apps["gameA"] = "/srv/gameA";
+            Assert.Equal("unknown", Routing.ExtractApp("/", opt));
+        }
+    }
+}

--- a/Hina.Host.Tests/SetupWizardTests.cs
+++ b/Hina.Host.Tests/SetupWizardTests.cs
@@ -1,0 +1,58 @@
+namespace Hina.Host.Tests
+{
+    public class SetupWizardTests : IDisposable
+    {
+        private readonly string _tempDir;
+
+        public SetupWizardTests()
+        {
+            _tempDir = Path.Combine(Path.GetTempPath(), "hina_wizard_" + Guid.NewGuid().ToString("N"));
+            Directory.CreateDirectory(_tempDir);
+        }
+
+        public void Dispose()
+        {
+            try { Directory.Delete(_tempDir, recursive: true); } catch { /* best effort */ }
+        }
+
+        private string PathFor(string name) => Path.Combine(_tempDir, name);
+
+        [Fact]
+        public void IsConfigMissingOrEmpty_MissingFile_True()
+        {
+            Assert.True(SetupWizard.IsConfigMissingOrEmpty(PathFor("absent.json")));
+        }
+
+        [Fact]
+        public void IsConfigMissingOrEmpty_EmptyObject_True()
+        {
+            string p = PathFor("empty.json");
+            File.WriteAllText(p, "{}");
+            Assert.True(SetupWizard.IsConfigMissingOrEmpty(p));
+        }
+
+        [Fact]
+        public void IsConfigMissingOrEmpty_NotAnObject_True()
+        {
+            string p = PathFor("array.json");
+            File.WriteAllText(p, "[1,2,3]");
+            Assert.True(SetupWizard.IsConfigMissingOrEmpty(p));
+        }
+
+        [Fact]
+        public void IsConfigMissingOrEmpty_InvalidJson_True()
+        {
+            string p = PathFor("broken.json");
+            File.WriteAllText(p, "not json at all");
+            Assert.True(SetupWizard.IsConfigMissingOrEmpty(p));
+        }
+
+        [Fact]
+        public void IsConfigMissingOrEmpty_PopulatedConfig_False()
+        {
+            string p = PathFor("ok.json");
+            File.WriteAllText(p, """{ "urls": "http://127.0.0.1:5000" }""");
+            Assert.False(SetupWizard.IsConfigMissingOrEmpty(p));
+        }
+    }
+}

--- a/Hina.Host/AccessStats.cs
+++ b/Hina.Host/AccessStats.cs
@@ -1,0 +1,94 @@
+using System.Collections.Concurrent;
+
+namespace Hina.Host
+{
+    // In-memory request counters keyed by (ip, app), backing /stats, the periodic summary
+    // log, and abuse warnings.
+    internal sealed class AccessStats
+    {
+        readonly ConcurrentDictionary<string, IpBucket> _keys = new(); // key = ip|app
+        readonly ConcurrentDictionary<string, long> _paths = new();
+        readonly ConcurrentDictionary<string, long> _apps = new();
+        readonly ConcurrentDictionary<string, long> _appRejections = new();
+        long _total;
+        long _rejections;
+
+        public void RecordRequest(string ip, string appName, string path)
+        {
+            Interlocked.Increment(ref _total);
+            _paths.AddOrUpdate(path, 1, (_, v) => v + 1);
+            _apps.AddOrUpdate(appName, 1, (_, v) => v + 1);
+            var bucket = _keys.GetOrAdd($"{ip}|{appName}", _ => new IpBucket());
+            bucket.Hit();
+        }
+
+        public void RecordRejection(string ip, string appName)
+        {
+            Interlocked.Increment(ref _rejections);
+            _appRejections.AddOrUpdate(appName, 1, (_, v) => v + 1);
+            var bucket = _keys.GetOrAdd($"{ip}|{appName}", _ => new IpBucket());
+            Interlocked.Increment(ref bucket.Rejections);
+        }
+
+        public bool ShouldLogAbuse(string ip, string appName, int threshold, out long count)
+        {
+            count = 0;
+            if (!_keys.TryGetValue($"{ip}|{appName}", out var b)) return false;
+            count = b.CountLastMinute();
+            if (count < threshold) return false;
+            long now = Environment.TickCount64;
+            long last = Interlocked.Read(ref b.LastAbuseLogTick);
+            if (now - last < 60_000) return false;
+            return Interlocked.CompareExchange(ref b.LastAbuseLogTick, now, last) == last;
+        }
+
+        public StatsSnapshot Snapshot()
+        {
+            var topKey = _keys.Select(kv => (kv.Key, kv.Value.CountLastMinute())).OrderByDescending(t => t.Item2).FirstOrDefault();
+            var topPath = _paths.OrderByDescending(kv => kv.Value).FirstOrDefault();
+            var topApp = _apps.OrderByDescending(kv => kv.Value).FirstOrDefault();
+            string topIp = topKey.Key is null ? "-" : topKey.Key.Split('|')[0];
+            return new StatsSnapshot(
+                Interlocked.Read(ref _total),
+                Interlocked.Read(ref _rejections),
+                topIp,
+                topApp.Key ?? "-",
+                topPath.Key ?? "-",
+                _keys.OrderByDescending(kv => kv.Value.CountLastMinute()).Take(10)
+                    .ToDictionary(kv => kv.Key, kv => kv.Value.CountLastMinute()),
+                _apps.OrderByDescending(kv => kv.Value).Take(20).ToDictionary(kv => kv.Key, kv => kv.Value),
+                _paths.OrderByDescending(kv => kv.Value).Take(10).ToDictionary(kv => kv.Key, kv => kv.Value),
+                _appRejections.ToDictionary(kv => kv.Key, kv => kv.Value));
+        }
+
+        sealed class IpBucket
+        {
+            readonly ConcurrentQueue<long> _hits = new();
+            public long Rejections;
+            public long LastAbuseLogTick;
+
+            public void Hit()
+            {
+                long now = Environment.TickCount64;
+                _hits.Enqueue(now);
+                Prune(now);
+            }
+
+            public long CountLastMinute()
+            {
+                Prune(Environment.TickCount64);
+                return _hits.Count;
+            }
+
+            void Prune(long now)
+            {
+                long cutoff = now - 60_000;
+                while (_hits.TryPeek(out long t) && t < cutoff) _hits.TryDequeue(out _);
+            }
+        }
+    }
+
+    internal record StatsSnapshot(long TotalRequests, long Rejections, string TopIp, string TopApp, string TopPath,
+        Dictionary<string, long> TopIpApps, Dictionary<string, long> Apps, Dictionary<string, long> TopPaths,
+        Dictionary<string, long> AppRejections);
+}

--- a/Hina.Host/Hina.Host.csproj
+++ b/Hina.Host/Hina.Host.csproj
@@ -4,6 +4,10 @@
     <ProjectReference Include="..\Hina.Core\Hina.Core.csproj" />
   </ItemGroup>
 
+  <ItemGroup>
+    <InternalsVisibleTo Include="Hina.Host.Tests" />
+  </ItemGroup>
+
   <PropertyGroup>
     <ApplicationIcon>..\img\HinaHPack_Logo.ico</ApplicationIcon>
     <PackageIcon>HinaPack_Logo.png</PackageIcon>

--- a/Hina.Host/HostOptions.cs
+++ b/Hina.Host/HostOptions.cs
@@ -1,0 +1,67 @@
+using System.Text.Json;
+
+namespace Hina.Host
+{
+    // Server configuration merged from hina.host.json, the legacy Patcher:Root setting,
+    // and command-line flags (flags win).
+    internal sealed class HostOptions
+    {
+        public string Root { get; set; } = "patch";
+        public string? Urls { get; set; }
+        public int RequestsPerMinutePerIp { get; set; } = 600;
+        public int AbuseThresholdPerMinute { get; set; } = 300;
+        public int SummaryIntervalSeconds { get; set; } = 60;
+        public bool StatsEnabled { get; set; } = true;
+        public List<string> Cors { get; set; } = new();
+        public Dictionary<string, string> Apps { get; set; } = new(StringComparer.OrdinalIgnoreCase);
+
+        public static HostOptions Load(string[] args, IConfiguration config)
+        {
+            var opt = new HostOptions();
+
+            string? configPath = GetArg(args, "--config");
+            string? jsonPath = configPath is not null && File.Exists(configPath)
+                ? configPath
+                : (File.Exists("hina.host.json") ? "hina.host.json" : null);
+
+            if (jsonPath is not null)
+            {
+                using var doc = JsonDocument.Parse(File.ReadAllText(jsonPath));
+                var r = doc.RootElement;
+                if (r.TryGetProperty("root", out var v) && v.ValueKind == JsonValueKind.String) opt.Root = v.GetString()!;
+                if (r.TryGetProperty("urls", out v) && v.ValueKind == JsonValueKind.String) opt.Urls = v.GetString();
+                if (r.TryGetProperty("requestsPerMinutePerIp", out v) && v.TryGetInt32(out int n)) opt.RequestsPerMinutePerIp = n;
+                if (r.TryGetProperty("abuseThresholdPerMinute", out v) && v.TryGetInt32(out n)) opt.AbuseThresholdPerMinute = n;
+                if (r.TryGetProperty("summaryIntervalSeconds", out v) && v.TryGetInt32(out n)) opt.SummaryIntervalSeconds = n;
+                if (r.TryGetProperty("statsEnabled", out v) && v.ValueKind is JsonValueKind.True or JsonValueKind.False) opt.StatsEnabled = v.GetBoolean();
+                if (r.TryGetProperty("cors", out v) && v.ValueKind == JsonValueKind.Array)
+                    opt.Cors = v.EnumerateArray().Where(e => e.ValueKind == JsonValueKind.String).Select(e => e.GetString()!).ToList();
+                if (r.TryGetProperty("apps", out v) && v.ValueKind == JsonValueKind.Object)
+                    foreach (var prop in v.EnumerateObject())
+                        if (prop.Value.ValueKind == JsonValueKind.String)
+                            opt.Apps[prop.Name] = prop.Value.GetString()!;
+            }
+
+            string? legacy = config["Patcher:Root"];
+            if (!string.IsNullOrWhiteSpace(legacy)) opt.Root = legacy;
+
+            if (GetArg(args, "--root") is { } root) opt.Root = root;
+            if (GetArg(args, "--urls") is { } urls) opt.Urls = urls;
+            if (GetArg(args, "--port") is { } port && int.TryParse(port, out int p)) opt.Urls = $"http://0.0.0.0:{p}";
+            if (GetArg(args, "--rate-limit") is { } rl && int.TryParse(rl, out int rln)) opt.RequestsPerMinutePerIp = rln == 0 ? int.MaxValue : rln;
+            if (GetArg(args, "--abuse-threshold") is { } ab && int.TryParse(ab, out int abn)) opt.AbuseThresholdPerMinute = abn;
+            if (GetArg(args, "--cors") is { } cors) opt.Cors = cors.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries).ToList();
+            if (args.Contains("--no-stats", StringComparer.OrdinalIgnoreCase)) opt.StatsEnabled = false;
+
+            return opt;
+        }
+
+        static string? GetArg(string[] args, string name)
+        {
+            for (int i = 0; i < args.Length - 1; i++)
+                if (string.Equals(args[i], name, StringComparison.OrdinalIgnoreCase))
+                    return args[i + 1];
+            return null;
+        }
+    }
+}

--- a/Hina.Host/Program.cs
+++ b/Hina.Host/Program.cs
@@ -1,8 +1,9 @@
-using System.Collections.Concurrent;
 using System.Net;
-using System.Text.Json;
 using System.Threading.RateLimiting;
+using Hina.Host;
 using Microsoft.AspNetCore.HttpOverrides;
+// ASP.NET Core ships its own Microsoft.Extensions.Hosting.HostOptions; alias ours explicitly.
+using HostOptions = Hina.Host.HostOptions;
 using Microsoft.AspNetCore.RateLimiting;
 using Microsoft.Extensions.FileProviders;
 
@@ -16,7 +17,9 @@ bool forceSetup = args.Contains("--setup", StringComparer.OrdinalIgnoreCase);
 string? explicitConfig = GetArgTop(args, "--config");
 string defaultConfigPath = explicitConfig ?? "hina.host.json";
 
-if (forceSetup || ShouldRunWizard(defaultConfigPath))
+// The wizard only makes sense on an interactive terminal; piped/redirected stdin
+// (services, containers, tests) skips it and runs with defaults.
+if (forceSetup || (!Console.IsInputRedirected && SetupWizard.IsConfigMissingOrEmpty(defaultConfigPath)))
 {
     if (!SetupWizard.Run(defaultConfigPath, forceSetup))
     {
@@ -28,21 +31,6 @@ if (forceSetup || ShouldRunWizard(defaultConfigPath))
 var builder = WebApplication.CreateBuilder(args);
 
 HostOptions options = HostOptions.Load(args, builder.Configuration);
-
-static bool ShouldRunWizard(string path)
-{
-    if (Console.IsInputRedirected) return false;
-    if (!File.Exists(path)) return true;
-    try
-    {
-        using var doc = JsonDocument.Parse(File.ReadAllText(path));
-        if (doc.RootElement.ValueKind != JsonValueKind.Object) return true;
-        int props = 0;
-        foreach (var _ in doc.RootElement.EnumerateObject()) { props++; break; }
-        return props == 0;
-    }
-    catch { return true; }
-}
 
 static string? GetArgTop(string[] args, string name)
 {
@@ -203,6 +191,11 @@ foreach (var m in mounts)
     var staticOpts = new StaticFileOptions
     {
         FileProvider = fp,
+        // ".chunk.br" (and any other unmapped extension in a patch root) must be served:
+        // the default content-type provider has no ".br" mapping, so without this every
+        // chunk request 404s.
+        ServeUnknownFileTypes = true,
+        DefaultContentType = "application/octet-stream",
         OnPrepareResponse = ctx =>
         {
             string? p = ctx.Context.Request.Path.Value;
@@ -292,244 +285,6 @@ static void PrintHelp()
         """);
 }
 
-static class SetupWizard
-{
-    public static bool Run(string outPath, bool force)
-    {
-        Console.WriteLine();
-        Console.WriteLine("=== Hina.Host first-run setup ===");
-        if (File.Exists(outPath) && force)
-        {
-            Console.Write($"'{outPath}' already exists. Overwrite? [y/N]: ");
-            var confirm = Console.ReadLine();
-            if (!string.Equals(confirm?.Trim(), "y", StringComparison.OrdinalIgnoreCase)) return false;
-        }
-        else if (!File.Exists(outPath))
-        {
-            Console.WriteLine($"No config found at '{outPath}'. Let's create one.");
-        }
-        else
-        {
-            Console.WriteLine($"Config '{outPath}' looks empty. Let's populate it.");
-        }
-
-        string port = Ask("Listen port (default 49876 is in the dynamic/private range)", "49876");
-        string bindAll = Ask("Bind on all interfaces (0.0.0.0)? [Y/n]", "y").Trim().ToLowerInvariant();
-        string host = bindAll is "" or "y" or "yes" ? "0.0.0.0" : "127.0.0.1";
-        string urls = $"http://{host}:{port}";
-
-        string mode = Ask("Mode: [s]ingle-app or [m]ulti-app?", "s").Trim().ToLowerInvariant();
-        var json = new Dictionary<string, object> { ["urls"] = urls };
-
-        if (mode.StartsWith("m"))
-        {
-            var apps = new Dictionary<string, string>();
-            Console.WriteLine("Add apps. Leave app name blank to finish.");
-            while (true)
-            {
-                string name = Ask("  App name (blank to stop)", "").Trim();
-                if (string.IsNullOrEmpty(name)) break;
-                string path = Ask($"  Path for '{name}'", $"./patches/{name}").Trim();
-                apps[name] = path;
-            }
-            if (apps.Count == 0)
-            {
-                Console.WriteLine("No apps defined; falling back to single-app mode.");
-                json["root"] = Ask("Patch root directory", "patch").Trim();
-            }
-            else
-            {
-                json["apps"] = apps;
-            }
-        }
-        else
-        {
-            json["root"] = Ask("Patch root directory", "patch").Trim();
-        }
-
-        if (int.TryParse(Ask("Max requests/min per (IP,App)", "600"), out int rl) && rl > 0)
-            json["requestsPerMinutePerIp"] = rl;
-        if (int.TryParse(Ask("Abuse warning threshold/min", "300"), out int at) && at > 0)
-            json["abuseThresholdPerMinute"] = at;
-
-        string cors = Ask("CORS origins (comma-separated, blank for none)", "").Trim();
-        if (!string.IsNullOrEmpty(cors))
-            json["cors"] = cors.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries).ToList();
-
-        string serialized = JsonSerializer.Serialize(json, new JsonSerializerOptions { WriteIndented = true });
-        File.WriteAllText(outPath, serialized);
-        Console.WriteLine();
-        Console.WriteLine($"Wrote {Path.GetFullPath(outPath)}:");
-        Console.WriteLine(serialized);
-        Console.WriteLine("=== Setup complete. Starting host... ===");
-        Console.WriteLine();
-        return true;
-    }
-
-    static string Ask(string prompt, string def)
-    {
-        Console.Write(string.IsNullOrEmpty(def) ? $"{prompt}: " : $"{prompt} [{def}]: ");
-        string? line = Console.ReadLine();
-        return string.IsNullOrWhiteSpace(line) ? def : line;
-    }
-}
-
-static class Routing
-{
-    public static string ExtractApp(string path, HostOptions opt)
-    {
-        if (opt.Apps.Count == 0) return "default";
-        var segs = path.Split('/', StringSplitOptions.RemoveEmptyEntries);
-        if (segs.Length == 0) return "unknown";
-        return opt.Apps.ContainsKey(segs[0]) ? segs[0] : "unknown";
-    }
-}
-
-sealed class HostOptions
-{
-    public string Root { get; set; } = "patch";
-    public string? Urls { get; set; }
-    public int RequestsPerMinutePerIp { get; set; } = 600;
-    public int AbuseThresholdPerMinute { get; set; } = 300;
-    public int SummaryIntervalSeconds { get; set; } = 60;
-    public bool StatsEnabled { get; set; } = true;
-    public List<string> Cors { get; set; } = new();
-    public Dictionary<string, string> Apps { get; set; } = new(StringComparer.OrdinalIgnoreCase);
-
-    public static HostOptions Load(string[] args, IConfiguration config)
-    {
-        var opt = new HostOptions();
-
-        string? configPath = GetArg(args, "--config");
-        string? jsonPath = configPath is not null && File.Exists(configPath)
-            ? configPath
-            : (File.Exists("hina.host.json") ? "hina.host.json" : null);
-
-        if (jsonPath is not null)
-        {
-            using var doc = JsonDocument.Parse(File.ReadAllText(jsonPath));
-            var r = doc.RootElement;
-            if (r.TryGetProperty("root", out var v) && v.ValueKind == JsonValueKind.String) opt.Root = v.GetString()!;
-            if (r.TryGetProperty("urls", out v) && v.ValueKind == JsonValueKind.String) opt.Urls = v.GetString();
-            if (r.TryGetProperty("requestsPerMinutePerIp", out v) && v.TryGetInt32(out int n)) opt.RequestsPerMinutePerIp = n;
-            if (r.TryGetProperty("abuseThresholdPerMinute", out v) && v.TryGetInt32(out n)) opt.AbuseThresholdPerMinute = n;
-            if (r.TryGetProperty("summaryIntervalSeconds", out v) && v.TryGetInt32(out n)) opt.SummaryIntervalSeconds = n;
-            if (r.TryGetProperty("statsEnabled", out v) && v.ValueKind is JsonValueKind.True or JsonValueKind.False) opt.StatsEnabled = v.GetBoolean();
-            if (r.TryGetProperty("cors", out v) && v.ValueKind == JsonValueKind.Array)
-                opt.Cors = v.EnumerateArray().Where(e => e.ValueKind == JsonValueKind.String).Select(e => e.GetString()!).ToList();
-            if (r.TryGetProperty("apps", out v) && v.ValueKind == JsonValueKind.Object)
-                foreach (var prop in v.EnumerateObject())
-                    if (prop.Value.ValueKind == JsonValueKind.String)
-                        opt.Apps[prop.Name] = prop.Value.GetString()!;
-        }
-
-        string? legacy = config["Patcher:Root"];
-        if (!string.IsNullOrWhiteSpace(legacy)) opt.Root = legacy;
-
-        if (GetArg(args, "--root") is { } root) opt.Root = root;
-        if (GetArg(args, "--urls") is { } urls) opt.Urls = urls;
-        if (GetArg(args, "--port") is { } port && int.TryParse(port, out int p)) opt.Urls = $"http://0.0.0.0:{p}";
-        if (GetArg(args, "--rate-limit") is { } rl && int.TryParse(rl, out int rln)) opt.RequestsPerMinutePerIp = rln == 0 ? int.MaxValue : rln;
-        if (GetArg(args, "--abuse-threshold") is { } ab && int.TryParse(ab, out int abn)) opt.AbuseThresholdPerMinute = abn;
-        if (GetArg(args, "--cors") is { } cors) opt.Cors = cors.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries).ToList();
-        if (args.Contains("--no-stats", StringComparer.OrdinalIgnoreCase)) opt.StatsEnabled = false;
-
-        return opt;
-    }
-
-    static string? GetArg(string[] args, string name)
-    {
-        for (int i = 0; i < args.Length - 1; i++)
-            if (string.Equals(args[i], name, StringComparison.OrdinalIgnoreCase))
-                return args[i + 1];
-        return null;
-    }
-}
-
-sealed class AccessStats
-{
-    readonly ConcurrentDictionary<string, IpBucket> _keys = new(); // key = ip|app
-    readonly ConcurrentDictionary<string, long> _paths = new();
-    readonly ConcurrentDictionary<string, long> _apps = new();
-    readonly ConcurrentDictionary<string, long> _appRejections = new();
-    long _total;
-    long _rejections;
-
-    public void RecordRequest(string ip, string appName, string path)
-    {
-        Interlocked.Increment(ref _total);
-        _paths.AddOrUpdate(path, 1, (_, v) => v + 1);
-        _apps.AddOrUpdate(appName, 1, (_, v) => v + 1);
-        var bucket = _keys.GetOrAdd($"{ip}|{appName}", _ => new IpBucket());
-        bucket.Hit();
-    }
-
-    public void RecordRejection(string ip, string appName)
-    {
-        Interlocked.Increment(ref _rejections);
-        _appRejections.AddOrUpdate(appName, 1, (_, v) => v + 1);
-        var bucket = _keys.GetOrAdd($"{ip}|{appName}", _ => new IpBucket());
-        Interlocked.Increment(ref bucket.Rejections);
-    }
-
-    public bool ShouldLogAbuse(string ip, string appName, int threshold, out long count)
-    {
-        count = 0;
-        if (!_keys.TryGetValue($"{ip}|{appName}", out var b)) return false;
-        count = b.CountLastMinute();
-        if (count < threshold) return false;
-        long now = Environment.TickCount64;
-        long last = Interlocked.Read(ref b.LastAbuseLogTick);
-        if (now - last < 60_000) return false;
-        return Interlocked.CompareExchange(ref b.LastAbuseLogTick, now, last) == last;
-    }
-
-    public StatsSnapshot Snapshot()
-    {
-        var topKey = _keys.Select(kv => (kv.Key, kv.Value.CountLastMinute())).OrderByDescending(t => t.Item2).FirstOrDefault();
-        var topPath = _paths.OrderByDescending(kv => kv.Value).FirstOrDefault();
-        var topApp = _apps.OrderByDescending(kv => kv.Value).FirstOrDefault();
-        string topIp = topKey.Key is null ? "-" : topKey.Key.Split('|')[0];
-        return new StatsSnapshot(
-            Interlocked.Read(ref _total),
-            Interlocked.Read(ref _rejections),
-            topIp,
-            topApp.Key ?? "-",
-            topPath.Key ?? "-",
-            _keys.OrderByDescending(kv => kv.Value.CountLastMinute()).Take(10)
-                .ToDictionary(kv => kv.Key, kv => kv.Value.CountLastMinute()),
-            _apps.OrderByDescending(kv => kv.Value).Take(20).ToDictionary(kv => kv.Key, kv => kv.Value),
-            _paths.OrderByDescending(kv => kv.Value).Take(10).ToDictionary(kv => kv.Key, kv => kv.Value),
-            _appRejections.ToDictionary(kv => kv.Key, kv => kv.Value));
-    }
-
-    sealed class IpBucket
-    {
-        readonly ConcurrentQueue<long> _hits = new();
-        public long Rejections;
-        public long LastAbuseLogTick;
-
-        public void Hit()
-        {
-            long now = Environment.TickCount64;
-            _hits.Enqueue(now);
-            Prune(now);
-        }
-
-        public long CountLastMinute()
-        {
-            Prune(Environment.TickCount64);
-            return _hits.Count;
-        }
-
-        void Prune(long now)
-        {
-            long cutoff = now - 60_000;
-            while (_hits.TryPeek(out long t) && t < cutoff) _hits.TryDequeue(out _);
-        }
-    }
-}
-
-record StatsSnapshot(long TotalRequests, long Rejections, string TopIp, string TopApp, string TopPath,
-    Dictionary<string, long> TopIpApps, Dictionary<string, long> Apps, Dictionary<string, long> TopPaths,
-    Dictionary<string, long> AppRejections);
+// Exposes the implicit Program class so Hina.Host.Tests can boot the app in-process
+// via WebApplicationFactory<Program>.
+public partial class Program { }

--- a/Hina.Host/Routing.cs
+++ b/Hina.Host/Routing.cs
@@ -1,0 +1,13 @@
+namespace Hina.Host
+{
+    internal static class Routing
+    {
+        public static string ExtractApp(string path, HostOptions opt)
+        {
+            if (opt.Apps.Count == 0) return "default";
+            var segs = path.Split('/', StringSplitOptions.RemoveEmptyEntries);
+            if (segs.Length == 0) return "unknown";
+            return opt.Apps.ContainsKey(segs[0]) ? segs[0] : "unknown";
+        }
+    }
+}

--- a/Hina.Host/SetupWizard.cs
+++ b/Hina.Host/SetupWizard.cs
@@ -1,0 +1,104 @@
+using System.Text.Json;
+
+namespace Hina.Host
+{
+    // First-run interactive setup: writes hina.host.json. The caller decides whether a
+    // terminal is attached; this class only owns the config-file logic and the prompts.
+    internal static class SetupWizard
+    {
+        // True when the wizard should be offered: no config yet, an empty JSON object, or
+        // an unparseable file.
+        public static bool IsConfigMissingOrEmpty(string path)
+        {
+            if (!File.Exists(path)) return true;
+            try
+            {
+                using var doc = JsonDocument.Parse(File.ReadAllText(path));
+                if (doc.RootElement.ValueKind != JsonValueKind.Object) return true;
+                int props = 0;
+                foreach (var _ in doc.RootElement.EnumerateObject()) { props++; break; }
+                return props == 0;
+            }
+            catch { return true; }
+        }
+
+        public static bool Run(string outPath, bool force)
+        {
+            Console.WriteLine();
+            Console.WriteLine("=== Hina.Host first-run setup ===");
+            if (File.Exists(outPath) && force)
+            {
+                Console.Write($"'{outPath}' already exists. Overwrite? [y/N]: ");
+                var confirm = Console.ReadLine();
+                if (!string.Equals(confirm?.Trim(), "y", StringComparison.OrdinalIgnoreCase)) return false;
+            }
+            else if (!File.Exists(outPath))
+            {
+                Console.WriteLine($"No config found at '{outPath}'. Let's create one.");
+            }
+            else
+            {
+                Console.WriteLine($"Config '{outPath}' looks empty. Let's populate it.");
+            }
+
+            string port = Ask("Listen port (default 49876 is in the dynamic/private range)", "49876");
+            string bindAll = Ask("Bind on all interfaces (0.0.0.0)? [Y/n]", "y").Trim().ToLowerInvariant();
+            string host = bindAll is "" or "y" or "yes" ? "0.0.0.0" : "127.0.0.1";
+            string urls = $"http://{host}:{port}";
+
+            string mode = Ask("Mode: [s]ingle-app or [m]ulti-app?", "s").Trim().ToLowerInvariant();
+            var json = new Dictionary<string, object> { ["urls"] = urls };
+
+            if (mode.StartsWith("m"))
+            {
+                var apps = new Dictionary<string, string>();
+                Console.WriteLine("Add apps. Leave app name blank to finish.");
+                while (true)
+                {
+                    string name = Ask("  App name (blank to stop)", "").Trim();
+                    if (string.IsNullOrEmpty(name)) break;
+                    string path = Ask($"  Path for '{name}'", $"./patches/{name}").Trim();
+                    apps[name] = path;
+                }
+                if (apps.Count == 0)
+                {
+                    Console.WriteLine("No apps defined; falling back to single-app mode.");
+                    json["root"] = Ask("Patch root directory", "patch").Trim();
+                }
+                else
+                {
+                    json["apps"] = apps;
+                }
+            }
+            else
+            {
+                json["root"] = Ask("Patch root directory", "patch").Trim();
+            }
+
+            if (int.TryParse(Ask("Max requests/min per (IP,App)", "600"), out int rl) && rl > 0)
+                json["requestsPerMinutePerIp"] = rl;
+            if (int.TryParse(Ask("Abuse warning threshold/min", "300"), out int at) && at > 0)
+                json["abuseThresholdPerMinute"] = at;
+
+            string cors = Ask("CORS origins (comma-separated, blank for none)", "").Trim();
+            if (!string.IsNullOrEmpty(cors))
+                json["cors"] = cors.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries).ToList();
+
+            string serialized = JsonSerializer.Serialize(json, new JsonSerializerOptions { WriteIndented = true });
+            File.WriteAllText(outPath, serialized);
+            Console.WriteLine();
+            Console.WriteLine($"Wrote {Path.GetFullPath(outPath)}:");
+            Console.WriteLine(serialized);
+            Console.WriteLine("=== Setup complete. Starting host... ===");
+            Console.WriteLine();
+            return true;
+        }
+
+        static string Ask(string prompt, string def)
+        {
+            Console.Write(string.IsNullOrEmpty(def) ? $"{prompt}: " : $"{prompt} [{def}]: ");
+            string? line = Console.ReadLine();
+            return string.IsNullOrWhiteSpace(line) ? def : line;
+        }
+    }
+}

--- a/Hina.sln
+++ b/Hina.sln
@@ -21,6 +21,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Hina.CLI.Tests", "Hina.CLI.
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Hina.Builder.Tests", "Hina.Builder.Tests\Hina.Builder.Tests.csproj", "{CA436D7B-4F84-4E9B-B7D1-A5A0F0948FBD}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Hina.Host.Tests", "Hina.Host.Tests\Hina.Host.Tests.csproj", "{569C234E-ADB7-4929-A60B-83BA551A3597}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -139,6 +141,18 @@ Global
 		{CA436D7B-4F84-4E9B-B7D1-A5A0F0948FBD}.Release|x64.Build.0 = Release|Any CPU
 		{CA436D7B-4F84-4E9B-B7D1-A5A0F0948FBD}.Release|x86.ActiveCfg = Release|Any CPU
 		{CA436D7B-4F84-4E9B-B7D1-A5A0F0948FBD}.Release|x86.Build.0 = Release|Any CPU
+		{569C234E-ADB7-4929-A60B-83BA551A3597}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{569C234E-ADB7-4929-A60B-83BA551A3597}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{569C234E-ADB7-4929-A60B-83BA551A3597}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{569C234E-ADB7-4929-A60B-83BA551A3597}.Debug|x64.Build.0 = Debug|Any CPU
+		{569C234E-ADB7-4929-A60B-83BA551A3597}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{569C234E-ADB7-4929-A60B-83BA551A3597}.Debug|x86.Build.0 = Debug|Any CPU
+		{569C234E-ADB7-4929-A60B-83BA551A3597}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{569C234E-ADB7-4929-A60B-83BA551A3597}.Release|Any CPU.Build.0 = Release|Any CPU
+		{569C234E-ADB7-4929-A60B-83BA551A3597}.Release|x64.ActiveCfg = Release|Any CPU
+		{569C234E-ADB7-4929-A60B-83BA551A3597}.Release|x64.Build.0 = Release|Any CPU
+		{569C234E-ADB7-4929-A60B-83BA551A3597}.Release|x86.ActiveCfg = Release|Any CPU
+		{569C234E-ADB7-4929-A60B-83BA551A3597}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
## Summary
- `Hina.Host/Program.cs` (535 lines, monolithic, untested) reduced to pipeline wiring; `HostOptions`, `Routing`, `AccessStats`, `SetupWizard` extracted to their own files (internal + `InternalsVisibleTo`)
- `public partial class Program` exposed for in-process testing
- New **Hina.Host.Tests** project (25 tests): unit tests for options loading/CLI overrides, app routing, stats/abuse throttling, wizard config probe; integration tests via `WebApplicationFactory` (/health, /stats loopback gate, manifest + chunk serving with cache headers)

## Bug fix
The integration tests caught a real one: **`*.chunk.br` files were never served** — ASP.NET's static file middleware 404s unknown extensions and `.br` has no default content-type mapping. Fixed with `ServeUnknownFileTypes = true` + `application/octet-stream` default.

## Verification
- Full suite green: 536 tests (511 existing + 25 new)
- Manual smoke test: served `/health`, `/manifest.json` (`must-revalidate`) and `/chunks/ab/test.chunk.br` (200, `immutable`, octet-stream) from a temp root

🤖 Generated with [Claude Code](https://claude.com/claude-code)