### PR TITLE
fix: bug hunt round 7 — eight user-triggerable failures hardened

### DIFF
--- a/.claude/scheduled_tasks.lock
+++ b/.claude/scheduled_tasks.lock
@@ -1,1 +1,1 @@
-{"sessionId":"6364bd6e-4d1a-41dd-abcc-0f3b3a6c54ef","pid":92183,"procStart":"Mon Jun  8 15:21:55 2026","acquiredAt":1780934428533}
+{"sessionId":"c31342aa-66f9-4d4a-a363-ca3c799fe98b","pid":86386,"procStart":"Tue Jun  9 21:05:31 2026","acquiredAt":1781047462860}

--- a/Hina.Builder.Tests/BuildCommandTests.cs
+++ b/Hina.Builder.Tests/BuildCommandTests.cs
@@ -36,6 +36,36 @@ namespace Hina.Builder.Tests
             Platform = platform
         };
 
+        // A typo'd chunk parameter ('--chunk 0', min > max…) used to escape as an unhandled
+        // ArgumentOutOfRangeException with a stack trace — the builder has no top-level
+        // catch. It must be a clean usage error (exit 2) instead.
+        [Theory]
+        [InlineData("fixed", 0, 2048, 65536, 8192)]
+        [InlineData("fixed", -5, 2048, 65536, 8192)]
+        [InlineData("cdc", 65536, 0, 65536, 8192)]
+        [InlineData("cdc", 65536, 2048, 65536, 0)]
+        [InlineData("cdc", 65536, 65536, 2048, 8192)]
+        public async Task Build_InvalidChunkParams_FailsWithUsageError(string mode, int chunk, int min, int max, int avg)
+        {
+            File.WriteAllText(Path.Combine(_input, "game"), "payload");
+            var opts = new BuildOptions
+            {
+                Input = _input,
+                Output = _out,
+                BaseUrl = "https://patch.example.com/",
+                Version = "1.0.0",
+                ChunkingMode = mode,
+                ChunkSize = chunk,
+                MinChunk = min,
+                MaxChunk = max,
+                AvgChunk = avg
+            };
+
+            int code = await BuildCommand.RunAsync(opts, NullLogger.Instance, CancellationToken.None);
+
+            Assert.Equal(2, code);
+        }
+
         [Fact]
         public async Task Build_WithPlatform_WritesPlatformManifest()
         {

--- a/Hina.Builder/BuildCommand.cs
+++ b/Hina.Builder/BuildCommand.cs
@@ -58,6 +58,23 @@ namespace Hina.Builder
                 return 2;
             }
 
+            // Chunk parameters are publisher input (--chunk / --min-chunk / --max-chunk /
+            // --avg-chunk); a typo'd value must be a usage error, not an unhandled
+            // ArgumentOutOfRangeException from the chunker constructors.
+            if (options.ChunkSize <= 0)
+            {
+                logger.LogError("--chunk must be a positive number of bytes (got {Chunk}).", options.ChunkSize);
+                return 2;
+            }
+            if (string.Equals(options.ChunkingMode, "cdc", StringComparison.OrdinalIgnoreCase) &&
+                (options.MinChunk <= 0 || options.AvgChunk <= 0 || options.MaxChunk <= 0 ||
+                 options.MinChunk > options.AvgChunk || options.AvgChunk > options.MaxChunk))
+            {
+                logger.LogError("CDC chunk sizes must be positive and ordered min <= avg <= max (got min={Min}, avg={Avg}, max={Max}).",
+                    options.MinChunk, options.AvgChunk, options.MaxChunk);
+                return 2;
+            }
+
             string manifestName = "manifest.json";
             if (!string.IsNullOrEmpty(options.Platform))
             {

--- a/Hina.Builder/Program.cs
+++ b/Hina.Builder/Program.cs
@@ -27,24 +27,40 @@ namespace Hina.Builder
 
             ILogger logger = loggerFactory.CreateLogger("Hina.Builder");
 
-            string command = args[0].ToLowerInvariant();
-            switch (command)
+            // Top-level safety net, mirroring Hina.CLI's CommandRouter: anything a command
+            // throws (bad input reaching a constructor guard, unexpected IO) exits with a
+            // clean message instead of an unhandled stack trace.
+            try
             {
-                case "build":
-                    return await BuildCommand.RunAsync(BuildOptions.FromArgs(args), logger, CancellationToken.None);
-                case "keygen":
-                    return KeygenCommand.Run(args, logger);
-                case "init":
-                    if (Console.IsInputRedirected)
-                    {
-                        logger.LogError("`init` is interactive and needs a terminal. In CI, use `build` + `hina dev sign-descriptor` instead.");
+                string command = args[0].ToLowerInvariant();
+                switch (command)
+                {
+                    case "build":
+                        return await BuildCommand.RunAsync(BuildOptions.FromArgs(args), logger, CancellationToken.None);
+                    case "keygen":
+                        return KeygenCommand.Run(args, logger);
+                    case "init":
+                        if (Console.IsInputRedirected)
+                        {
+                            logger.LogError("`init` is interactive and needs a terminal. In CI, use `build` + `hina dev sign-descriptor` instead.");
+                            return 2;
+                        }
+                        return await InitCommand.RunAsync(args, new ConsolePrompt(), logger, CancellationToken.None);
+                    default:
+                        logger.LogError("Unknown command: {Command}", command);
+                        PrintHelp();
                         return 2;
-                    }
-                    return await InitCommand.RunAsync(args, new ConsolePrompt(), logger, CancellationToken.None);
-                default:
-                    logger.LogError("Unknown command: {Command}", command);
-                    PrintHelp();
-                    return 2;
+                }
+            }
+            catch (OperationCanceledException)
+            {
+                logger.LogError("Cancelled.");
+                return 1;
+            }
+            catch (Exception ex)
+            {
+                logger.LogError("{Message}", ex.Message);
+                return 2;
             }
         }
 

--- a/Hina.Core.Tests/HttpChunkClientHashTests.cs
+++ b/Hina.Core.Tests/HttpChunkClientHashTests.cs
@@ -1,0 +1,36 @@
+using System;
+using System.IO;
+using System.Net;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+using Hina.Core.Net;
+using Xunit;
+
+namespace Hina.Core.Tests
+{
+    // A hostile or corrupt (unsigned) manifest can carry a chunk strong hash shorter than
+    // the two characters the bucket path needs. That must surface as a clean manifest
+    // error, not an ArgumentOutOfRangeException from Substring.
+    public class HttpChunkClientHashTests
+    {
+        [Theory]
+        [InlineData("")]
+        [InlineData("a")]
+        [InlineData("sha256:")]
+        [InlineData("sha256:f")]
+        public async Task GetChunkAsync_TruncatedStrongHash_ThrowsInvalidData(string strong)
+        {
+            var client = new HttpChunkClient(new HttpClient(new NotFoundHandler()));
+
+            await Assert.ThrowsAsync<InvalidDataException>(
+                () => client.GetChunkAsync(new Uri("http://test.local/"), strong, CancellationToken.None));
+        }
+
+        private sealed class NotFoundHandler : HttpMessageHandler
+        {
+            protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken ct)
+                => Task.FromResult(new HttpResponseMessage(HttpStatusCode.NotFound));
+        }
+    }
+}

--- a/Hina.Core.Tests/PatchJournalCorruptionTests.cs
+++ b/Hina.Core.Tests/PatchJournalCorruptionTests.cs
@@ -1,0 +1,89 @@
+using System;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using Hina.Core.Configuration;
+using Hina.Core.Patching;
+using Xunit;
+
+namespace Hina.Core.Tests
+{
+    // A corrupt journal (interrupted save, disk full, manual edit) must surface an
+    // actionable error naming the journal file — not a raw JsonException. Without this,
+    // every subsequent patch fails forever with a cryptic parser message and the user
+    // has no way to know that deleting .hina/journal.json is the way out.
+    public class PatchJournalCorruptionTests : IDisposable
+    {
+        private readonly string _tempRoot;
+
+        public PatchJournalCorruptionTests()
+        {
+            _tempRoot = Path.Combine(Path.GetTempPath(), "hina_journal_" + Guid.NewGuid().ToString("N"));
+            Directory.CreateDirectory(_tempRoot);
+        }
+
+        public void Dispose()
+        {
+            try { Directory.Delete(_tempRoot, recursive: true); } catch { /* best effort */ }
+        }
+
+        private string WriteCorruptJournal(string content)
+        {
+            string path = PatchJournal.GetJournalPath(_tempRoot);
+            Directory.CreateDirectory(Path.GetDirectoryName(path)!);
+            File.WriteAllText(path, content);
+            return path;
+        }
+
+        [Theory]
+        [InlineData("{ truncated")]
+        [InlineData("not json at all")]
+        [InlineData("")]
+        [InlineData("null")]
+        public void Load_CorruptJournal_ThrowsActionableError(string content)
+        {
+            string path = WriteCorruptJournal(content);
+
+            var ex = Assert.Throws<InvalidDataException>(() => PatchJournal.Load(path));
+
+            // The message must name the file and hint at recovery, so the user can act.
+            Assert.Contains(path, ex.Message);
+            Assert.Contains("corrupt", ex.Message, StringComparison.OrdinalIgnoreCase);
+        }
+
+        [Fact]
+        public void Load_MissingJournal_ReturnsNull()
+        {
+            Assert.Null(PatchJournal.Load(PatchJournal.GetJournalPath(_tempRoot)));
+        }
+
+        [Fact]
+        public async Task Load_ValidJournal_RoundTrips()
+        {
+            var journal = new PatchJournal();
+            journal.Entries.Add(new PatchJournalEntry { TargetPath = "a", BackupPath = "b" });
+            string path = PatchJournal.GetJournalPath(_tempRoot);
+            await journal.SaveAsync(path);
+
+            PatchJournal? loaded = PatchJournal.Load(path);
+
+            Assert.NotNull(loaded);
+            Assert.Single(loaded!.Entries);
+        }
+
+        [Fact]
+        public async Task RollbackAsync_CorruptJournal_ThrowsActionableError()
+        {
+            string path = WriteCorruptJournal("{ broken");
+            var client = new PatchClient(new PatcherConfig
+            {
+                BaseUrl = new Uri("http://test.local/"),
+                Channel = "stable"
+            });
+
+            var ex = await Assert.ThrowsAsync<InvalidDataException>(
+                () => client.RollbackAsync(_tempRoot, CancellationToken.None));
+            Assert.Contains(path, ex.Message);
+        }
+    }
+}

--- a/Hina.Core.Tests/PatcherConfigTests.cs
+++ b/Hina.Core.Tests/PatcherConfigTests.cs
@@ -106,6 +106,29 @@ namespace Hina.Core.Tests
             Assert.ThrowsAny<Exception>(() => PatcherConfigLoader.Load("/nonexistent/path/config.json"));
         }
 
+        // A hand-edited config with a typo must name the offending file — `hina dev` can be
+        // reading either an explicit --config or an implicit ./hina.config.json, and a raw
+        // JsonException doesn't say which one is broken.
+        [Theory]
+        [InlineData("{ truncated")]
+        [InlineData("not json")]
+        public void PatcherConfigLoader_Load_CorruptJson_ThrowsActionableError(string content)
+        {
+            string tempDir = CreateTempDir();
+            try
+            {
+                string configPath = Path.Combine(tempDir, "hina.config.json");
+                File.WriteAllText(configPath, content);
+
+                var ex = Assert.Throws<InvalidDataException>(() => PatcherConfigLoader.Load(configPath));
+                Assert.Contains(configPath, ex.Message);
+            }
+            finally
+            {
+                Directory.Delete(tempDir, recursive: true);
+            }
+        }
+
         private static string CreateTempDir()
         {
             string path = Path.Combine(Path.GetTempPath(), "hina-tests-" + Guid.NewGuid().ToString("N"));

--- a/Hina.Core/Configuration/PatcherConfigLoader.cs
+++ b/Hina.Core/Configuration/PatcherConfigLoader.cs
@@ -10,8 +10,18 @@ namespace Hina.Core.Configuration
         public static PatcherConfig Load(string path)
         {
             string json = File.ReadAllText(path);
-            PatcherConfig? config = JsonSerializer.Deserialize(json, HinaCoreJsonContext.Default.PatcherConfig);
-            return config ?? new PatcherConfig();
+            try
+            {
+                PatcherConfig? config = JsonSerializer.Deserialize(json, HinaCoreJsonContext.Default.PatcherConfig);
+                return config ?? new PatcherConfig();
+            }
+            catch (JsonException ex)
+            {
+                // Name the file: the caller may be reading an explicit --config or the
+                // implicit ./hina.config.json — a raw parser error doesn't say which.
+                throw new InvalidDataException(
+                    $"Config file '{path}' is not valid JSON: {ex.Message}", ex);
+            }
         }
     }
 }

--- a/Hina.Core/Net/HttpChunkClient.cs
+++ b/Hina.Core/Net/HttpChunkClient.cs
@@ -79,8 +79,14 @@ namespace Hina.Core.Net
 
         public async Task<byte[]> GetChunkAsync(Uri baseUrl, string strongHash, CancellationToken ct, int expectedSize = 0)
         {
-            // Chunk URL uses a two-character bucket based on hash prefix.
+            // Chunk URL uses a two-character bucket based on hash prefix. A hostile/corrupt
+            // manifest can carry a hash shorter than that; fail as a manifest error instead
+            // of an ArgumentOutOfRangeException from Substring.
             string hashOnly = HashOnly(strongHash);
+            if (hashOnly.Length < 2)
+            {
+                throw new InvalidDataException($"Manifest contains an invalid chunk strong hash '{strongHash}'.");
+            }
             string bucket = hashOnly.Substring(0, 2);
             string relative = $"chunks/{bucket}/{hashOnly}.chunk.br";
             Uri chunkUrl = new Uri(baseUrl, relative);

--- a/Hina.Core/Patching/PatchJournal.cs
+++ b/Hina.Core/Patching/PatchJournal.cs
@@ -25,8 +25,26 @@ namespace Hina.Core.Patching
             {
                 return null;
             }
-            string json = File.ReadAllText(path);
-            return JsonSerializer.Deserialize(json, HinaCoreJsonContext.Default.PatchJournal);
+            try
+            {
+                string json = File.ReadAllText(path);
+                PatchJournal? journal = JsonSerializer.Deserialize(json, HinaCoreJsonContext.Default.PatchJournal);
+                if (journal == null)
+                {
+                    throw new JsonException("Journal deserialized to null.");
+                }
+                return journal;
+            }
+            catch (JsonException ex)
+            {
+                // A corrupt journal (interrupted save, full disk) would otherwise make every
+                // future patch fail with a raw parser error and no recovery hint — and the
+                // user has no way to know the journal file is the blocker.
+                throw new InvalidDataException(
+                    $"Patch journal at '{path}' is corrupt (likely an interrupted save). " +
+                    "Backups (*.hina.bak) may still exist next to the patched files; restore them " +
+                    "manually if needed, then delete the journal file to let patching continue.", ex);
+            }
         }
 
         public async Task SaveAsync(string path)

--- a/Hina.Host.Tests/AccessStatsBoundsTests.cs
+++ b/Hina.Host.Tests/AccessStatsBoundsTests.cs
@@ -1,0 +1,51 @@
+namespace Hina.Host.Tests
+{
+    // A public host gets scanned: every probe brings a fresh path and many bring fresh IPs.
+    // The per-path and per-(ip|app) tracking tables must stop growing at a cap instead of
+    // accumulating for the lifetime of the process (slow memory exhaustion).
+    public class AccessStatsBoundsTests
+    {
+        [Fact]
+        public void RecordRequest_UniquePathFlood_PathTableIsBounded()
+        {
+            var stats = new AccessStats();
+            for (int i = 0; i < AccessStats.MaxTrackedPaths + 500; i++)
+            {
+                stats.RecordRequest("1.2.3.4", "default", $"/probe/{i}");
+            }
+
+            Assert.True(stats.TrackedPathCount <= AccessStats.MaxTrackedPaths,
+                $"paths grew to {stats.TrackedPathCount}");
+            // The total counter must keep counting even past the cap.
+            Assert.Equal(AccessStats.MaxTrackedPaths + 500, stats.Snapshot().TotalRequests);
+        }
+
+        [Fact]
+        public void RecordRequest_UniqueIpFlood_KeyTableIsBounded()
+        {
+            var stats = new AccessStats();
+            for (int i = 0; i < AccessStats.MaxTrackedKeys + 500; i++)
+            {
+                stats.RecordRequest($"10.0.{i / 256}.{i % 256}-{i}", "default", "/manifest.json");
+            }
+
+            Assert.True(stats.TrackedKeyCount <= AccessStats.MaxTrackedKeys,
+                $"keys grew to {stats.TrackedKeyCount}");
+        }
+
+        [Fact]
+        public void RecordRequest_KnownPathPastCap_StillCounted()
+        {
+            var stats = new AccessStats();
+            stats.RecordRequest("1.2.3.4", "default", "/manifest.json");
+            for (int i = 0; i < AccessStats.MaxTrackedPaths + 10; i++)
+            {
+                stats.RecordRequest("1.2.3.4", "default", $"/probe/{i}");
+            }
+
+            // A path tracked before the cap keeps updating after it.
+            stats.RecordRequest("1.2.3.4", "default", "/manifest.json");
+            Assert.Equal("/manifest.json", stats.Snapshot().TopPath);
+        }
+    }
+}

--- a/Hina.Host.Tests/SetupWizardTests.cs
+++ b/Hina.Host.Tests/SetupWizardTests.cs
@@ -17,6 +17,24 @@ namespace Hina.Host.Tests
 
         private string PathFor(string name) => Path.Combine(_tempDir, name);
 
+        // A port typo accepted by the wizard gets persisted into hina.host.json and then
+        // crashes the host on every start — and the wizard won't re-run because the config
+        // is non-empty. The wizard must reject invalid ports up front.
+        [Theory]
+        [InlineData("49876", true)]
+        [InlineData("1", true)]
+        [InlineData("65535", true)]
+        [InlineData("0", false)]
+        [InlineData("65536", false)]
+        [InlineData("-1", false)]
+        [InlineData("8o80", false)]
+        [InlineData("", false)]
+        [InlineData("8080 ", true)]
+        public void IsValidPort_Cases(string value, bool expected)
+        {
+            Assert.Equal(expected, SetupWizard.IsValidPort(value));
+        }
+
         [Fact]
         public void IsConfigMissingOrEmpty_MissingFile_True()
         {

--- a/Hina.Host/AccessStats.cs
+++ b/Hina.Host/AccessStats.cs
@@ -6,6 +6,15 @@ namespace Hina.Host
     // log, and abuse warnings.
     internal sealed class AccessStats
     {
+        // Caps on the tracking tables: a scanned/abused public host would otherwise grow an
+        // entry per unique probe path and per (ip,app) for the process lifetime — a slow
+        // memory exhaustion. Past the cap, NEW keys are no longer tracked individually
+        // (totals still count and rate limiting is unaffected); existing keys keep updating.
+        // The check-then-add is not atomic, so the cap can overshoot by a few entries under
+        // concurrency — it bounds growth, it is not an exact limit.
+        internal const int MaxTrackedPaths = 10_000;
+        internal const int MaxTrackedKeys = 50_000;
+
         readonly ConcurrentDictionary<string, IpBucket> _keys = new(); // key = ip|app
         readonly ConcurrentDictionary<string, long> _paths = new();
         readonly ConcurrentDictionary<string, long> _apps = new();
@@ -13,21 +22,44 @@ namespace Hina.Host
         long _total;
         long _rejections;
 
+        internal int TrackedPathCount => _paths.Count;
+        internal int TrackedKeyCount => _keys.Count;
+
         public void RecordRequest(string ip, string appName, string path)
         {
             Interlocked.Increment(ref _total);
-            _paths.AddOrUpdate(path, 1, (_, v) => v + 1);
+            if (_paths.ContainsKey(path) || _paths.Count < MaxTrackedPaths)
+            {
+                _paths.AddOrUpdate(path, 1, (_, v) => v + 1);
+            }
+            // App names come from Routing.ExtractApp (configured apps, "default", "unknown"),
+            // so _apps and _appRejections are naturally bounded.
             _apps.AddOrUpdate(appName, 1, (_, v) => v + 1);
-            var bucket = _keys.GetOrAdd($"{ip}|{appName}", _ => new IpBucket());
-            bucket.Hit();
+            string key = $"{ip}|{appName}";
+            if (_keys.TryGetValue(key, out var bucket))
+            {
+                bucket.Hit();
+            }
+            else if (_keys.Count < MaxTrackedKeys)
+            {
+                _keys.GetOrAdd(key, _ => new IpBucket()).Hit();
+            }
         }
 
         public void RecordRejection(string ip, string appName)
         {
             Interlocked.Increment(ref _rejections);
             _appRejections.AddOrUpdate(appName, 1, (_, v) => v + 1);
-            var bucket = _keys.GetOrAdd($"{ip}|{appName}", _ => new IpBucket());
-            Interlocked.Increment(ref bucket.Rejections);
+            string key = $"{ip}|{appName}";
+            if (_keys.TryGetValue(key, out var bucket))
+            {
+                Interlocked.Increment(ref bucket.Rejections);
+            }
+            else if (_keys.Count < MaxTrackedKeys)
+            {
+                bucket = _keys.GetOrAdd(key, _ => new IpBucket());
+                Interlocked.Increment(ref bucket.Rejections);
+            }
         }
 
         public bool ShouldLogAbuse(string ip, string appName, int threshold, out long count)

--- a/Hina.Host/SetupWizard.cs
+++ b/Hina.Host/SetupWizard.cs
@@ -41,7 +41,7 @@ namespace Hina.Host
                 Console.WriteLine($"Config '{outPath}' looks empty. Let's populate it.");
             }
 
-            string port = Ask("Listen port (default 49876 is in the dynamic/private range)", "49876");
+            string port = AskPort("Listen port (default 49876 is in the dynamic/private range)", "49876");
             string bindAll = Ask("Bind on all interfaces (0.0.0.0)? [Y/n]", "y").Trim().ToLowerInvariant();
             string host = bindAll is "" or "y" or "yes" ? "0.0.0.0" : "127.0.0.1";
             string urls = $"http://{host}:{port}";
@@ -92,6 +92,21 @@ namespace Hina.Host
             Console.WriteLine("=== Setup complete. Starting host... ===");
             Console.WriteLine();
             return true;
+        }
+
+        // A typo'd port would be persisted into hina.host.json and crash the host on every
+        // start — and the wizard won't re-run over a non-empty config. Reject it up front.
+        internal static bool IsValidPort(string value)
+            => int.TryParse(value.Trim(), out int p) && p >= 1 && p <= 65535;
+
+        static string AskPort(string prompt, string def)
+        {
+            while (true)
+            {
+                string value = Ask(prompt, def).Trim();
+                if (IsValidPort(value)) return value;
+                Console.WriteLine($"  '{value}' is not a valid port (1-65535). Try again, or press Enter for {def}.");
+            }
         }
 
         static string Ask(string prompt, string def)

--- a/Hina.PackageManager.Tests/DescriptorParserCorruptTests.cs
+++ b/Hina.PackageManager.Tests/DescriptorParserCorruptTests.cs
@@ -1,0 +1,44 @@
+using System.IO;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Hina.PackageManager.Descriptor;
+using Xunit;
+
+namespace Hina.PackageManager.Tests
+{
+    // `hina install <url>` pointing at something that isn't a descriptor (a web page, a
+    // captive portal, a bucket listing) must fail with "not a valid Hina app descriptor",
+    // not a raw JsonException ("'<' is an invalid start of a value...").
+    public class DescriptorParserCorruptTests
+    {
+        [Theory]
+        [InlineData("<html><body>It works!</body></html>")]
+        [InlineData("not json")]
+        [InlineData("")]
+        [InlineData("null")]
+        public void Parse_NonDescriptorContent_ThrowsActionableError(string content)
+        {
+            var ex = Assert.Throws<InvalidDataException>(() => DescriptorParser.Parse(content));
+            Assert.Contains("descriptor", ex.Message, System.StringComparison.OrdinalIgnoreCase);
+        }
+
+        [Theory]
+        [InlineData("<html><body>It works!</body></html>")]
+        [InlineData("not json")]
+        public async Task ReadAsync_NonDescriptorContent_ThrowsActionableError(string content)
+        {
+            using var stream = new MemoryStream(Encoding.UTF8.GetBytes(content));
+            var ex = await Assert.ThrowsAsync<InvalidDataException>(
+                () => DescriptorParser.ReadAsync(stream, CancellationToken.None));
+            Assert.Contains("descriptor", ex.Message, System.StringComparison.OrdinalIgnoreCase);
+        }
+
+        [Fact]
+        public void Parse_ValidDescriptor_StillParses()
+        {
+            AppDescriptor d = DescriptorParser.Parse("""{ "name": "demo", "version": "1.0.0" }""");
+            Assert.Equal("demo", d.Name);
+        }
+    }
+}

--- a/Hina.PackageManager.Tests/UpdateServiceTests.cs
+++ b/Hina.PackageManager.Tests/UpdateServiceTests.cs
@@ -301,6 +301,40 @@ namespace Hina.PackageManager.Tests
             Assert.Equal("1.0.0", final.Apps["demo"].InstalledVersion); // demo rolled back to v1
         }
 
+        [Fact]
+        public async Task UpdateAll_OneInvalidDescriptor_DoesNotAbortTheRun()
+        {
+            await InstallV1("alpha");
+            await InstallV1("beta");
+
+            // alpha's publisher now serves a descriptor that FAILS validation (rooted exec).
+            // EnsureValid throwing out of UpdateAsync used to fault its task and abort the
+            // whole UpdateAllAsync run, discarding beta's (successful) result.
+            AppDescriptor bad = BuildDescriptor(_pubKey, name: "alpha", version: "1.1.0");
+            bad.Exec = new ExecMap { Windows = "C:\\abs\\demo.exe", Linux = "/abs/demo", Macos = "/abs/demo" };
+            DescriptorSigner.AttachSignature(bad, Convert.FromBase64String(_privKey));
+
+            AppDescriptor good = BuildDescriptor(_pubKey, name: "beta", version: "1.1.0");
+            DescriptorSigner.AttachSignature(good, Convert.FromBase64String(_privKey));
+
+            UpdateService svc = new UpdateService(
+                _paths,
+                _platform,
+                fetcher: new RoutingFetcher(url => url.AbsoluteUri.Contains("alpha") ? bad : good),
+                patchClientFactory: cfg => new FakePatchClient(cfg, NewExecFiles()));
+
+            List<UpdateResult> results = await svc.UpdateAllAsync(null, CancellationToken.None);
+
+            Assert.Equal(2, results.Count);
+            UpdateResult? alpha = results.Find(r => r?.Name == "alpha");
+            UpdateResult? beta = results.Find(r => r?.Name == "beta");
+            Assert.NotNull(alpha);
+            Assert.NotNull(beta);
+            Assert.Equal(UpdateStatus.Failed, alpha!.Status);
+            Assert.False(string.IsNullOrWhiteSpace(alpha.Message));
+            Assert.Equal(UpdateStatus.Updated, beta!.Status);
+        }
+
         // Performs a clean v1 install via the real InstallService so the registry has a
         // realistic starting state with hooks + shell entries the update can diff against.
         private async Task InstallV1(string name = "demo")
@@ -413,6 +447,14 @@ namespace Hina.PackageManager.Tests
         {
             [ExecRelative()] = new byte[] { 1, 2, 3 }
         };
+    }
+
+    // Routes each descriptor URL to its own stub descriptor (multi-app update tests).
+    internal sealed class RoutingFetcher : DescriptorFetcher
+    {
+        private readonly Func<Uri, AppDescriptor> _route;
+        public RoutingFetcher(Func<Uri, AppDescriptor> route) { _route = route; }
+        public override Task<AppDescriptor> FetchAsync(Uri url, CancellationToken ct) => Task.FromResult(_route(url));
     }
 
     // Runs a side-effect (simulating a concurrent registry writer) then reports patch failure.

--- a/Hina.PackageManager/Descriptor/DescriptorParser.cs
+++ b/Hina.PackageManager/Descriptor/DescriptorParser.cs
@@ -12,12 +12,22 @@ namespace Hina.PackageManager.Descriptor
     {
         public static AppDescriptor Parse(string json)
         {
-            AppDescriptor? descriptor = JsonSerializer.Deserialize(json, PackageManagerJsonContext.Default.AppDescriptor);
-            if (descriptor == null)
+            try
             {
-                throw new InvalidDataException("Descriptor JSON parsed to null.");
+                AppDescriptor? descriptor = JsonSerializer.Deserialize(json, PackageManagerJsonContext.Default.AppDescriptor);
+                if (descriptor == null)
+                {
+                    throw new InvalidDataException("Descriptor JSON parsed to null; this is not a valid Hina app descriptor.");
+                }
+                return descriptor;
             }
-            return descriptor;
+            catch (JsonException ex)
+            {
+                // The most common way here is a URL that serves a web page / captive portal /
+                // bucket listing instead of hina.app.json. Surface that, not parser internals.
+                throw new InvalidDataException(
+                    $"Content is not a valid Hina app descriptor (hina.app.json): {ex.Message}", ex);
+            }
         }
 
         public static AppDescriptor Parse(byte[] utf8Json)
@@ -27,12 +37,20 @@ namespace Hina.PackageManager.Descriptor
 
         public static async Task<AppDescriptor> ReadAsync(Stream stream, CancellationToken ct)
         {
-            AppDescriptor? descriptor = await JsonSerializer.DeserializeAsync(stream, PackageManagerJsonContext.Default.AppDescriptor, ct);
-            if (descriptor == null)
+            try
             {
-                throw new InvalidDataException("Descriptor JSON parsed to null.");
+                AppDescriptor? descriptor = await JsonSerializer.DeserializeAsync(stream, PackageManagerJsonContext.Default.AppDescriptor, ct);
+                if (descriptor == null)
+                {
+                    throw new InvalidDataException("Descriptor JSON parsed to null; this is not a valid Hina app descriptor.");
+                }
+                return descriptor;
             }
-            return descriptor;
+            catch (JsonException ex)
+            {
+                throw new InvalidDataException(
+                    $"Content is not a valid Hina app descriptor (hina.app.json): {ex.Message}", ex);
+            }
         }
 
         public static string Serialize(AppDescriptor descriptor, bool indented = true)

--- a/Hina.PackageManager/Install/UpdateService.cs
+++ b/Hina.PackageManager/Install/UpdateService.cs
@@ -486,6 +486,16 @@ namespace Hina.PackageManager.Install
                     {
                         results[idx] = await UpdateAsync(names[idx], options, ct);
                     }
+                    catch (OperationCanceledException) when (ct.IsCancellationRequested)
+                    {
+                        throw;
+                    }
+                    catch (Exception ex)
+                    {
+                        // One app throwing (e.g. its re-fetched descriptor fails validation)
+                        // must not fault the whole run and discard every other app's result.
+                        results[idx] = new UpdateResult { Name = names[idx], Status = UpdateStatus.Failed, Message = ex.Message };
+                    }
                     finally
                     {
                         gate.Release();


### PR DESCRIPTION
## Summary
Systematic bug hunt (find → prove with a red test → check the fix's blast radius → fix). Eight real, user-triggerable issues, each with regression tests:

1. **Corrupt patch journal = permanent failure loop** — every subsequent patch failed with a raw `JsonException` and no pointer to `.hina/journal.json`. Now an actionable error naming the file and the recovery steps.
2. **Truncated chunk hash in a manifest crashed fresh installs** — `Substring(0,2)` on a short hash threw `ArgumentOutOfRangeException` (the rsync matcher's validation only runs when a local file exists). Now a clean manifest error.
3. **Setup wizard persisted invalid ports** — a typo ('8o80') was written to `hina.host.json`, the host then crashed on every start and the wizard never re-ran. Now re-prompts until valid (1-65535).
4. **`hina install` against a web page / captive portal** surfaced `"'<' is an invalid start of a value"` — now "not a valid Hina app descriptor".
5. **AccessStats grew unbounded under scan traffic** — one entry per unique probe path and per (ip,app) forever; tables now cap (10k paths / 50k buckets), totals and rate limiting unaffected.
6. **One bad app aborted the whole `hina update` run** — a descriptor failing validation threw out of `UpdateAsync`, faulting `Task.WhenAll` and discarding every other app's result. Per-app failures are now isolated; cancellation still propagates.
7. **Corrupt `hina.config.json` didn't name the file** — ambiguous between explicit `--config` and the implicit CWD config. Now named.
8. **`hina-builder build --chunk 0` crashed with a stack trace** (exit 134) — chunk params now validated (usage error) and the builder gained the CLI's top-level catch, so no command can escape as a raw stack trace.

Verified clean during the hunt (no action needed): hook path validation, LockManager crash-release semantics, TOFU/key pinning, RegistryVerifier fail-soft paths, SelfUpdate, ProjectMetadataReader, base64 handling in both signers.

## Tests
578 green (540 → 578; +38 regression tests). Builder crash also re-verified against the real binary (clean exit 2).

🤖 Generated with [Claude Code](https://claude.com/claude-code)