### PR TITLE
release: v1.4.1

### DIFF
--- a/Hina.PackageManager/Install/HinaVersion.cs
+++ b/Hina.PackageManager/Install/HinaVersion.cs
@@ -12,7 +12,7 @@ namespace Hina.PackageManager.Install
         // Single source of truth for the running version. The release tag MUST equal
         // "v" + this value (release.yml verifies it), so `hina version`, `hina check-update`,
         // and the published GitHub tag never drift.
-        public const string Current = "1.4.0";
+        public const string Current = "1.4.1";
 
         // True if running version >= required minimum. Both sides parsed as SemVer
         // major.minor.patch; pre-release / build-metadata suffix is tolerated but

--- a/docs/Changelog.md
+++ b/docs/Changelog.md
@@ -4,7 +4,7 @@ All notable changes to Hina are documented in this file.
 
 ---
 
-## Unreleased
+## v1.4.1 — delta-update and chunk-serving fixes, patch-path performance
 
 ### Fixed
 
@@ -33,7 +33,7 @@ All notable changes to Hina are documented in this file.
   parser was removed).
 - `Hina.Host` split into testable units (`HostOptions`, `Routing`, `AccessStats`,
   `SetupWizard`) with a new `Hina.Host.Tests` suite (25 tests, in-process endpoint
-  tests). Total suite: 539 tests.
+  tests). Total suite: 540 tests.
 - CI: GitHub Actions bumped to v4 with NuGet package caching.
 
 ---


### PR DESCRIPTION
## Summary
Version bump 1.4.0 → 1.4.1 and changelog finalization (`Unreleased` → `v1.4.1`).

### Highlights (see Changelog)
- **Fixed:** delta updates of existing files failed with a sharing violation when rsync reused local chunks; Hina.Host returned 404 for every `*.chunk.br` (now mapped to `application/octet-stream`; other unknown extensions stay unserved)
- **Performance:** verify hashes during rebuild (no re-read pass), pooled buffers, one less copy per chunk download
- **Internal:** Directory.Build.props + Central Package Management, shared arg parsing in Hina.Core, Hina.Host split + 26-test suite, CI v4 + NuGet caching

540 tests green.

After merge: `git tag v1.4.1 && git push origin v1.4.1` triggers the release pipeline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)