### PR TITLE
fix: post-optimization review findings

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -34,7 +34,7 @@ jobs:
       uses: actions/cache@v4
       with:
         path: ~/.nuget/packages
-        key: nuget-${{ runner.os }}-${{ hashFiles('**/*.csproj') }}
+        key: nuget-${{ runner.os }}-${{ hashFiles('**/*.csproj', 'Directory.Packages.props') }}
         restore-keys: |
           nuget-${{ runner.os }}-
     - name: Restore dependencies
@@ -70,7 +70,7 @@ jobs:
       uses: actions/cache@v4
       with:
         path: ~/.nuget/packages
-        key: nuget-${{ runner.os }}-${{ hashFiles('**/*.csproj') }}
+        key: nuget-${{ runner.os }}-${{ hashFiles('**/*.csproj', 'Directory.Packages.props') }}
         restore-keys: |
           nuget-${{ runner.os }}-
     - name: Restore dependencies
@@ -95,7 +95,7 @@ jobs:
       uses: actions/cache@v4
       with:
         path: ~/.nuget/packages
-        key: nuget-${{ runner.os }}-${{ hashFiles('**/*.csproj') }}
+        key: nuget-${{ runner.os }}-${{ hashFiles('**/*.csproj', 'Directory.Packages.props') }}
         restore-keys: |
           nuget-${{ runner.os }}-
     - name: Restore dependencies

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,7 +21,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: ~/.nuget/packages
-          key: nuget-${{ runner.os }}-${{ hashFiles('**/*.csproj') }}
+          key: nuget-${{ runner.os }}-${{ hashFiles('**/*.csproj', 'Directory.Packages.props') }}
           restore-keys: |
             nuget-${{ runner.os }}-
       - run: dotnet restore
@@ -58,7 +58,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: ~/.nuget/packages
-          key: nuget-${{ runner.os }}-${{ hashFiles('**/*.csproj') }}
+          key: nuget-${{ runner.os }}-${{ hashFiles('**/*.csproj', 'Directory.Packages.props') }}
           restore-keys: |
             nuget-${{ runner.os }}-
 
@@ -263,7 +263,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: ~/.nuget/packages
-          key: nuget-${{ runner.os }}-${{ hashFiles('**/*.csproj') }}
+          key: nuget-${{ runner.os }}-${{ hashFiles('**/*.csproj', 'Directory.Packages.props') }}
           restore-keys: |
             nuget-${{ runner.os }}-
 

--- a/Hina.Core/Net/HttpChunkClient.cs
+++ b/Hina.Core/Net/HttpChunkClient.cs
@@ -113,8 +113,9 @@ namespace Hina.Core.Net
             using CappedReadStream limited = new CappedReadStream(stream, compressedCap);
             // Pre-size from Content-Length when the server provides one (EnsureWithinCap already
             // rejected anything above the cap), and read the backing buffer directly instead of
-            // ToArray() — skips one full copy of every chunk.
-            int capacity = response.Content.Headers.ContentLength is long cl && cl > 0 ? (int)cl : 0;
+            // ToArray() — skips one full copy of every chunk. The int.MaxValue guard keeps a
+            // hostile header that passed the cap from overflowing the cast.
+            int capacity = response.Content.Headers.ContentLength is long cl && cl > 0 && cl <= int.MaxValue ? (int)cl : 0;
             using MemoryStream buffer = new MemoryStream(capacity);
             await limited.CopyToAsync(buffer, ct);
             return DecompressAndVerify(buffer.GetBuffer(), (int)buffer.Length, hashOnly, maxBytes);

--- a/Hina.Host.Tests/HostEndpointsTests.cs
+++ b/Hina.Host.Tests/HostEndpointsTests.cs
@@ -17,6 +17,7 @@ namespace Hina.Host.Tests
             Directory.CreateDirectory(Path.Combine(_root, "chunks", "ab"));
             File.WriteAllText(Path.Combine(_root, "manifest.json"), """{ "version": "1.0.0" }""");
             File.WriteAllBytes(Path.Combine(_root, "chunks", "ab", "abcd.chunk.br"), new byte[] { 1, 2, 3 });
+            File.WriteAllText(Path.Combine(_root, "signing.key"), "not-a-real-key");
 
             _factory = new WebApplicationFactory<Program>()
                 .WithWebHostBuilder(b => b.UseSetting("Patcher:Root", _root));
@@ -66,6 +67,16 @@ namespace Hina.Host.Tests
             Assert.Equal(HttpStatusCode.OK, resp.StatusCode);
             string cache = resp.Headers.TryGetValues("Cache-Control", out var v) ? string.Join(",", v) : "";
             Assert.Contains("immutable", cache);
+        }
+
+        [Fact]
+        public async Task UnknownExtension_IsNotServed()
+        {
+            // Only the content types a patch root legitimately contains (.json, .br) are
+            // served. A stray secret (.key/.pem) in the root must keep returning 404.
+            using var client = _factory.CreateClient();
+            var resp = await client.GetAsync("/signing.key");
+            Assert.Equal(HttpStatusCode.NotFound, resp.StatusCode);
         }
 
         [Fact]

--- a/Hina.Host/Program.cs
+++ b/Hina.Host/Program.cs
@@ -184,6 +184,12 @@ if (options.Apps.Count > 0)
     });
 }
 
+// ".chunk.br" must be served: the default content-type provider has no ".br" mapping, so
+// without this every chunk request 404s. Map just ".br" instead of ServeUnknownFileTypes —
+// a stray secret (.key/.pem) accidentally left in a patch root stays unserved.
+var chunkContentTypes = new Microsoft.AspNetCore.StaticFiles.FileExtensionContentTypeProvider();
+chunkContentTypes.Mappings[".br"] = "application/octet-stream";
+
 foreach (var m in mounts)
 {
     var fp = new PhysicalFileProvider(m.Path);
@@ -191,11 +197,7 @@ foreach (var m in mounts)
     var staticOpts = new StaticFileOptions
     {
         FileProvider = fp,
-        // ".chunk.br" (and any other unmapped extension in a patch root) must be served:
-        // the default content-type provider has no ".br" mapping, so without this every
-        // chunk request 404s.
-        ServeUnknownFileTypes = true,
-        DefaultContentType = "application/octet-stream",
+        ContentTypeProvider = chunkContentTypes,
         OnPrepareResponse = ctx =>
         {
             string? p = ctx.Context.Request.Path.Value;

--- a/docs/Changelog.md
+++ b/docs/Changelog.md
@@ -14,7 +14,8 @@ All notable changes to Hina are documented in this file.
   "file is being used by another process". The handle is now released before the swap.
 - **Hina.Host actually serves chunks.** ASP.NET's static-file middleware rejects unknown
   extensions, and `.br` has no registered content type, so every `*.chunk.br` request
-  returned 404. The host now serves unknown extensions as `application/octet-stream`.
+  returned 404. The host now maps `.br` to `application/octet-stream`; other unknown
+  extensions (e.g. a stray `.key` left in a patch root) remain unserved.
 
 ### Performance
 


### PR DESCRIPTION
## Summary
Regression review of today's PRs (#19–#23) found three issues, all fixed here:

1. **Host static-file surface widened too much** (from #22): `ServeUnknownFileTypes=true` made *any* extension in a patch root downloadable — including an accidentally-placed `.key`/`.pem`. Replaced with an explicit `.br → application/octet-stream` content-type mapping: chunks serve, everything else unknown stays 404 (pre-#22 behavior). New test `UnknownExtension_IsNotServed` locks it (written red-first).
2. **Content-Length cast overflow** (from #21): a hostile header > `int.MaxValue` that still fits under the compressed cap would overflow the `(int)` cast in `HttpChunkClient`. Guarded.
3. **Stale NuGet cache key** (from #19+#20 interaction): with Central Package Management, version bumps edit `Directory.Packages.props`, not csproj — but the cache key only hashed csproj files. Key now includes the props file.

Also verified clean (no action): csproj property migration lossless, Args semantics identical to v1.4.0, Builder call-sites fully migrated, Host wiring semantically equivalent, new tests not flaky (no CWD writes, GUID temp dirs, TestServer).

## Tests
540 green (539 + 1 new).

🤖 Generated with [Claude Code](https://claude.com/claude-code)