### PR TITLE
docs: refresh architecture, diagrams, troubleshooting, changelog

### DIFF
--- a/docs/Architecture-Review.md
+++ b/docs/Architecture-Review.md
@@ -5,6 +5,12 @@
 > **valutativo + prescrittivo** (cosa migliorare, perché, in che ordine).
 >
 > Data: 2026-05-28 · Scope: intero solution (`Hina.sln`, ~14k LOC, 7 progetti, .NET 10 NativeAOT)
+>
+> **Aggiornamento 2026-06-09:** la solution è cresciuta a 10 progetti (5 shipped + 5 test,
+> 539 test verdi: si sono aggiunti `Hina.CLI.Tests`, `Hina.Builder.Tests`, `Hina.Host.Tests`)
+> e la build è centralizzata in `Directory.Build.props` + `Directory.Packages.props`.
+> Vedi [Architecture.md](Architecture.md) per lo stato corrente; i numeri sotto riflettono
+> lo snapshot del 2026-05-28.
 
 ---
 

--- a/docs/Architecture.md
+++ b/docs/Architecture.md
@@ -6,17 +6,25 @@ This document describes the internal architecture of Hina, including the project
 
 ## Project Structure
 
-Hina is organized into five projects plus two test projects:
+Hina is organized into five shipped projects plus five test projects:
 
 | Project | Type | Description |
 |---------|------|-------------|
-| **Hina.Core** | Class Library | Core engine: patching, rsync matching, manifest handling, chunking, hashing, signing, compression, networking, configuration |
+| **Hina.Core** | Class Library | Core engine: patching, rsync matching, manifest handling, chunking, hashing, signing, compression, networking, configuration, shared CLI arg parsing (`Cli/Args.cs`) |
 | **Hina.PackageManager** | Class Library | Package-manager layer: descriptor schema, validator, signer/fetcher, install/uninstall/update/reinstall services, hook executor, per-OS shell integration, local registry |
 | **Hina.CLI** | Console App (NativeAOT) | End-user CLI (`hina install/update/uninstall/list/info/which/reinstall/run/perms/verify`) plus developer subcommands under `hina dev <cmd>` |
-| **Hina.Builder** | Console App | Manifest generator and chunk store builder |
-| **Hina.Host** | ASP.NET Core App | Lightweight static file server for serving patches |
+| **Hina.Builder** | Console App | Manifest/chunk-store builder and interactive publish wizard (`init`) |
+| **Hina.Host** | ASP.NET Core App | Lightweight static file server for serving patches (`HostOptions`, `Routing`, `AccessStats`, `SetupWizard` each in their own file; `Program.cs` is pipeline wiring only) |
 | **Hina.Core.Tests** | xUnit Test Project | Unit and integration tests for the core engine |
 | **Hina.PackageManager.Tests** | xUnit Test Project | Unit + cross-platform integration tests for the package-manager layer |
+| **Hina.CLI.Tests** | xUnit Test Project | Command routing and arg parsing tests |
+| **Hina.Builder.Tests** | xUnit Test Project | Build/keygen and init-wizard tests |
+| **Hina.Host.Tests** | xUnit Test Project | Options/routing/stats unit tests plus in-process endpoint tests via `WebApplicationFactory` |
+
+Build settings shared by every project (`TargetFramework`, `Nullable`, `ImplicitUsings`)
+live in the root `Directory.Build.props`; NuGet package versions are centralized in
+`Directory.Packages.props` (Central Package Management) — bump versions there, not in
+the individual `.csproj` files.
 
 ### Dependency Graph
 

--- a/docs/Changelog.md
+++ b/docs/Changelog.md
@@ -4,6 +4,39 @@ All notable changes to Hina are documented in this file.
 
 ---
 
+## Unreleased
+
+### Fixed
+
+- **Delta updates of existing files no longer fail with a sharing violation.** Patching
+  a file that reused local chunks (rsync match) kept a read handle open across the final
+  file swap, so every in-place delta update of a real-sized file failed with
+  "file is being used by another process". The handle is now released before the swap.
+- **Hina.Host actually serves chunks.** ASP.NET's static-file middleware rejects unknown
+  extensions, and `.br` has no registered content type, so every `*.chunk.br` request
+  returned 404. The host now serves unknown extensions as `application/octet-stream`.
+
+### Performance
+
+- Whole-file verification (`verify: true`) hashes the rebuilt file incrementally while
+  it is written instead of re-reading it from disk afterwards — one full I/O pass saved
+  per patched file.
+- Matched-chunk copies reuse pooled buffers; chunk downloads skip a full in-memory copy
+  before decompression.
+
+### Internal
+
+- Build settings centralized in `Directory.Build.props`; NuGet versions managed via
+  Central Package Management (`Directory.Packages.props`).
+- Shared CLI arg parsing moved to `Hina.Core/Cli/Args.cs` (the builder's duplicate
+  parser was removed).
+- `Hina.Host` split into testable units (`HostOptions`, `Routing`, `AccessStats`,
+  `SetupWizard`) with a new `Hina.Host.Tests` suite (25 tests, in-process endpoint
+  tests). Total suite: 539 tests.
+- CI: GitHub Actions bumped to v4 with NuGet package caching.
+
+---
+
 ## v1.4.0 — multi-platform variants, publish wizard, edge-case hardening
 
 ### Per-platform variants (selective download)

--- a/docs/Diagrams.md
+++ b/docs/Diagrams.md
@@ -23,9 +23,10 @@ AppContainer backend exists — see [Windows-Sandbox-Resume.md](Windows-Sandbox-
 
 ## System architecture
 
-The five shipped projects plus two test projects and their references. `Hina.CLI`
+The five shipped projects plus five test projects and their references. `Hina.CLI`
 references both `Hina.PackageManager` (top-level commands) and `Hina.Core` directly
-(the `hina dev` patcher subcommands). `Hina.PackageManager` reuses
+(the `hina dev` patcher subcommands). `Hina.Builder` references `Hina.PackageManager`
+too (descriptor validation in the `init` wizard). `Hina.PackageManager` reuses
 `Hina.Core.PatchClient` for delta downloads — there is no parallel engine.
 
 ```mermaid
@@ -37,20 +38,29 @@ graph LR
     Host["Hina.Host<br/>(ASP.NET static server)"]
     CoreT["Hina.Core.Tests"]
     PMT["Hina.PackageManager.Tests"]
+    CLIT["Hina.CLI.Tests"]
+    BuilderT["Hina.Builder.Tests"]
+    HostT["Hina.Host.Tests"]
 
     CLI --> PM
     CLI --> Core
     PM --> Core
     Builder --> Core
+    Builder --> PM
+    Host --> Core
     PMT --> PM
     PMT --> Core
     CoreT --> Core
-    Host -.->|"serves chunks/manifests"| Core
+    CLIT --> CLI
+    CLIT --> PM
+    BuilderT --> Builder
+    BuilderT --> PM
+    HostT --> Host
 
     classDef ship fill:#dbeafe,stroke:#1e40af,color:#1e3a8a;
     classDef test fill:#f3f4f6,stroke:#9ca3af,color:#374151;
     class CLI,PM,Core,Builder,Host ship;
-    class CoreT,PMT test;
+    class CoreT,PMT,CLIT,BuilderT,HostT test;
 ```
 
 ---

--- a/docs/Troubleshooting.md
+++ b/docs/Troubleshooting.md
@@ -128,12 +128,20 @@ Request failed after 4 attempts: ...
 - The chunks directory was not uploaded to the server, or only partially uploaded.
 - The `baseUrl` does not match the URL structure expected by the chunk path (`chunks/<prefix>/<hash>.chunk.br`).
 - The build output was regenerated but the old chunks were not cleaned up or the new ones were not deployed.
+- The server refuses unknown file extensions. Generic static-file servers (and **Hina.Host
+  versions up to v1.4.0**, fixed since) return 404 for `.chunk.br` because `.br` has no
+  registered content type.
 
 **Solutions:**
 
 - Verify the complete `chunks/` directory was uploaded to the server under the base URL.
 - Check that the two-character hash prefix directories exist (e.g., `chunks/a3/`, `chunks/b1/`).
 - Re-run the build and redeploy all output files.
+- If the manifest downloads fine but **every** chunk 404s while the files exist on disk,
+  configure the server to serve unknown extensions as `application/octet-stream`
+  (nginx: `default_type application/octet-stream;` for the chunks location; IIS: add a
+  `.br` MIME mapping). If you serve with Hina.Host, update it to a version newer than
+  v1.4.0 — older builds had exactly this bug.
 
 ---
 
@@ -345,6 +353,32 @@ hina patch --dir ./game --base https://patch.example.com/
 ```
 
 Or create a `hina.config.json` with `baseUrl` and use `--dir` on the command line.
+
+---
+
+### 14. Patch Fails with "File Is Being Used by Another Process"
+
+**Error:**
+
+```
+System.IO.IOException: The process cannot access the file '<app>/<file>' because it is being used by another process.
+```
+
+**Causes:**
+
+- The app being patched is still running (its executable/data files are locked) — close it and retry.
+- An antivirus or indexer is holding a handle on the file — usually transient, retry.
+- **Hina versions up to v1.4.0** had a bug where patching an existing file that shared
+  chunks with the new version (rsync reuse) kept a read handle open across the final
+  file swap, failing with this error even when nothing else touched the file. Fixed
+  since; update the CLI if you hit this reliably on every delta update.
+
+**Solutions:**
+
+- Make sure the target app is not running while `hina update` runs.
+- Retry — the journal-based rollback leaves the install consistent, so a retry is safe.
+- Update to a Hina build newer than v1.4.0 if the failure reproduces on every update
+  that reuses local chunks.
 
 ---
 


### PR DESCRIPTION
## Summary
Docs catch-up after PRs #19–#22:

- **Architecture.md** — project table now lists all 10 projects (5 shipped + 5 test); notes `Directory.Build.props` / `Directory.Packages.props` centralization; Builder/Host descriptions updated
- **Diagrams.md** — system architecture Mermaid graph: added `Hina.CLI.Tests`, `Hina.Builder.Tests`, `Hina.Host.Tests` and the missing `Builder → PackageManager` edge (true since the v1.4.0 init wizard)
- **Architecture-Review.md** — header note marking it a 2026-05-28 snapshot with a pointer to current state (kept historical numbers intact)
- **Troubleshooting.md** — §4 chunk 404: new cause (unknown `.br` extension; Hina.Host ≤ v1.4.0 bug) with nginx/IIS workarounds; new §14 for the file-in-use sharing violation on delta updates
- **Changelog.md** — new `Unreleased` section (2 fixes, perf, internal)

No code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)