### PR TITLE
chore: untrack Claude Code session-local state

### DIFF
--- a/.claude/scheduled_tasks.lock
+++ b/.claude/scheduled_tasks.lock
@@ -1,1 +1,0 @@
-{"sessionId":"c31342aa-66f9-4d4a-a363-ca3c799fe98b","pid":86386,"procStart":"Tue Jun  9 21:05:31 2026","acquiredAt":1781047462860}

--- a/.gitignore
+++ b/.gitignore
@@ -388,3 +388,6 @@ MigrationBackup/
 # Release script output (scripts/release.sh)
 dist/
 .DS_Store
+
+# Claude Code session-local state (lock files, local settings)
+.claude/


### PR DESCRIPTION
`.claude/scheduled_tasks.lock` is per-session tooling state (pid, session id) that slipped into the repo in PR #12 and churns on every session. Removed from tracking; `.claude/` ignored.

🤖 Generated with [Claude Code](https://claude.com/claude-code)