### PR TITLE
Bug hunt round 10: installer scripts and packaging (curl|sh, PowerShell, scoop)

### DIFF
--- a/packaging/scoop/hina.json.template
+++ b/packaging/scoop/hina.json.template
@@ -6,13 +6,11 @@
   "architecture": {
     "64bit": {
       "url": "https://github.com/Arutosio/Hina/releases/download/__TAG__/Hina-windows-x64.zip",
-      "hash": "__HASH_X64__",
-      "extract_dir": "Hina-windows-x64"
+      "hash": "__HASH_X64__"
     },
     "arm64": {
       "url": "https://github.com/Arutosio/Hina/releases/download/__TAG__/Hina-windows-arm64.zip",
-      "hash": "__HASH_ARM64__",
-      "extract_dir": "Hina-windows-arm64"
+      "hash": "__HASH_ARM64__"
     }
   },
   "bin": "hina.exe",

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -63,6 +63,23 @@ function Invoke-Main {
         }
     }
 
+    # Extract a bare X.Y.Z from arbitrary text (e.g. "hina 1.0.0" or "v1.0.0").
+    function Get-VerNum([string]$s) {
+        if ($s -and $s -match '(\d+\.\d+\.\d+)') { return $Matches[1] }
+        return $null
+    }
+
+    # Compare two X.Y.Z versions numerically: -1 if $a<$b, 0 if equal, 1 if $a>$b.
+    function Compare-SemVer([string]$a, [string]$b) {
+        $pa = $a -split '\.'
+        $pb = $b -split '\.'
+        for ($i = 0; $i -lt 3; $i++) {
+            if ([int]$pa[$i] -lt [int]$pb[$i]) { return -1 }
+            if ([int]$pa[$i] -gt [int]$pb[$i]) { return 1 }
+        }
+        return 0
+    }
+
     function Resolve-LatestTag {
         try {
             $rel = Invoke-RestMethod -UseBasicParsing -Uri "https://api.github.com/repos/$Repo/releases/latest"
@@ -118,8 +135,17 @@ function Invoke-Main {
         try {
             Invoke-WebRequest -UseBasicParsing -Uri $ShaUrl -OutFile $shaFile -TimeoutSec 60
         } catch {
-            Write-Info "no SHA-256 published for $Tag (older release?). Falling back to structural zip check only."
-            return
+            # Only a real 404 (checksum genuinely not published, i.e. an old
+            # release) may skip verification. A transient network error - or a
+            # MITM blocking just the .sha256 - must NOT silently downgrade the
+            # install to unverified.
+            $status = 0
+            try { $status = [int]$_.Exception.Response.StatusCode } catch { }
+            if ($status -eq 404) {
+                Write-Info "no SHA-256 published for $Tag (older release). Falling back to structural zip check only."
+                return
+            }
+            Stop-Err "could not download the SHA-256 checksum for $Tag (network or server error, not a missing file). Refusing to install an unverified archive; re-run the installer, or set HINA_NO_CHECKSUM=1 to bypass (not recommended)."
         }
         $expected = ((Get-Content -LiteralPath $shaFile -TotalCount 1) -split '\s+')[0].ToLowerInvariant()
         if (-not $expected) { Stop-Err 'downloaded .sha256 is empty or malformed' }
@@ -260,11 +286,30 @@ function Invoke-Main {
                 default             { Stop-Err "invalid choice: $choice" }
             }
         } else {
-            if ($existingVer -eq $Tag -or $existingVer -like "*$Tag*") {
-                Write-Info 'non-interactive: same version already installed, nothing to do (set HINA_ACTION to override)'
-                $action = 'exit'
+            # The old comparison ($existingVer -like "*$Tag*") could never match:
+            # `hina --version` prints "hina 1.4.2" while the tag is "v1.4.2", so
+            # every non-interactive re-run re-downloaded and reinstalled the same
+            # version - and silently downgraded an installed build newer than the
+            # target. Mirror install.sh: numeric compare, upgrade only when behind.
+            $existingNum = Get-VerNum $existingVer
+            $targetNum   = Get-VerNum $Tag
+            if ($existingNum -and $targetNum) {
+                switch (Compare-SemVer $existingNum $targetNum) {
+                    -1 {
+                        Write-Info "non-interactive: $existingNum is behind $targetNum, upgrading (set HINA_ACTION to override)"
+                        $action = 'reinstall'
+                    }
+                    0 {
+                        Write-Info "non-interactive: already at $targetNum, nothing to do (set HINA_ACTION to override)"
+                        $action = 'exit'
+                    }
+                    1 {
+                        Write-Info "non-interactive: installed $existingNum is newer than target $targetNum, leaving as-is (set HINA_ACTION=reinstall to force)"
+                        $action = 'exit'
+                    }
+                }
             } else {
-                Write-Info 'non-interactive: different version detected, upgrading (set HINA_ACTION to override)'
+                Write-Info 'non-interactive: could not determine installed version, upgrading (set HINA_ACTION to override)'
                 $action = 'reinstall'
             }
         }

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -206,13 +206,23 @@ EOF
         err "download failed after 5 attempts: $url"
     }
 
-    fetch_optional() {
-        # 0 = fetched, 1 = 404 / network fail (caller decides)
+    # Fetch the .sha256 companion file. Distinguishes "genuinely not published"
+    # from "network/server failure": only a real 404 may skip verification, so a
+    # transient outage (or a MITM that blocks just the checksum) cannot silently
+    # downgrade the install to unverified.
+    # Returns: 0 = fetched, 1 = 404 (not published), 2 = network/server failure.
+    fetch_sha() {
         url="$1"
         out="$2"
-        curl --fail --location --proto '=https' --tlsv1.2 \
+        http_code="$(curl --location --proto '=https' --tlsv1.2 \
              --connect-timeout 15 --max-time 60 \
-             -o "$out" "$url" 2>/dev/null
+             --retry 3 --retry-delay 1 \
+             -w '%{http_code}' -o "$out" "$url" 2>/dev/null)" || http_code="000"
+        case "$http_code" in
+            200) return 0 ;;
+            404) return 1 ;;
+            *)   return 2 ;;
+        esac
     }
 
     verify_archive_checksum() {
@@ -225,17 +235,25 @@ EOF
         fi
 
         sha_file="${archive}.sha256"
-        if fetch_optional "$sha_url" "$sha_file"; then
-            expected="$(awk '{print $1}' "$sha_file" | head -n1)"
-            [ -n "$expected" ] || err "downloaded .sha256 is empty or malformed"
-            actual="$(sha256_of "$archive")"
-            if [ "$expected" != "$actual" ]; then
-                err "SHA-256 mismatch for $(basename "$archive") — expected $expected, got $actual. Archive may be corrupt or tampered."
-            fi
-            info "checksum verified (SHA-256)"
-        else
-            info "no SHA-256 published for ${TAG} (older release?). Falling back to structural tarball check only."
-        fi
+        sha_rc=0
+        fetch_sha "$sha_url" "$sha_file" || sha_rc=$?
+        case "$sha_rc" in
+            0)
+                expected="$(awk '{print $1}' "$sha_file" | head -n1)"
+                [ -n "$expected" ] || err "downloaded .sha256 is empty or malformed"
+                actual="$(sha256_of "$archive")"
+                if [ "$expected" != "$actual" ]; then
+                    err "SHA-256 mismatch for $(basename "$archive") — expected $expected, got $actual. Archive may be corrupt or tampered."
+                fi
+                info "checksum verified (SHA-256)"
+                ;;
+            1)
+                info "no SHA-256 published for ${TAG} (older release). Falling back to structural tarball check only."
+                ;;
+            *)
+                err "could not download the SHA-256 checksum for ${TAG} (network or server error, not a missing file). Refusing to install an unverified archive; re-run the installer, or set HINA_NO_CHECKSUM=1 to bypass (not recommended)."
+                ;;
+        esac
     }
 
     acquire_lock() {
@@ -726,7 +744,19 @@ WARN
 
         mkdir -p "$(dirname "$rc_file")"
         tmp_rc="${rc_file}.hina-tmp.$$"
-        [ -f "$rc_file" ] && cp -p "$rc_file" "$tmp_rc" || : > "$tmp_rc"
+        # The copy MUST succeed before we mv the tmp over the user's rc file: with
+        # the old `[ -f ] && cp || : >` form a failing cp (unreadable file, disk
+        # full) truncated the tmp and the rename replaced the user's entire rc
+        # with just the hina block.
+        if [ -f "$rc_file" ]; then
+            if ! cp -p "$rc_file" "$tmp_rc"; then
+                rm -f "$tmp_rc"
+                info "could not read ${rc_file}; skipping PATH setup for it. Add manually: ${line_export}"
+                return 0
+            fi
+        else
+            : > "$tmp_rc"
+        fi
         {
             printf '\n%s\n' "$marker_begin"
             printf '%s\n' "$line_export"
@@ -753,7 +783,9 @@ WARN
                     fi
                     ;;
                 fish)
-                    modify_rc "${HOME}/.config/fish/config.fish" "set -gx PATH ${DEST} \$PATH"
+                    # Quote the dir in fish syntax: an install dir with a space
+                    # would otherwise split into two PATH entries.
+                    modify_rc "${HOME}/.config/fish/config.fish" "set -gx PATH \"${DEST}\" \$PATH"
                     ;;
                 *)
                     modify_rc "${HOME}/.profile" "export PATH=\"${DEST}:\$PATH\""


### PR DESCRIPTION
Round 10 targeted the never-hunted perimeter: the installer scripts and packaging. 6 user-reachable fixes in 3 commits, each reproduced empirically first (live runs against the published v1.4.2 release assets).

### install.sh (curl|sh installer)

1. **A failing rc-file copy destroyed the user's shell config.** `modify_rc` used the `[ -f ] && cp || : > tmp` pitfall: when the copy failed (unreadable file, disk full), the fallback truncated the tmp file and the atomic rename replaced the user's entire `.zshrc`/`.bashrc` with just the hina PATH block. Reproduced with `chmod 000 .zshrc` — the file was wiped. Now the copy must succeed or the file is skipped with a manual-add hint.
2. **Checksum verification silently skipped on any network error.** Every curl failure on the `.sha256` fetch was treated as "not published (older release?)" — a transient outage, or a MITM blocking just the checksum, downgraded the install to unverified. `fetch_sha` now distinguishes by HTTP code: only a real 404 may skip; anything else is a hard error (`HINA_NO_CHECKSUM=1` stays as the explicit bypass).
3. **fish PATH line unquoted** — an install dir with a space split into two PATH entries.

### install.ps1 (Windows installer)

4. **Non-interactive re-runs always reinstalled — and silently downgraded.** The version check compared `"hina 1.4.2"` (binary output) against `"v1.4.2"` (tag) with `-like`, which can never match: every scripted re-run re-downloaded the same version, and an installed build newer than the target was downgraded. Now mirrors install.sh (numeric semver compare: behind→upgrade, same/ahead→no-op). Verified under pwsh 7.6.
5. **Same checksum-skip-on-network-error bug as (2)** — fixed with HTTP-status classification, probed live (404 asset → skip allowed, connection refused → hard error, real `.sha256` → fetched).

### packaging/scoop

6. **`scoop install` was broken since the manifest was added.** The template declared `"extract_dir": "Hina-windows-x64"`, but release.yml zips the publish folder contents — `hina.exe` sits at the archive root (verified against the live v1.4.2 zip). Scoop was told to strip a directory that doesn't exist. Removed.

### Verified end-to-end
Full live install of v1.4.2 into a sandboxed HOME (download, checksum, PATH stanza, smoke test), idempotent re-run ("nothing to do"), `HINA_ACTION=verify` (integrity OK), `uninstall-binary` (binary removed, registry preserved). `sh -n`/`bash -n` and PowerShell AST parse clean.

### Observations (not fixed, documented)
- install.ps1 PATH editing via `SetEnvironmentVariable` expands `%VAR%` entries and writes REG_SZ; preserving REG_EXPAND_SZ needs a registry rewrite + WM_SETTINGCHANGE broadcast that can't be verified from this machine.
- Release archives ship `.pdb` files (40 MB `Hina.CLI.pdb`; 51 MB unzipped) — size optimization candidate in release.yml.
- `scripts/release.sh` (local fallback) archives a `Hina-<rid>/` subdir while CI archives root-level — self-consistent but divergent layouts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)