### PR TITLE
Bug hunt round 9: proxy rate limiting, config preservation, commit-point cancellation, identity drift

### DIFF
--- a/Hina.Host.Tests/ForwardedHeadersTests.cs
+++ b/Hina.Host.Tests/ForwardedHeadersTests.cs
@@ -1,0 +1,106 @@
+using System.Net;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Hina.Host.Tests
+{
+    // The rate limiter and the /stats loopback gate both key on Connection.RemoteIpAddress,
+    // which UseForwardedHeaders rewrites from X-Forwarded-For only for trusted proxies.
+    // Behind a remote reverse proxy / load balancer every client used to share the proxy's
+    // IP (one rate-limit bucket for everyone); "trustedProxies" opts that proxy in.
+    //
+    // /stats (loopback-only) is the observable: if X-Forwarded-For: 127.0.0.1 from a given
+    // remote address flips /stats to 200, the forwarded client IP was trusted.
+    public class ForwardedHeadersTests : IDisposable
+    {
+        private readonly string _root;
+
+        public ForwardedHeadersTests()
+        {
+            _root = Path.Combine(Path.GetTempPath(), "hina_host_fwd_" + Guid.NewGuid().ToString("N"));
+            Directory.CreateDirectory(_root);
+        }
+
+        public void Dispose()
+        {
+            try { Directory.Delete(_root, recursive: true); } catch { /* best effort */ }
+        }
+
+        // Prepends a middleware that fakes the TestServer connection's remote address,
+        // simulating a connection arriving from a given proxy/client IP. IStartupFilter
+        // middlewares run before the app pipeline, so UseForwardedHeaders sees the fake.
+        private sealed class FakeRemoteIpFilter : IStartupFilter
+        {
+            private readonly IPAddress _ip;
+            public FakeRemoteIpFilter(IPAddress ip) => _ip = ip;
+
+            public Action<IApplicationBuilder> Configure(Action<IApplicationBuilder> next) =>
+                app =>
+                {
+                    app.Use(async (ctx, nxt) =>
+                    {
+                        ctx.Connection.RemoteIpAddress = _ip;
+                        await nxt();
+                    });
+                    next(app);
+                };
+        }
+
+        private WebApplicationFactory<Program> Boot(string remoteIp, string? trustedProxies)
+        {
+            return new WebApplicationFactory<Program>().WithWebHostBuilder(b =>
+            {
+                b.UseSetting("Patcher:Root", _root);
+                if (trustedProxies is not null)
+                    b.UseSetting("TrustedProxies", trustedProxies);
+                b.ConfigureServices(s =>
+                    s.AddSingleton<IStartupFilter>(new FakeRemoteIpFilter(IPAddress.Parse(remoteIp))));
+            });
+        }
+
+        [Fact]
+        public async Task TrustedProxy_ForwardedClientIp_IsHonored()
+        {
+            using var factory = Boot("10.1.2.3", trustedProxies: "10.1.2.3");
+            using var client = factory.CreateClient();
+
+            var req = new HttpRequestMessage(HttpMethod.Get, "/stats");
+            req.Headers.Add("X-Forwarded-For", "127.0.0.1");
+            var resp = await client.SendAsync(req);
+
+            Assert.Equal(HttpStatusCode.OK, resp.StatusCode);
+        }
+
+        [Fact]
+        public async Task UntrustedRemote_ForwardedClientIp_IsIgnored()
+        {
+            // 10.9.9.9 is not in the trusted list: its X-Forwarded-For must not be believed.
+            using var factory = Boot("10.9.9.9", trustedProxies: "10.1.2.3");
+            using var client = factory.CreateClient();
+
+            var req = new HttpRequestMessage(HttpMethod.Get, "/stats");
+            req.Headers.Add("X-Forwarded-For", "127.0.0.1");
+            var resp = await client.SendAsync(req);
+
+            Assert.Equal(HttpStatusCode.NotFound, resp.StatusCode);
+        }
+
+        [Fact]
+        public async Task NoTrustedProxies_RemoteForwardedClientIp_IsIgnored()
+        {
+            // Default deployment (no trustedProxies): a remote caller spoofing
+            // X-Forwarded-For: 127.0.0.1 must not reach the loopback-only /stats.
+            using var factory = Boot("10.1.2.3", trustedProxies: null);
+            using var client = factory.CreateClient();
+
+            var req = new HttpRequestMessage(HttpMethod.Get, "/stats");
+            req.Headers.Add("X-Forwarded-For", "127.0.0.1");
+            var resp = await client.SendAsync(req);
+
+            Assert.Equal(HttpStatusCode.NotFound, resp.StatusCode);
+        }
+    }
+}

--- a/Hina.Host.Tests/HostOptionsTests.cs
+++ b/Hina.Host.Tests/HostOptionsTests.cs
@@ -180,6 +180,21 @@ namespace Hina.Host.Tests
         }
 
         [Fact]
+        public void Load_RootIsNotAnObject_ThrowsActionableError()
+        {
+            // A config whose root is an array/string parses as JSON, but TryGetProperty
+            // on a non-object root throws a raw InvalidOperationException at startup.
+            string cfg = Path.Combine(_tempDir, "hina.host.json");
+            File.WriteAllText(cfg, "[1,2,3]");
+
+            var ex = Assert.Throws<InvalidDataException>(
+                () => HostOptions.Load(new[] { "--config", cfg }, EmptyConfig()));
+
+            Assert.Contains(cfg, ex.Message);
+            Assert.Contains("object", ex.Message);
+        }
+
+        [Fact]
         public void Load_TrustedProxies_DefaultsToEmpty()
         {
             var opt = HostOptions.Load(Array.Empty<string>(), EmptyConfig());

--- a/Hina.Host.Tests/HostOptionsTests.cs
+++ b/Hina.Host.Tests/HostOptionsTests.cs
@@ -178,5 +178,60 @@ namespace Hina.Host.Tests
             var opt = HostOptions.Load(Array.Empty<string>(), config);
             Assert.Equal("legacy-root", opt.Root);
         }
+
+        [Fact]
+        public void Load_TrustedProxies_DefaultsToEmpty()
+        {
+            var opt = HostOptions.Load(Array.Empty<string>(), EmptyConfig());
+            Assert.Empty(opt.TrustedProxies);
+        }
+
+        [Fact]
+        public void Load_TrustedProxiesFromJson_ParsesList()
+        {
+            string cfg = Path.Combine(_tempDir, "hina.host.json");
+            File.WriteAllText(cfg, """{ "trustedProxies": ["10.1.2.3", "2001:db8::1"] }""");
+
+            var opt = HostOptions.Load(new[] { "--config", cfg }, EmptyConfig());
+
+            Assert.Equal(new[] { "10.1.2.3", "2001:db8::1" }, opt.TrustedProxies);
+        }
+
+        [Fact]
+        public void Load_TrustedProxiesFromFlag_ParsesCommaSeparatedList()
+        {
+            var opt = HostOptions.Load(new[] { "--trusted-proxies", "10.1.2.3, 10.1.2.4" }, EmptyConfig());
+
+            Assert.Equal(new[] { "10.1.2.3", "10.1.2.4" }, opt.TrustedProxies);
+        }
+
+        [Theory]
+        [InlineData("not-an-ip")]
+        [InlineData("10.1.2.3/24")]
+        [InlineData("proxy.example.com")]
+        public void Load_InvalidTrustedProxyInJson_ThrowsActionableError(string value)
+        {
+            // CIDR ranges and hostnames are not supported — only literal IPs. A typo'd
+            // entry must fail at startup, not silently leave the proxy untrusted (which
+            // would put every client in one rate-limit bucket with no visible cause).
+            string cfg = Path.Combine(_tempDir, "hina.host.json");
+            File.WriteAllText(cfg, $$"""{ "trustedProxies": ["{{value}}"] }""");
+
+            var ex = Assert.Throws<InvalidDataException>(
+                () => HostOptions.Load(new[] { "--config", cfg }, EmptyConfig()));
+
+            Assert.Contains("trustedProxies", ex.Message);
+            Assert.Contains(value, ex.Message);
+        }
+
+        [Fact]
+        public void Load_InvalidTrustedProxyInFlag_ThrowsActionableError()
+        {
+            var ex = Assert.Throws<InvalidDataException>(
+                () => HostOptions.Load(new[] { "--trusted-proxies", "nope" }, EmptyConfig()));
+
+            Assert.Contains("--trusted-proxies", ex.Message);
+            Assert.Contains("nope", ex.Message);
+        }
     }
 }

--- a/Hina.Host.Tests/SetupWizardTests.cs
+++ b/Hina.Host.Tests/SetupWizardTests.cs
@@ -50,19 +50,31 @@ namespace Hina.Host.Tests
         }
 
         [Fact]
-        public void IsConfigMissingOrEmpty_NotAnObject_True()
+        public void IsConfigMissingOrEmpty_WhitespaceOnly_True()
         {
-            string p = PathFor("array.json");
-            File.WriteAllText(p, "[1,2,3]");
+            string p = PathFor("blank.json");
+            File.WriteAllText(p, "  \n\t ");
             Assert.True(SetupWizard.IsConfigMissingOrEmpty(p));
         }
 
+        // A corrupt-but-non-empty config must NOT trigger the auto-wizard: the wizard
+        // ends with File.WriteAllText over the user's file, so a single JSON typo in a
+        // hand-maintained config (apps, cors, ...) would destroy it after the prompts.
+        // Corrupt configs flow to HostOptions.Load, which names the file and the error.
         [Fact]
-        public void IsConfigMissingOrEmpty_InvalidJson_True()
+        public void IsConfigMissingOrEmpty_NotAnObject_False()
+        {
+            string p = PathFor("array.json");
+            File.WriteAllText(p, "[1,2,3]");
+            Assert.False(SetupWizard.IsConfigMissingOrEmpty(p));
+        }
+
+        [Fact]
+        public void IsConfigMissingOrEmpty_InvalidJson_False()
         {
             string p = PathFor("broken.json");
-            File.WriteAllText(p, "not json at all");
-            Assert.True(SetupWizard.IsConfigMissingOrEmpty(p));
+            File.WriteAllText(p, """{ "urls": "http://0.0.0.0:5000" "apps": {} }""");
+            Assert.False(SetupWizard.IsConfigMissingOrEmpty(p));
         }
 
         [Fact]

--- a/Hina.Host/HostOptions.cs
+++ b/Hina.Host/HostOptions.cs
@@ -46,6 +46,15 @@ namespace Hina.Host
                 using (doc)
                 {
                     var r = doc.RootElement;
+                    if (r.ValueKind != JsonValueKind.Object)
+                    {
+                        // TryGetProperty on a non-object root throws a raw
+                        // InvalidOperationException; fail with the same actionable shape
+                        // as the not-valid-JSON case instead.
+                        throw new InvalidDataException(
+                            $"Host config '{Path.GetFullPath(jsonPath)}' must contain a JSON object at the top level (found {r.ValueKind}). " +
+                            "Fix the file, or delete it and re-run with --setup to regenerate it.");
+                    }
                     if (r.TryGetProperty("root", out var v) && v.ValueKind == JsonValueKind.String) opt.Root = v.GetString()!;
                     if (r.TryGetProperty("urls", out v) && v.ValueKind == JsonValueKind.String) opt.Urls = v.GetString();
                     if (r.TryGetProperty("requestsPerMinutePerIp", out v) && v.TryGetInt32(out int n))

--- a/Hina.Host/HostOptions.cs
+++ b/Hina.Host/HostOptions.cs
@@ -13,6 +13,10 @@ namespace Hina.Host
         public int SummaryIntervalSeconds { get; set; } = 60;
         public bool StatsEnabled { get; set; } = true;
         public List<string> Cors { get; set; } = new();
+        // Literal IPs of reverse proxies whose X-Forwarded-For is trusted. Without this,
+        // every client behind a remote proxy/LB shares the proxy's IP — i.e. one
+        // rate-limit bucket for everyone (local loopback proxies are trusted by default).
+        public List<string> TrustedProxies { get; set; } = new();
         public Dictionary<string, string> Apps { get; set; } = new(StringComparer.OrdinalIgnoreCase);
 
         public static HostOptions Load(string[] args, IConfiguration config)
@@ -65,6 +69,14 @@ namespace Hina.Host
                     if (r.TryGetProperty("statsEnabled", out v) && v.ValueKind is JsonValueKind.True or JsonValueKind.False) opt.StatsEnabled = v.GetBoolean();
                     if (r.TryGetProperty("cors", out v) && v.ValueKind == JsonValueKind.Array)
                         opt.Cors = v.EnumerateArray().Where(e => e.ValueKind == JsonValueKind.String).Select(e => e.GetString()!).ToList();
+                    if (r.TryGetProperty("trustedProxies", out v) && v.ValueKind == JsonValueKind.Array)
+                    {
+                        opt.TrustedProxies = v.EnumerateArray()
+                            .Where(e => e.ValueKind == JsonValueKind.String)
+                            .Select(e => e.GetString()!)
+                            .ToList();
+                        ValidateTrustedProxies(opt.TrustedProxies, $"Host config '{jsonPath}': \"trustedProxies\"");
+                    }
                     if (r.TryGetProperty("apps", out v) && v.ValueKind == JsonValueKind.Object)
                     {
                         foreach (var prop in v.EnumerateObject())
@@ -87,6 +99,15 @@ namespace Hina.Host
 
             string? legacy = config["Patcher:Root"];
             if (!string.IsNullOrWhiteSpace(legacy)) opt.Root = legacy;
+
+            // Also honored from IConfiguration (env var / host settings) so in-process
+            // deployments and tests can set it without a json file, like Patcher:Root.
+            string? trustedFromConfig = config["TrustedProxies"];
+            if (!string.IsNullOrWhiteSpace(trustedFromConfig))
+            {
+                opt.TrustedProxies = SplitList(trustedFromConfig);
+                ValidateTrustedProxies(opt.TrustedProxies, "TrustedProxies setting");
+            }
 
             if (GetArg(args, "--root") is { } root) opt.Root = root;
             if (GetArg(args, "--urls") is { } urls) opt.Urls = urls;
@@ -111,10 +132,30 @@ namespace Hina.Host
                     throw new InvalidDataException($"--abuse-threshold '{ab}' must be a number >= 0.");
                 opt.AbuseThresholdPerMinute = abn;
             }
-            if (GetArg(args, "--cors") is { } cors) opt.Cors = cors.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries).ToList();
+            if (GetArg(args, "--cors") is { } cors) opt.Cors = SplitList(cors);
+            if (GetArg(args, "--trusted-proxies") is { } proxies)
+            {
+                opt.TrustedProxies = SplitList(proxies);
+                ValidateTrustedProxies(opt.TrustedProxies, "--trusted-proxies");
+            }
             if (args.Contains("--no-stats", StringComparer.OrdinalIgnoreCase)) opt.StatsEnabled = false;
 
             return opt;
+        }
+
+        static List<string> SplitList(string value) =>
+            value.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries).ToList();
+
+        static void ValidateTrustedProxies(List<string> proxies, string source)
+        {
+            foreach (string p in proxies)
+            {
+                if (!System.Net.IPAddress.TryParse(p, out _))
+                {
+                    throw new InvalidDataException(
+                        $"{source}: '{p}' is not a valid IP address. Use literal proxy IPs (no hostnames or CIDR ranges), e.g. \"10.0.0.5\".");
+                }
+            }
         }
 
         static string? GetArg(string[] args, string name)

--- a/Hina.Host/Program.cs
+++ b/Hina.Host/Program.cs
@@ -67,7 +67,14 @@ builder.Services.AddSingleton<AccessStats>();
 builder.Services.Configure<ForwardedHeadersOptions>(o =>
 {
     o.ForwardedHeaders = ForwardedHeaders.XForwardedFor | ForwardedHeaders.XForwardedProto;
+    // Only proxies listed in trustedProxies may rewrite the client IP via
+    // X-Forwarded-For (plus the loopback default for same-machine proxies).
+    // The rate limiter and the /stats loopback gate key on that IP: trusting an
+    // unlisted proxy would let remote callers spoof it, while NOT listing a real
+    // remote proxy/LB collapses all its clients into one rate-limit bucket.
     o.KnownProxies.Clear();
+    foreach (string p in options.TrustedProxies)
+        o.KnownProxies.Add(IPAddress.Parse(p));
 });
 
 builder.Services.AddRateLimiter(rl =>
@@ -275,6 +282,9 @@ static void PrintHelp()
           --abuse-threshold <n>      Log warning when (IP,App) exceeds N req/min (default: 300)
           --no-stats                 Disable the /stats endpoint (loopback-only by default)
           --cors <origin[,origin]>   Enable CORS for the given origins
+          --trusted-proxies <ip[,ip]> Reverse-proxy IPs whose X-Forwarded-For is trusted
+                                     (needed behind a remote proxy/LB so rate limiting
+                                     sees real client IPs; json key: "trustedProxies")
           --setup                    Run the interactive setup wizard (overwrites existing config)
           -h, --help                 Show this help
 

--- a/Hina.Host/SetupWizard.cs
+++ b/Hina.Host/SetupWizard.cs
@@ -6,20 +6,25 @@ namespace Hina.Host
     // terminal is attached; this class only owns the config-file logic and the prompts.
     internal static class SetupWizard
     {
-        // True when the wizard should be offered: no config yet, an empty JSON object, or
-        // an unparseable file.
+        // True when the wizard should be offered: no config yet, a whitespace-only file,
+        // or an empty JSON object. A corrupt-but-non-empty file must return false: the
+        // wizard ends by overwriting the file, so auto-running it would destroy a
+        // hand-maintained config over a single JSON typo. Corrupt configs flow to
+        // HostOptions.Load instead, which reports the file and the parse error.
         public static bool IsConfigMissingOrEmpty(string path)
         {
             if (!File.Exists(path)) return true;
+            string text;
+            try { text = File.ReadAllText(path); } catch { return false; }
+            if (string.IsNullOrWhiteSpace(text)) return true;
             try
             {
-                using var doc = JsonDocument.Parse(File.ReadAllText(path));
-                if (doc.RootElement.ValueKind != JsonValueKind.Object) return true;
-                int props = 0;
-                foreach (var _ in doc.RootElement.EnumerateObject()) { props++; break; }
-                return props == 0;
+                using var doc = JsonDocument.Parse(text);
+                if (doc.RootElement.ValueKind != JsonValueKind.Object) return false;
+                foreach (var _ in doc.RootElement.EnumerateObject()) return false;
+                return true;
             }
-            catch { return true; }
+            catch { return false; }
         }
 
         public static bool Run(string outPath, bool force)

--- a/Hina.PackageManager.Tests/FakePlatformIntegration.cs
+++ b/Hina.PackageManager.Tests/FakePlatformIntegration.cs
@@ -35,6 +35,10 @@ namespace Hina.PackageManager.Tests
         // Same seam for CreateMenuShortcut (update add-phase cancellation).
         public CancellationTokenSource? CancelOnCreateShortcut { get; set; }
 
+        // Cancels the source but completes normally — simulates Ctrl+C arriving in the
+        // window between the last add-phase step and the final registry write.
+        public CancellationTokenSource? CancelAfterCreateShortcut { get; set; }
+
         public Task<string> CreateMenuShortcut(ShellEntry entry, string appDir, CancellationToken ct)
         {
             if (CancelOnCreateShortcut != null)
@@ -42,6 +46,7 @@ namespace Hina.PackageManager.Tests
                 CancelOnCreateShortcut.Cancel();
                 ct.ThrowIfCancellationRequested();
             }
+            CancelAfterCreateShortcut?.Cancel();
             if (ThrowOnCreateShortcutId != null && entry.Id == ThrowOnCreateShortcutId)
             {
                 throw new System.InvalidOperationException($"Simulated failure creating shortcut '{entry.Id}'.");

--- a/Hina.PackageManager.Tests/UpdateServiceTests.cs
+++ b/Hina.PackageManager.Tests/UpdateServiceTests.cs
@@ -490,6 +490,33 @@ namespace Hina.PackageManager.Tests
             Assert.Equal("1.0.0", reg.Apps["demo"].InstalledVersion);
         }
 
+        [Fact]
+        public async Task Update_CancelledAfterHookAdd_StillCommitsRegistry()
+        {
+            // Ctrl+C landing between the end of the add-phase and the final registry write:
+            // every piece of work is already done (files v2, hooks/entries v2), so the commit
+            // must complete instead of leaving files at v2 with the registry still at v1 and
+            // reporting a bogus "registry could not be saved: operation was canceled" failure.
+            await InstallV1();
+
+            AppDescriptor v2 = BuildDescriptor(_pubKey, version: "1.1.0");
+            v2.Entries[0].Id = "main2";
+            DescriptorSigner.AttachSignature(v2, Convert.FromBase64String(_privKey));
+
+            using var cts = new CancellationTokenSource();
+            _platform.CancelAfterCreateShortcut = cts;
+            UpdateService svc = new UpdateService(
+                _paths, _platform,
+                fetcher: new StubFetcher(v2),
+                patchClientFactory: cfg => new FakePatchClient(cfg, NewExecFiles()));
+
+            UpdateResult result = await svc.UpdateAsync("demo", null, cts.Token);
+
+            Assert.Equal(UpdateStatus.Updated, result.Status);
+            Registry.Registry reg = new RegistryStore(_paths.RegistryFile).Load();
+            Assert.Equal("1.1.0", reg.Apps["demo"].InstalledVersion);
+        }
+
         private static AppDescriptor BuildDescriptor(string publicKey, string name = "demo", string version = "1.0.0")
         {
             return new AppDescriptor

--- a/Hina.PackageManager.Tests/UpdateServiceTests.cs
+++ b/Hina.PackageManager.Tests/UpdateServiceTests.cs
@@ -491,6 +491,31 @@ namespace Hina.PackageManager.Tests
         }
 
         [Fact]
+        public async Task Update_DescriptorRenamesApp_IsRefused()
+        {
+            // The pinned key and the version direction are both guarded, but the app's
+            // primary identity wasn't: a re-fetched descriptor declaring a different name
+            // updated fine and refreshed the descriptor cache with the new name, leaving
+            // the registry row keyed "demo" with a cached descriptor claiming "demo2".
+            await InstallV1();
+
+            AppDescriptor renamed = BuildDescriptor(_pubKey, name: "demo2", version: "1.1.0");
+            DescriptorSigner.AttachSignature(renamed, Convert.FromBase64String(_privKey));
+
+            UpdateService svc = new UpdateService(
+                _paths, _platform,
+                fetcher: new StubFetcher(renamed),
+                patchClientFactory: cfg => new FakePatchClient(cfg, NewExecFiles()));
+
+            UpdateResult result = await svc.UpdateAsync("demo", null, CancellationToken.None);
+
+            Assert.Equal(UpdateStatus.Failed, result.Status);
+            Assert.Contains("demo2", result.Message);
+            Registry.Registry reg = new RegistryStore(_paths.RegistryFile).Load();
+            Assert.Equal("1.0.0", reg.Apps["demo"].InstalledVersion);
+        }
+
+        [Fact]
         public async Task Update_CancelledAfterHookAdd_StillCommitsRegistry()
         {
             // Ctrl+C landing between the end of the add-phase and the final registry write:

--- a/Hina.PackageManager/Install/UninstallService.cs
+++ b/Hina.PackageManager/Install/UninstallService.cs
@@ -107,8 +107,11 @@ namespace Hina.PackageManager.Install
             }
             catch (System.Exception ex) { _logger.LogDebug(ex, "Removal of descriptor cache failed for {Name} (fail-soft).", name); }
 
+            // Commit point past the point of no return declared above: the install dir is
+            // already gone, so this write must not observe ct — a Ctrl+C here would leave
+            // a registry row pointing at a deleted directory (ghost app in `hina list`).
             registry.Apps.Remove(name);
-            await store.SaveAsync(registry, ct);
+            await store.SaveAsync(registry, CancellationToken.None);
 
             return new UninstallResult { Name = name, Removed = true };
         }

--- a/Hina.PackageManager/Install/UpdateService.cs
+++ b/Hina.PackageManager/Install/UpdateService.cs
@@ -345,12 +345,18 @@ namespace Hina.PackageManager.Install
             // so we merge with any changes other concurrent operations made to OTHER
             // apps; we then overwrite our own app's row with the updated entry.
             // H1: if SaveAsync still fails, dump a recovery snapshot.
+            // This is the commit point and runs on CancellationToken.None: all the work
+            // is already done (files, hooks, entries are at v2), so a Ctrl+C in this
+            // window must not abort the write — it would leave files at v2 with the
+            // registry still claiming v1, and the swallowed cancellation surfaced as a
+            // bogus "registry could not be saved: operation was canceled" failure.
+            // Bounded: AcquireAsync gives up with a TimeoutException after its max wait.
             try
             {
-                using RegistryLock writeLock = await locks.AcquireAsync(ct);
+                using RegistryLock writeLock = await locks.AcquireAsync(CancellationToken.None);
                 registry = store.Load();
                 registry.Apps[name] = updated;
-                await store.SaveAsync(registry, ct);
+                await store.SaveAsync(registry, CancellationToken.None);
             }
             catch (Exception saveEx)
             {

--- a/Hina.PackageManager/Install/UpdateService.cs
+++ b/Hina.PackageManager/Install/UpdateService.cs
@@ -93,6 +93,23 @@ namespace Hina.PackageManager.Install
             // [2] Validate + signature pinning.
             DescriptorValidator.Validate(descriptor).EnsureValid();
 
+            // The app's primary identity must not drift on update: the registry row and the
+            // descriptor cache are both keyed by the installed name, so accepting a renamed
+            // descriptor leaves a row "demo" whose cached descriptor claims "demo2". Refuse,
+            // like the pinned-key and downgrade gates above/below.
+            if (!string.Equals(descriptor.Name, app.Name, StringComparison.Ordinal))
+            {
+                return new UpdateResult
+                {
+                    Name = name,
+                    FromVersion = app.InstalledVersion,
+                    ToVersion = descriptor.Version,
+                    Status = UpdateStatus.Failed,
+                    Message = $"Descriptor at {app.DescriptorUrl} now declares name '{descriptor.Name}' but '{app.Name}' is installed. " +
+                              $"If the publisher renamed the app, install it fresh with `hina install <url>` and then `hina uninstall {app.Name}`."
+                };
+            }
+
             // [2a] Same minHinaVersion gate as InstallService — block an update that would
             //      drag the install into a state this Hina can't drive.
             if (!string.IsNullOrWhiteSpace(descriptor.MinHinaVersion) && !HinaVersion.IsSatisfiedBy(descriptor.MinHinaVersion))

--- a/docs/Host-Guide.md
+++ b/docs/Host-Guide.md
@@ -56,6 +56,7 @@ The primary configuration file. Place it in the working directory alongside the 
 | `summaryIntervalSeconds` | `int` | `60` | How often the aggregated traffic summary is logged. |
 | `statsEnabled` | `bool` | `true` | Expose `/stats` (loopback-only) with top IPs / paths / rejections. |
 | `cors` | `string[]` | `[]` | Origins allowed for CORS. Empty means CORS middleware is not installed. |
+| `trustedProxies` | `string[]` | `[]` | Literal IPs of reverse proxies whose `X-Forwarded-For` is trusted. Required when the proxy/LB runs on a **different machine**, otherwise all its clients share one rate-limit bucket (same-machine loopback proxies are trusted by default). Only list proxies that overwrite or append the header. |
 | `apps` | `object` | `{}` | Multi-app mode. Maps `<appName>` → physical directory. Each app is served under `/<appName>/...`. When set, `root` is ignored and unknown prefixes return 404. |
 
 ### Multi-App Hosting
@@ -96,6 +97,7 @@ All JSON keys have an equivalent flag and override the file:
 | `--rate-limit <n>` | `requestsPerMinutePerIp` (0 disables) |
 | `--abuse-threshold <n>` | `abuseThresholdPerMinute` |
 | `--cors <origins>` | comma-separated origins |
+| `--trusted-proxies <ips>` | `trustedProxies` (comma-separated) |
 | `--no-stats` | `statsEnabled = false` |
 | `-h`, `--help` | prints usage and exits |
 
@@ -235,6 +237,17 @@ server {
         }
     }
 }
+```
+
+A proxy on the **same machine** (as above, `127.0.0.1`) is trusted automatically and
+per-client rate limiting works out of the box. If the proxy or load balancer runs on a
+**different machine**, add its IP to `trustedProxies` (or `--trusted-proxies`) —
+otherwise Hina.Host sees every request as coming from the proxy's IP and all clients
+share a single rate-limit bucket (mass `429` once their combined traffic exceeds the
+limit):
+
+```json
+{ "trustedProxies": ["10.0.0.5"] }
 ```
 
 ### Behind Apache Reverse Proxy


### PR DESCRIPTION
Round 9 of the systematic bug hunt. 5 user-reachable fixes, suite 615 → 629 tests, every behavioral fix reproduced red-first.

### Fixes

1. **Host: per-client rate limiting behind a remote reverse proxy** — `KnownProxies.Clear()` meant `X-Forwarded-For` was never trusted from a non-loopback address, so behind a remote proxy/LB every client shared the proxy's IP: one rate-limit bucket for everyone and mass 429 once combined traffic crossed the limit. New `trustedProxies` json key / `--trusted-proxies` flag opts specific proxy IPs in (validated at startup; hostnames/CIDR rejected with an actionable error). Default unchanged: remote XFF stays untrusted, so spoofing a loopback IP still can't reach the loopback-only `/stats`.

2. **Host: setup wizard no longer destroys a corrupt config** — a hand-maintained `hina.host.json` with one JSON typo counted as "missing or empty", so an interactive start auto-ran the wizard and finished by overwriting the file — the user's apps/cors/rate-limit setup was silently destroyed. Corrupt non-empty (and unreadable) files now skip the auto-wizard and surface the parse error with the file named. Bonus: a config whose root is not a JSON object (`[1,2,3]`) crashed startup with a raw `InvalidOperationException`; now an actionable error.

3. **Update: Ctrl+C between the add-phase and the registry write no longer fakes a failure** — cancellation in that window was swallowed by the generic save catch and reported as "Files updated but the registry could not be saved: The operation was canceled." with files at v2 and the registry at v1. The final write is the commit point (all work already done), so it now runs on `CancellationToken.None` and completes. `update --all` abort semantics unaffected.

4. **Uninstall: registry write past the point of no return ignores Ctrl+C** — same class as (3): the install dir was already deleted, but the final registry write still observed ct, so a Ctrl+C there left a ghost row pointing at a deleted directory.

5. **Update: a descriptor that renames the app is refused** — pinned key and downgrades are gated, but the primary identity wasn't: a re-fetched descriptor with a different `name` updated fine and refreshed the descriptor cache, leaving a registry row keyed `demo` whose cached descriptor claims `demo2` (silent identity drift read by run/perms/info/verify). Now fails naming both names and the recovery path.

### Verified clean this round
Culture-sensitive case/number APIs, install URL scheme edges (`file://` already cleanly rejected), builder `--platform` token, registry save atomicity, newer-schema downgrade guard, corrupt descriptor cache in run/perms/info, CheckUpdate/Which commands, ReinstallService ordering.

🤖 Generated with [Claude Code](https://claude.com/claude-code)