### PR TITLE
feat: hina-builder --common — shared files across platform variants

### DIFF
--- a/Hina.Builder.Tests/BuildCommandTests.cs
+++ b/Hina.Builder.Tests/BuildCommandTests.cs
@@ -1,5 +1,6 @@
 using System;
 using System.IO;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Hina.Builder;
@@ -173,6 +174,246 @@ namespace Hina.Builder.Tests
             File.WriteAllText(Path.Combine(_input, "game"), "x");
             int code = await BuildCommand.RunAsync(Opts("solaris-sparc"), NullLogger.Instance, CancellationToken.None);
             Assert.Equal(2, code);
+        }
+
+        // ---- --common: shared files merged into the variant build ----
+
+        private string MakeCommonDir(params (string RelPath, string Content)[] files)
+        {
+            string common = Path.Combine(_base, "common");
+            Directory.CreateDirectory(common);
+            foreach ((string rel, string content) in files)
+            {
+                string full = Path.Combine(common, rel.Replace('/', Path.DirectorySeparatorChar));
+                Directory.CreateDirectory(Path.GetDirectoryName(full)!);
+                File.WriteAllText(full, content);
+            }
+            return common;
+        }
+
+        [Fact]
+        public async Task Build_WithCommon_MergesCommonFilesIntoManifest()
+        {
+            File.WriteAllText(Path.Combine(_input, "game"), "linux binary");
+            string common = MakeCommonDir(("data/map0.mul", "map bytes"), ("art.mul", "art bytes"));
+
+            int code = await BuildCommand.RunAsync(new BuildOptions
+            {
+                Input = _input,
+                Output = _out,
+                BaseUrl = "https://patch.example.com/",
+                Version = "1.0.0",
+                ChunkingMode = "cdc",
+                Platform = "linux",
+                Common = common
+            }, NullLogger.Instance, CancellationToken.None);
+
+            Assert.Equal(0, code);
+            var manifest = await Hina.Core.Manifest.ManifestSerializer.ReadAsync(
+                Path.Combine(_out, "manifest.linux.json"), CancellationToken.None);
+            var paths = manifest.Files.Select(f => f.Path).ToList();
+            Assert.Contains("game", paths);
+            Assert.Contains("data/map0.mul", paths);
+            Assert.Contains("art.mul", paths);
+            Assert.True(Directory.Exists(Path.Combine(_out, "chunks")));
+        }
+
+        [Fact]
+        public async Task Build_WithCommon_NoPlatform_WritesMergedManifestJson()
+        {
+            File.WriteAllText(Path.Combine(_input, "game"), "binary");
+            string common = MakeCommonDir(("shared.dat", "shared"));
+
+            int code = await BuildCommand.RunAsync(new BuildOptions
+            {
+                Input = _input,
+                Output = _out,
+                BaseUrl = "https://patch.example.com/",
+                Version = "1.0.0",
+                ChunkingMode = "cdc",
+                Common = common
+            }, NullLogger.Instance, CancellationToken.None);
+
+            Assert.Equal(0, code);
+            var manifest = await Hina.Core.Manifest.ManifestSerializer.ReadAsync(
+                Path.Combine(_out, "manifest.json"), CancellationToken.None);
+            Assert.Contains(manifest.Files, f => f.Path == "shared.dat");
+            Assert.Contains(manifest.Files, f => f.Path == "game");
+        }
+
+        [Fact]
+        public async Task Build_WithCommon_VariantOverridesCommonFile_VariantWins_AndLogs()
+        {
+            File.WriteAllText(Path.Combine(_input, "config.ini"), "variant-version-longer");
+            string common = MakeCommonDir(("config.ini", "common"));
+            var log = new CapturingLogger();
+
+            int code = await BuildCommand.RunAsync(new BuildOptions
+            {
+                Input = _input,
+                Output = _out,
+                BaseUrl = "https://patch.example.com/",
+                Version = "1.0.0",
+                ChunkingMode = "cdc",
+                Platform = "linux",
+                Common = common
+            }, log, CancellationToken.None);
+
+            Assert.Equal(0, code);
+            var manifest = await Hina.Core.Manifest.ManifestSerializer.ReadAsync(
+                Path.Combine(_out, "manifest.linux.json"), CancellationToken.None);
+            var entry = Assert.Single(manifest.Files, f => f.Path == "config.ini");
+            Assert.Equal("variant-version-longer".Length, entry.Size);
+            Assert.Contains(log.Messages, m => m.Contains("config.ini") && m.Contains("overrides"));
+        }
+
+        [Fact]
+        public async Task Build_WithCommon_OverriddenCommonChunks_NotWrittenToStore()
+        {
+            // Learn the overridden common file's chunk names from a throwaway build of the
+            // common side alone, then assert none of them landed in the real store.
+            File.WriteAllText(Path.Combine(_input, "config.ini"), "variant-version-longer");
+            string common = MakeCommonDir(("config.ini", "common-only-content"));
+
+            string refOut = Path.Combine(_base, "ref-out");
+            int refCode = await BuildCommand.RunAsync(new BuildOptions
+            {
+                Input = common,
+                Output = refOut,
+                BaseUrl = "https://patch.example.com/",
+                Version = "1.0.0",
+                ChunkingMode = "cdc"
+            }, NullLogger.Instance, CancellationToken.None);
+            Assert.Equal(0, refCode);
+            string[] commonChunks = Directory.GetFiles(Path.Combine(refOut, "chunks"), "*.chunk.br", SearchOption.AllDirectories)
+                .Select(Path.GetFileName)
+                .ToArray()!;
+            Assert.NotEmpty(commonChunks);
+
+            int code = await BuildCommand.RunAsync(new BuildOptions
+            {
+                Input = _input,
+                Output = _out,
+                BaseUrl = "https://patch.example.com/",
+                Version = "1.0.0",
+                ChunkingMode = "cdc",
+                Platform = "linux",
+                Common = common
+            }, NullLogger.Instance, CancellationToken.None);
+            Assert.Equal(0, code);
+
+            string[] storeChunks = Directory.GetFiles(Path.Combine(_out, "chunks"), "*.chunk.br", SearchOption.AllDirectories)
+                .Select(Path.GetFileName)
+                .ToArray()!;
+            foreach (string chunk in commonChunks)
+            {
+                Assert.DoesNotContain(chunk, storeChunks);
+            }
+        }
+
+        [Fact]
+        public async Task Build_CommonNotFound_FailsWithUsageError()
+        {
+            File.WriteAllText(Path.Combine(_input, "game"), "x");
+            var log = new CapturingLogger();
+
+            int code = await BuildCommand.RunAsync(new BuildOptions
+            {
+                Input = _input,
+                Output = _out,
+                BaseUrl = "https://patch.example.com/",
+                Common = Path.Combine(_base, "absent")
+            }, log, CancellationToken.None);
+
+            Assert.Equal(2, code);
+            Assert.Contains(log.Messages, m => m.Contains("--common"));
+        }
+
+        [Theory]
+        [InlineData("in/shared")]   // --common inside --input
+        [InlineData("in")]          // --common == --input
+        public async Task Build_CommonOverlappingInput_FailsWithUsageError(string relCommon)
+        {
+            File.WriteAllText(Path.Combine(_input, "game"), "x");
+            string common = Path.Combine(_base, relCommon.Replace('/', Path.DirectorySeparatorChar));
+            Directory.CreateDirectory(common);
+            var log = new CapturingLogger();
+
+            int code = await BuildCommand.RunAsync(new BuildOptions
+            {
+                Input = _input,
+                Output = _out,
+                BaseUrl = "https://patch.example.com/",
+                Common = common
+            }, log, CancellationToken.None);
+
+            Assert.Equal(2, code);
+            Assert.Contains(log.Messages, m => m.Contains("--common"));
+        }
+
+        [Fact]
+        public async Task Build_InputInsideCommon_FailsWithUsageError()
+        {
+            // The whole --input tree would also be enumerated as common content.
+            string common = Path.Combine(_base, "tree");
+            string input = Path.Combine(common, "variant");
+            Directory.CreateDirectory(input);
+            File.WriteAllText(Path.Combine(input, "game"), "x");
+
+            int code = await BuildCommand.RunAsync(new BuildOptions
+            {
+                Input = input,
+                Output = _out,
+                BaseUrl = "https://patch.example.com/",
+                Common = common
+            }, NullLogger.Instance, CancellationToken.None);
+
+            Assert.Equal(2, code);
+        }
+
+        [Fact]
+        public async Task Build_OutInsideCommon_FailsWithUsageError()
+        {
+            File.WriteAllText(Path.Combine(_input, "game"), "x");
+            string common = MakeCommonDir(("shared.dat", "s"));
+
+            int code = await BuildCommand.RunAsync(new BuildOptions
+            {
+                Input = _input,
+                Output = Path.Combine(common, "store"),
+                BaseUrl = "https://patch.example.com/",
+                Common = common
+            }, NullLogger.Instance, CancellationToken.None);
+
+            Assert.Equal(2, code);
+        }
+
+        [Fact]
+        public async Task Build_CommonInsideOut_FailsWithUsageError()
+        {
+            File.WriteAllText(Path.Combine(_input, "game"), "x");
+            string common = Path.Combine(_out, "common");
+            Directory.CreateDirectory(common);
+
+            int code = await BuildCommand.RunAsync(new BuildOptions
+            {
+                Input = _input,
+                Output = _out,
+                BaseUrl = "https://patch.example.com/",
+                Common = common
+            }, NullLogger.Instance, CancellationToken.None);
+
+            Assert.Equal(2, code);
+        }
+
+        private sealed class CapturingLogger : Microsoft.Extensions.Logging.ILogger
+        {
+            public System.Collections.Generic.List<string> Messages { get; } = new();
+            public IDisposable? BeginScope<TState>(TState state) where TState : notnull => null;
+            public bool IsEnabled(Microsoft.Extensions.Logging.LogLevel logLevel) => true;
+            public void Log<TState>(Microsoft.Extensions.Logging.LogLevel logLevel, Microsoft.Extensions.Logging.EventId eventId,
+                TState state, Exception? exception, Func<TState, Exception?, string> formatter)
+                => Messages.Add(formatter(state, exception));
         }
     }
 }

--- a/Hina.Builder.Tests/InitCommandTests.cs
+++ b/Hina.Builder.Tests/InitCommandTests.cs
@@ -158,6 +158,69 @@ namespace Hina.Builder.Tests
         }
 
         [Fact]
+        public async Task Init_VariantSubdirsWithCommonFolder_MergesCommonIntoEveryVariantManifest()
+        {
+            WriteBin("windows-x64", "Game.exe", new byte[] { 0x4D, 0x5A, 0x90, 0x00 });   // PE
+            WriteBin("linux", "game", new byte[] { 0x7F, 0x45, 0x4C, 0x46 });              // ELF
+            string commonDir = Path.Combine(_payload, "common");
+            Directory.CreateDirectory(commonDir);
+            await File.WriteAllTextAsync(Path.Combine(commonDir, "shared.dat"), "game data shared by every OS");
+
+            ScriptedPrompt script = new ScriptedPrompt(
+                asks: new[]
+                {
+                    "mygame", "My Game", "1.2.3", "Acme", "A fun game", "",
+                    "https://patch.example.com/",
+                    _out
+                },
+                confirms: new[]
+                {
+                    true, true,   // use detected exec for each of the 2 variants
+                    true,         // sandbox
+                    true,         // internet
+                    true          // generate key
+                },
+                chooses: new[] { 1 });
+
+            int code = await InitCommand.RunAsync(
+                new[] { "init", "--input", _payload }, script, NullLogger.Instance, CancellationToken.None);
+
+            Assert.Equal(0, code);
+
+            string patch = Path.Combine(_out, "patch");
+            foreach (string manifestName in new[] { "manifest.windows-x64.json", "manifest.linux.json" })
+            {
+                var manifest = await Hina.Core.Manifest.ManifestSerializer.ReadAsync(
+                    Path.Combine(patch, manifestName), CancellationToken.None);
+                // Shared file present at its root-relative path, NOT under a common/ prefix.
+                Assert.Contains(manifest.Files, f => f.Path == "shared.dat");
+                Assert.DoesNotContain(manifest.Files, f => f.Path.StartsWith("common/", StringComparison.Ordinal));
+            }
+        }
+
+        [Fact]
+        public async Task Init_SinglePayloadWithCommonSubfolder_PackagedAsOrdinaryContent()
+        {
+            // No variant subdirs: a folder named "common" is just app content and keeps its
+            // path prefix in the manifest.
+            WriteElf("game");
+            string commonDir = Path.Combine(_payload, "common");
+            Directory.CreateDirectory(commonDir);
+            await File.WriteAllTextAsync(Path.Combine(commonDir, "shared.dat"), "asset");
+
+            int code = await InitCommand.RunAsync(
+                new[] { "init", "--input", _payload },
+                SingleLinuxScript(),
+                NullLogger.Instance,
+                CancellationToken.None);
+
+            Assert.Equal(0, code);
+            var manifest = await Hina.Core.Manifest.ManifestSerializer.ReadAsync(
+                Path.Combine(_out, "patch", "manifest.json"), CancellationToken.None);
+            Assert.Contains(manifest.Files, f => f.Path == "common/shared.dat");
+        }
+
+        [Fact]
         public async Task Init_ReRun_UsesExistingDescriptorAsDefaults()
         {
             WriteElf("game");

--- a/Hina.Builder/BuildCommand.cs
+++ b/Hina.Builder/BuildCommand.cs
@@ -1,10 +1,13 @@
 using System;
+using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Hina.Core.Cli;
 using Hina.Core.Chunking;
 using Hina.Core.Hashing;
+using Hina.Core.Inputs;
 using Hina.Core.Manifest;
 using Hina.Core.Rsync;
 using Microsoft.Extensions.Logging;
@@ -32,9 +35,15 @@ namespace Hina.Builder
         // so each variant's build dedupes common chunks against the others.
         public string? Platform { get; init; }
 
+        // Optional shared-files folder merged into the build (game data identical across
+        // variants). On a relative-path collision the --input copy wins, so a variant can
+        // still override a shared asset.
+        public string? Common { get; init; }
+
         public static BuildOptions FromArgs(string[] args) => new BuildOptions
         {
             Platform = Args.GetValue(args, "--platform"),
+            Common = Args.GetValue(args, "--common"),
             Input = Args.GetValue(args, "--input") ?? string.Empty,
             Output = Args.GetValue(args, "--out") ?? string.Empty,
             BaseUrl = Args.GetValue(args, "--base") ?? string.Empty,
@@ -86,6 +95,32 @@ namespace Hina.Builder
                 return 2;
             }
 
+            if (!string.IsNullOrWhiteSpace(options.Common))
+            {
+                if (!Directory.Exists(options.Common))
+                {
+                    logger.LogError("--common folder not found: {Common}", options.Common);
+                    return 2;
+                }
+                if (IsInside(options.Common, options.Input) || IsInside(options.Input, options.Common))
+                {
+                    logger.LogError("--common '{Common}' must not be inside --input '{Input}' (or contain it): its files would be packaged twice.",
+                        options.Common, options.Input);
+                    return 2;
+                }
+                if (IsInside(options.Output, options.Common))
+                {
+                    logger.LogError("--out '{Out}' must be outside the --common folder '{Common}': the manifest and chunk store would be picked up as shared files by the next build.",
+                        options.Output, options.Common);
+                    return 2;
+                }
+                if (IsInside(options.Common, options.Output))
+                {
+                    logger.LogError("--common '{Common}' must be outside --out '{Out}'.", options.Common, options.Output);
+                    return 2;
+                }
+            }
+
             string manifestName = "manifest.json";
             if (!string.IsNullOrEmpty(options.Platform))
             {
@@ -124,8 +159,34 @@ namespace Hina.Builder
                 logger.LogError("--base '{Url}' is not a valid absolute URL (expected e.g. https://cdn.example.com/mygame/).", options.BaseUrl);
                 return 2;
             }
+            // One resolved file set consumed by BOTH the manifest and the chunk store, so the
+            // two can never disagree. Roots in precedence order: common first, --input last
+            // (variant wins on a relative-path collision).
+            List<DirectoryInfo> roots = new List<DirectoryInfo>();
+            if (!string.IsNullOrWhiteSpace(options.Common))
+            {
+                roots.Add(new DirectoryInfo(options.Common));
+            }
+            roots.Add(inputDir);
+            InputSet inputs = InputSet.Resolve(roots);
+
+            if (roots.Count > 1)
+            {
+                int variantCount = inputs.Files.Count(f => f.SourceRoot == inputDir.FullName);
+                logger.LogInformation("Merging shared files from {Common}: {CommonCount} common + {VariantCount} variant files ({OverrideCount} overridden by the variant).",
+                    roots[0].FullName, inputs.Files.Count - variantCount, variantCount, inputs.Overrides.Count);
+                foreach (InputOverride ov in inputs.Overrides)
+                {
+                    logger.LogInformation("Variant overrides common file: {Path}", ov.RelativePath);
+                }
+            }
+            foreach (string clash in inputs.CaseClashes)
+            {
+                logger.LogWarning("Paths differing only by case will collide on Windows/macOS installs: {Path}", clash);
+            }
+
             logger.LogInformation("Building manifest from {InputDir}", inputDir.FullName);
-            Manifest manifest = await manifestBuilder.BuildAsync(inputDir, baseUri, options.ChunkSize, chunker, ct);
+            Manifest manifest = await manifestBuilder.BuildAsync(inputs, baseUri, options.ChunkSize, chunker, ct);
             manifest.Version = options.Version;
             if (!string.IsNullOrWhiteSpace(options.SignKeyPath))
             {
@@ -150,7 +211,7 @@ namespace Hina.Builder
 
             outputDir.Create();
             await ManifestSerializer.WriteAsync(manifest, Path.Combine(outputDir.FullName, manifestName), ct);
-            await chunkWriter.WriteChunksAsync(inputDir, chunkDir, ct);
+            await chunkWriter.WriteChunksAsync(inputs, chunkDir, ct);
 
             logger.LogInformation("Build complete");
             logger.LogInformation("Manifest: {ManifestPath}", Path.Combine(outputDir.FullName, manifestName));

--- a/Hina.Builder/Init/InitCommand.cs
+++ b/Hina.Builder/Init/InitCommand.cs
@@ -55,10 +55,16 @@ namespace Hina.Builder.Init
             List<PlatformVariant> platforms = new List<PlatformVariant>();
             List<VariantDir> variantDirs = DetectVariantDirs(input);
 
+            DirectoryInfo? commonDir = null;
             if (variantDirs.Count > 0)
             {
                 Console.WriteLine();
                 Console.WriteLine($"Detected {variantDirs.Count} platform variant folder(s); building one manifest per variant.");
+                commonDir = DetectCommonDir(input);
+                if (commonDir != null)
+                {
+                    Console.WriteLine("Found shared folder 'common/'; its files will be merged into every variant (variant files win on conflict).");
+                }
                 platforms = CollectVariants(prompt, variantDirs, logger);
                 if (platforms.Count == 0)
                 {
@@ -159,7 +165,8 @@ namespace Hina.Builder.Init
                         Version = version,
                         SignKeyPath = keyPath,
                         ChunkingMode = "cdc",
-                        Platform = vd.Token
+                        Platform = vd.Token,
+                        Common = commonDir?.FullName
                     }, logger, ct);
                     if (code != 0)
                     {
@@ -313,6 +320,13 @@ namespace Hina.Builder.Init
             public string? Arch { get; init; }
             public DirectoryInfo Dir { get; init; } = null!;
         }
+
+        // In variant mode, a sibling subfolder literally named "common" holds files shared by
+        // every variant (merged at build time; the variant's copy wins on a path conflict).
+        // Exact Ordinal match: on Linux "common" and "Common" can coexist, so a case-insensitive
+        // match would be ambiguous. In single-payload mode the folder is ordinary content.
+        private static DirectoryInfo? DetectCommonDir(DirectoryInfo input)
+            => input.EnumerateDirectories().FirstOrDefault(d => string.Equals(d.Name, "common", StringComparison.Ordinal));
 
         // Immediate subdirs whose NAME is a valid platform token (os[-arch]) are treated as
         // per-platform variant folders. None ⇒ single-payload mode.

--- a/Hina.Builder/Program.cs
+++ b/Hina.Builder/Program.cs
@@ -71,8 +71,9 @@ namespace Hina.Builder
             Console.WriteLine("  hina-builder init [--input <dir>]");
             Console.WriteLine("      Interactive wizard: scans the folder, asks a few questions, and generates a");
             Console.WriteLine("      signed hina.app.json plus the manifest/chunk store ready to host.");
-            Console.WriteLine("  hina-builder build --input <dir> --out <dir> --base <url> [--platform <os[-arch]>] [--version v] [--chunk 65536] [--chunking fixed|cdc] [--min-chunk 2048] [--max-chunk 65536] [--avg-chunk 8192] [--sign-key key.b64] [-v|--verbose]");
+            Console.WriteLine("  hina-builder build --input <dir> --out <dir> --base <url> [--platform <os[-arch]>] [--common <dir>] [--version v] [--chunk 65536] [--chunking fixed|cdc] [--min-chunk 2048] [--max-chunk 65536] [--avg-chunk 8192] [--sign-key key.b64] [-v|--verbose]");
             Console.WriteLine("      --platform writes manifest.<token>.json (one per variant) into a shared chunk store.");
+            Console.WriteLine("      --common merges a shared-files folder into the build; on a path conflict the --input copy wins.");
             Console.WriteLine("  hina-builder keygen [--out <dir>] [--name <prefix>]");
         }
     }

--- a/Hina.Core.Tests/CommonMergeRoundTripTests.cs
+++ b/Hina.Core.Tests/CommonMergeRoundTripTests.cs
@@ -1,0 +1,129 @@
+using System;
+using System.IO;
+using System.Net.Http;
+using System.Reflection;
+using System.Threading;
+using System.Threading.Tasks;
+using Hina.Core.Chunking;
+using Hina.Core.Configuration;
+using Hina.Core.Hashing;
+using Hina.Core.Inputs;
+using Hina.Core.Manifest;
+using Hina.Core.Net;
+using Hina.Core.Patching;
+using Xunit;
+
+namespace Hina.Core.Tests
+{
+    // End-to-end proof for the --common merge: a manifest built from [common, variant]
+    // installs both trees into one client root, and a later change to a COMMON file
+    // delta-updates exactly that file (the variant's binary is not re-downloaded).
+    public class CommonMergeRoundTripTests : IDisposable
+    {
+        private readonly string _tempRoot;
+        private readonly string _commonDir;
+        private readonly string _variantDir;
+        private readonly string _buildOutputDir;
+        private readonly string _targetDir;
+        private readonly Uri _baseUrl = new Uri("http://test.local/");
+        private const int ChunkSize = 4096;
+
+        public CommonMergeRoundTripTests()
+        {
+            _tempRoot = Path.Combine(Path.GetTempPath(), "hina_common_rt_" + Guid.NewGuid().ToString("N"));
+            _commonDir = Path.Combine(_tempRoot, "common");
+            _variantDir = Path.Combine(_tempRoot, "variant");
+            _buildOutputDir = Path.Combine(_tempRoot, "build");
+            _targetDir = Path.Combine(_tempRoot, "target");
+            Directory.CreateDirectory(_commonDir);
+            Directory.CreateDirectory(_variantDir);
+            Directory.CreateDirectory(_buildOutputDir);
+            Directory.CreateDirectory(_targetDir);
+        }
+
+        public void Dispose()
+        {
+            try { Directory.Delete(_tempRoot, recursive: true); } catch { /* best effort */ }
+        }
+
+        [Fact]
+        public async Task BuildWithMergedCommon_ChangedCommonFile_DeltaUpdatesClient()
+        {
+            WriteFile(_commonDir, "data/map0.mul", "shared map data v1");
+            WriteFile(_variantDir, "game.bin", "platform binary");
+
+            await RunMergedBuildAsync("1.0.0");
+            PatchResult v1 = await CreatePatchClient().PatchAsync(_targetDir, CancellationToken.None);
+            Assert.True(v1.Success, $"v1 patch failed: {v1.Message}");
+            Assert.Equal("shared map data v1", File.ReadAllText(Path.Combine(_targetDir, "data", "map0.mul")));
+            Assert.Equal("platform binary", File.ReadAllText(Path.Combine(_targetDir, "game.bin")));
+
+            // Clean the journal so the v2 patch does not roll back v1.
+            string journalPath = PatchJournal.GetJournalPath(_targetDir);
+            if (File.Exists(journalPath)) File.Delete(journalPath);
+
+            // Only the COMMON file changes (the game data updated; the binary did not).
+            WriteFile(_commonDir, "data/map0.mul", "shared map data v2 - patched");
+            await RunMergedBuildAsync("1.0.1");
+
+            PatchResult v2 = await CreatePatchClient().PatchAsync(_targetDir, CancellationToken.None);
+
+            Assert.True(v2.Success, $"v2 patch failed: {v2.Message}");
+            Assert.Single(v2.AppliedFiles);
+            Assert.Contains("data/map0.mul", v2.AppliedFiles);
+            Assert.Equal("shared map data v2 - patched", File.ReadAllText(Path.Combine(_targetDir, "data", "map0.mul")));
+            Assert.Equal("platform binary", File.ReadAllText(Path.Combine(_targetDir, "game.bin")));
+        }
+
+        private static void WriteFile(string root, string relPath, string content)
+        {
+            string full = Path.Combine(root, relPath.Replace('/', Path.DirectorySeparatorChar));
+            Directory.CreateDirectory(Path.GetDirectoryName(full)!);
+            File.WriteAllText(full, content);
+        }
+
+        private async Task RunMergedBuildAsync(string version)
+        {
+            IHasher hasher = new Sha256Hasher();
+            ManifestBuilder builder = new ManifestBuilder(hasher);
+            ChunkStoreWriter chunkWriter = new ChunkStoreWriter(hasher, ChunkSize);
+            DirectoryInfo chunkDir = new DirectoryInfo(Path.Combine(_buildOutputDir, "chunks"));
+
+            // Same precedence order as BuildCommand: common first, variant last (wins).
+            InputSet inputs = InputSet.Resolve(new[]
+            {
+                new DirectoryInfo(_commonDir),
+                new DirectoryInfo(_variantDir)
+            });
+
+            Manifest.Manifest manifest = await builder.BuildAsync(
+                inputs, _baseUrl, ChunkSize, new Hina.Core.Rsync.RsyncChunker(ChunkSize, hasher), CancellationToken.None);
+            manifest.Version = version;
+
+            await ManifestSerializer.WriteAsync(manifest, Path.Combine(_buildOutputDir, "manifest.json"), CancellationToken.None);
+            await chunkWriter.WriteChunksAsync(inputs, chunkDir, CancellationToken.None);
+        }
+
+        private PatchClient CreatePatchClient()
+        {
+            PatcherConfig config = new PatcherConfig
+            {
+                BaseUrl = _baseUrl,
+                Channel = "stable",
+                ChunkSize = ChunkSize,
+                Verify = true,
+                Backup = true,
+                TrustedPublicKey = null
+            };
+
+            PatchClient client = new PatchClient(config);
+
+            var httpChunkClient = new HttpChunkClient(new HttpClient(new LocalChunkHandler(_buildOutputDir)));
+            FieldInfo? httpField = typeof(PatchClient).GetField("_http", BindingFlags.NonPublic | BindingFlags.Instance);
+            Assert.NotNull(httpField);
+            httpField!.SetValue(client, httpChunkClient);
+
+            return client;
+        }
+    }
+}

--- a/Hina.Core.Tests/InputSetTests.cs
+++ b/Hina.Core.Tests/InputSetTests.cs
@@ -1,0 +1,147 @@
+using System;
+using System.IO;
+using System.Linq;
+using Hina.Core.Inputs;
+using Xunit;
+
+namespace Hina.Core.Tests
+{
+    public class InputSetTests : IDisposable
+    {
+        private readonly string _tempDir;
+
+        public InputSetTests()
+        {
+            _tempDir = Path.Combine(Path.GetTempPath(), "hina-inputset-" + Path.GetRandomFileName());
+            Directory.CreateDirectory(_tempDir);
+        }
+
+        public void Dispose()
+        {
+            try { Directory.Delete(_tempDir, recursive: true); } catch { /* best effort */ }
+        }
+
+        private DirectoryInfo Root(string name, params (string RelPath, string Content)[] files)
+        {
+            string root = Path.Combine(_tempDir, name);
+            foreach ((string rel, string content) in files)
+            {
+                string full = Path.Combine(root, rel.Replace('/', Path.DirectorySeparatorChar));
+                Directory.CreateDirectory(Path.GetDirectoryName(full)!);
+                File.WriteAllText(full, content);
+            }
+            Directory.CreateDirectory(root);
+            return new DirectoryInfo(root);
+        }
+
+        [Fact]
+        public void Resolve_SingleRoot_ListsAllFilesSortedByRelativePath_WithForwardSlashes()
+        {
+            DirectoryInfo root = Root("single",
+                ("sub/dir/b.dat", "b"),
+                ("a.txt", "a"),
+                ("sub/c.bin", "c"));
+
+            InputSet set = InputSet.Resolve(new[] { root });
+
+            Assert.Equal(new[] { "a.txt", "sub/c.bin", "sub/dir/b.dat" }, set.Files.Select(f => f.RelativePath));
+            Assert.All(set.Files, f => Assert.DoesNotContain('\\', f.RelativePath));
+            Assert.All(set.Files, f => Assert.True(File.Exists(f.AbsolutePath)));
+            Assert.All(set.Files, f => Assert.Equal(root.FullName, f.SourceRoot));
+            Assert.Empty(set.Overrides);
+            Assert.Empty(set.CaseClashes);
+        }
+
+        [Fact]
+        public void Resolve_MissingRoot_ThrowsDirectoryNotFound()
+        {
+            DirectoryInfo missing = new DirectoryInfo(Path.Combine(_tempDir, "nope"));
+            Assert.Throws<DirectoryNotFoundException>(() => InputSet.Resolve(new[] { missing }));
+        }
+
+        [Fact]
+        public void Resolve_TwoRoots_DisjointSets_MergesAll_NoOverrides()
+        {
+            DirectoryInfo common = Root("common", ("data/map0.mul", "map"), ("art.mul", "art"));
+            DirectoryInfo variant = Root("variant", ("game.exe", "exe"));
+
+            InputSet set = InputSet.Resolve(new[] { common, variant });
+
+            Assert.Equal(new[] { "art.mul", "data/map0.mul", "game.exe" }, set.Files.Select(f => f.RelativePath));
+            Assert.Empty(set.Overrides);
+        }
+
+        [Fact]
+        public void Resolve_SameRelativePathInBothRoots_LaterRootWins_AndOverrideRecorded()
+        {
+            DirectoryInfo common = Root("common", ("config.ini", "common-version"));
+            DirectoryInfo variant = Root("variant", ("config.ini", "variant-version"));
+
+            InputSet set = InputSet.Resolve(new[] { common, variant });
+
+            InputFile file = Assert.Single(set.Files);
+            Assert.Equal("config.ini", file.RelativePath);
+            Assert.Equal(variant.FullName, file.SourceRoot);
+            Assert.Equal("variant-version", File.ReadAllText(file.AbsolutePath));
+
+            InputOverride ov = Assert.Single(set.Overrides);
+            Assert.Equal("config.ini", ov.RelativePath);
+            Assert.Equal(variant.FullName, ov.WinningRoot);
+            Assert.Equal(common.FullName, ov.OverriddenRoot);
+        }
+
+        [Fact]
+        public void Resolve_EmptyCommonRoot_YieldsVariantFilesOnly()
+        {
+            DirectoryInfo common = Root("common");
+            DirectoryInfo variant = Root("variant", ("game.exe", "exe"));
+
+            InputSet set = InputSet.Resolve(new[] { common, variant });
+
+            Assert.Equal(new[] { "game.exe" }, set.Files.Select(f => f.RelativePath));
+            Assert.Empty(set.Overrides);
+        }
+
+        [Fact]
+        public void Resolve_NestedPathCollision_DetectedAcrossSubdirectories()
+        {
+            DirectoryInfo common = Root("common", ("data/maps/map0.mul", "old"));
+            DirectoryInfo variant = Root("variant", ("data/maps/map0.mul", "new"));
+
+            InputSet set = InputSet.Resolve(new[] { common, variant });
+
+            InputFile file = Assert.Single(set.Files);
+            Assert.Equal("data/maps/map0.mul", file.RelativePath);
+            Assert.Equal("new", File.ReadAllText(file.AbsolutePath));
+            Assert.Single(set.Overrides);
+        }
+
+        [Fact]
+        public void Resolve_CaseDifferingPaths_RemainDistinctFiles_ButReportedAsCaseClash()
+        {
+            // Distinct ordinal keys (Linux-correct: two different files), but on a
+            // case-insensitive filesystem (Windows/macOS) they would land on the same
+            // installed path - the set must surface that hazard.
+            DirectoryInfo common = Root("common", ("Data/readme.txt", "upper"));
+            DirectoryInfo variant = Root("variant", ("data/readme.txt", "lower"));
+
+            InputSet set = InputSet.Resolve(new[] { common, variant });
+
+            Assert.Equal(2, set.Files.Count);
+            Assert.Empty(set.Overrides);
+            string clash = Assert.Single(set.CaseClashes);
+            Assert.Equal("data/readme.txt", clash, ignoreCase: true);
+        }
+
+        [Fact]
+        public void Resolve_DeterministicOrder_SortedOrdinal()
+        {
+            // Ordinal sort: uppercase 'Z' (0x5A) sorts before lowercase 'a' (0x61).
+            DirectoryInfo root = Root("order", ("a.txt", "1"), ("Z.txt", "2"));
+
+            InputSet set = InputSet.Resolve(new[] { root });
+
+            Assert.Equal(new[] { "Z.txt", "a.txt" }, set.Files.Select(f => f.RelativePath));
+        }
+    }
+}

--- a/Hina.Core.Tests/IntegrationTests.cs
+++ b/Hina.Core.Tests/IntegrationTests.cs
@@ -389,56 +389,7 @@ namespace Hina.Core.Tests
             Assert.Equal(sourceBytes, targetBytes);
         }
 
-        /// <summary>
-        /// HttpMessageHandler that serves manifest.json and chunk files from a local
-        /// build output directory, simulating the remote HTTP server.
-        /// </summary>
-        private sealed class LocalChunkHandler : HttpMessageHandler
-        {
-            private readonly string _buildOutputDir;
-
-            public LocalChunkHandler(string buildOutputDir)
-            {
-                _buildOutputDir = buildOutputDir;
-            }
-
-            protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
-            {
-                string path = request.RequestUri!.AbsolutePath.TrimStart('/');
-
-                // Manifest requests.
-                if (path.StartsWith("manifest", StringComparison.OrdinalIgnoreCase) && path.EndsWith(".json", StringComparison.OrdinalIgnoreCase))
-                {
-                    string manifestPath = Path.Combine(_buildOutputDir, "manifest.json");
-                    if (File.Exists(manifestPath))
-                    {
-                        byte[] data = File.ReadAllBytes(manifestPath);
-                        var response = new HttpResponseMessage(HttpStatusCode.OK)
-                        {
-                            Content = new ByteArrayContent(data)
-                        };
-                        response.Content.Headers.ContentType = new System.Net.Http.Headers.MediaTypeHeaderValue("application/json");
-                        return Task.FromResult(response);
-                    }
-                }
-
-                // Chunk requests: chunks/{bucket}/{hash}.chunk.br
-                if (path.StartsWith("chunks/", StringComparison.OrdinalIgnoreCase))
-                {
-                    string chunkPath = Path.Combine(_buildOutputDir, path.Replace('/', Path.DirectorySeparatorChar));
-                    if (File.Exists(chunkPath))
-                    {
-                        byte[] data = File.ReadAllBytes(chunkPath);
-                        var response = new HttpResponseMessage(HttpStatusCode.OK)
-                        {
-                            Content = new ByteArrayContent(data)
-                        };
-                        return Task.FromResult(response);
-                    }
-                }
-
-                return Task.FromResult(new HttpResponseMessage(HttpStatusCode.NotFound));
-            }
-        }
+        // LocalChunkHandler (fake HTTP server over the build output) lives in its own file,
+        // shared with CommonMergeRoundTripTests.
     }
 }

--- a/Hina.Core.Tests/LocalChunkHandler.cs
+++ b/Hina.Core.Tests/LocalChunkHandler.cs
@@ -1,0 +1,59 @@
+using System;
+using System.IO;
+using System.Net;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Hina.Core.Tests
+{
+    // HttpMessageHandler that serves manifest.json and chunk files from a local
+    // build output directory, simulating the remote HTTP server.
+    internal sealed class LocalChunkHandler : HttpMessageHandler
+    {
+        private readonly string _buildOutputDir;
+
+        public LocalChunkHandler(string buildOutputDir)
+        {
+            _buildOutputDir = buildOutputDir;
+        }
+
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            string path = request.RequestUri!.AbsolutePath.TrimStart('/');
+
+            // Manifest requests.
+            if (path.StartsWith("manifest", StringComparison.OrdinalIgnoreCase) && path.EndsWith(".json", StringComparison.OrdinalIgnoreCase))
+            {
+                string manifestPath = Path.Combine(_buildOutputDir, "manifest.json");
+                if (File.Exists(manifestPath))
+                {
+                    byte[] data = File.ReadAllBytes(manifestPath);
+                    var response = new HttpResponseMessage(HttpStatusCode.OK)
+                    {
+                        Content = new ByteArrayContent(data)
+                    };
+                    response.Content.Headers.ContentType = new System.Net.Http.Headers.MediaTypeHeaderValue("application/json");
+                    return Task.FromResult(response);
+                }
+            }
+
+            // Chunk requests: chunks/{bucket}/{hash}.chunk.br
+            if (path.StartsWith("chunks/", StringComparison.OrdinalIgnoreCase))
+            {
+                string chunkPath = Path.Combine(_buildOutputDir, path.Replace('/', Path.DirectorySeparatorChar));
+                if (File.Exists(chunkPath))
+                {
+                    byte[] data = File.ReadAllBytes(chunkPath);
+                    var response = new HttpResponseMessage(HttpStatusCode.OK)
+                    {
+                        Content = new ByteArrayContent(data)
+                    };
+                    return Task.FromResult(response);
+                }
+            }
+
+            return Task.FromResult(new HttpResponseMessage(HttpStatusCode.NotFound));
+        }
+    }
+}

--- a/Hina.Core/Chunking/ChunkStoreWriter.cs
+++ b/Hina.Core/Chunking/ChunkStoreWriter.cs
@@ -5,6 +5,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Hina.Core.Compression;
 using Hina.Core.Hashing;
+using Hina.Core.Inputs;
 using Hina.Core.Manifest;
 using Hina.Core.Rsync;
 
@@ -32,30 +33,30 @@ namespace Hina.Core.Chunking
 
         public async Task WriteChunksAsync(DirectoryInfo root, DirectoryInfo chunkStoreDir, CancellationToken ct)
         {
-            if (!root.Exists)
-            {
-                throw new DirectoryNotFoundException(root.FullName);
-            }
+            await WriteChunksAsync(InputSet.Resolve(new[] { root }), chunkStoreDir, ct);
+        }
 
+        public async Task WriteChunksAsync(InputSet inputs, DirectoryInfo chunkStoreDir, CancellationToken ct)
+        {
             chunkStoreDir.Create();
 
             if (_chunker != null)
             {
-                await WriteChunksWithChunkerAsync(root, chunkStoreDir, ct);
+                await WriteChunksWithChunkerAsync(inputs.Files, chunkStoreDir, ct);
             }
             else
             {
-                await WriteChunksFixedAsync(root, chunkStoreDir, ct);
+                await WriteChunksFixedAsync(inputs.Files, chunkStoreDir, ct);
             }
         }
 
-        private async Task WriteChunksWithChunkerAsync(DirectoryInfo root, DirectoryInfo chunkStoreDir, CancellationToken ct)
+        private async Task WriteChunksWithChunkerAsync(IReadOnlyList<InputFile> files, DirectoryInfo chunkStoreDir, CancellationToken ct)
         {
-            foreach (string filePath in Directory.EnumerateFiles(root.FullName, "*", SearchOption.AllDirectories))
+            foreach (InputFile file in files)
             {
                 ct.ThrowIfCancellationRequested();
 
-                byte[] fileData = await File.ReadAllBytesAsync(filePath, ct);
+                byte[] fileData = await File.ReadAllBytesAsync(file.AbsolutePath, ct);
                 List<ManifestChunk> chunks;
                 using (var ms = new MemoryStream(fileData))
                 {
@@ -87,14 +88,14 @@ namespace Hina.Core.Chunking
             }
         }
 
-        private async Task WriteChunksFixedAsync(DirectoryInfo root, DirectoryInfo chunkStoreDir, CancellationToken ct)
+        private async Task WriteChunksFixedAsync(IReadOnlyList<InputFile> files, DirectoryInfo chunkStoreDir, CancellationToken ct)
         {
             // Store chunks by strong hash so clients can fetch missing blocks.
-            foreach (string filePath in Directory.EnumerateFiles(root.FullName, "*", SearchOption.AllDirectories))
+            foreach (InputFile file in files)
             {
                 ct.ThrowIfCancellationRequested();
 
-                using (FileStream fs = File.OpenRead(filePath))
+                using (FileStream fs = File.OpenRead(file.AbsolutePath))
                 {
                     long fileOffset = 0;
                     int index = 0;

--- a/Hina.Core/Inputs/InputFile.cs
+++ b/Hina.Core/Inputs/InputFile.cs
@@ -1,0 +1,15 @@
+namespace Hina.Core.Inputs
+{
+    // One file selected for packaging: where it lives on disk and the
+    // '/'-separated path it will have inside the manifest / install root.
+    public sealed class InputFile
+    {
+        public string AbsolutePath { get; init; } = string.Empty;
+        public string RelativePath { get; init; } = string.Empty;
+
+        // Full path of the input root this file was taken from. With merged
+        // roots this tells overrides apart (the winning root differs from the
+        // overridden one).
+        public string SourceRoot { get; init; } = string.Empty;
+    }
+}

--- a/Hina.Core/Inputs/InputSet.cs
+++ b/Hina.Core/Inputs/InputSet.cs
@@ -1,0 +1,100 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+
+namespace Hina.Core.Inputs
+{
+    // A relative path present in more than one root; the later root's copy won.
+    public sealed class InputOverride
+    {
+        public string RelativePath { get; init; } = string.Empty;
+        public string WinningRoot { get; init; } = string.Empty;
+        public string OverriddenRoot { get; init; } = string.Empty;
+    }
+
+    // Snapshot of the files to package, merged from one or more input roots.
+    // LATER roots win on a relative-path collision (variant-wins: pass the
+    // shared/common root first, the variant root last).
+    //
+    // Both the manifest builder and the chunk-store writer consume the SAME
+    // resolved set, so the manifest and the store can never disagree about
+    // which files exist (each used to enumerate the directory independently).
+    public sealed class InputSet
+    {
+        // Sorted by RelativePath, StringComparer.Ordinal: deterministic
+        // manifests regardless of filesystem enumeration order.
+        public IReadOnlyList<InputFile> Files { get; }
+
+        public IReadOnlyList<InputOverride> Overrides { get; }
+
+        // Relative paths that are distinct under ordinal comparison but would
+        // collide on a case-insensitive filesystem (Windows/macOS installs).
+        // Merging is ordinal so Linux semantics stay correct; callers should
+        // surface these as a warning.
+        public IReadOnlyList<string> CaseClashes { get; }
+
+        private InputSet(IReadOnlyList<InputFile> files, IReadOnlyList<InputOverride> overrides, IReadOnlyList<string> caseClashes)
+        {
+            Files = files;
+            Overrides = overrides;
+            CaseClashes = caseClashes;
+        }
+
+        public static InputSet Resolve(IReadOnlyList<DirectoryInfo> rootsInPrecedenceOrder)
+        {
+            if (rootsInPrecedenceOrder == null || rootsInPrecedenceOrder.Count == 0)
+            {
+                throw new ArgumentException("At least one input root is required.", nameof(rootsInPrecedenceOrder));
+            }
+
+            Dictionary<string, InputFile> byRelPath = new Dictionary<string, InputFile>(StringComparer.Ordinal);
+            List<InputOverride> overrides = new List<InputOverride>();
+
+            foreach (DirectoryInfo root in rootsInPrecedenceOrder)
+            {
+                if (!root.Exists)
+                {
+                    throw new DirectoryNotFoundException(root.FullName);
+                }
+
+                foreach (string filePath in Directory.EnumerateFiles(root.FullName, "*", SearchOption.AllDirectories))
+                {
+                    string relPath = Path.GetRelativePath(root.FullName, filePath).Replace('\\', '/');
+                    InputFile entry = new InputFile
+                    {
+                        AbsolutePath = filePath,
+                        RelativePath = relPath,
+                        SourceRoot = root.FullName
+                    };
+
+                    if (byRelPath.TryGetValue(relPath, out InputFile? previous))
+                    {
+                        overrides.Add(new InputOverride
+                        {
+                            RelativePath = relPath,
+                            WinningRoot = root.FullName,
+                            OverriddenRoot = previous.SourceRoot
+                        });
+                    }
+                    byRelPath[relPath] = entry;
+                }
+            }
+
+            List<InputFile> files = byRelPath.Values
+                .OrderBy(f => f.RelativePath, StringComparer.Ordinal)
+                .ToList();
+
+            List<string> caseClashes = files
+                .GroupBy(f => f.RelativePath, StringComparer.OrdinalIgnoreCase)
+                .Where(g => g.Count() > 1)
+                .Select(g => g.Key)
+                .OrderBy(p => p, StringComparer.Ordinal)
+                .ToList();
+
+            overrides.Sort((a, b) => string.CompareOrdinal(a.RelativePath, b.RelativePath));
+
+            return new InputSet(files, overrides, caseClashes);
+        }
+    }
+}

--- a/Hina.Core/Manifest/ManifestBuilder.cs
+++ b/Hina.Core/Manifest/ManifestBuilder.cs
@@ -4,11 +4,12 @@ using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
 using Hina.Core.Hashing;
+using Hina.Core.Inputs;
 using Hina.Core.Rsync;
 
 namespace Hina.Core.Manifest
 {
-    // Creates a manifest from a directory.
+    // Creates a manifest from a directory (or a merged set of input roots).
     public sealed class ManifestBuilder
     {
         private readonly IHasher _hasher;
@@ -35,27 +36,27 @@ namespace Hina.Core.Manifest
             IChunker chunker,
             CancellationToken ct)
         {
-            if (!root.Exists)
-            {
-                throw new DirectoryNotFoundException(root.FullName);
-            }
+            return await BuildAsync(InputSet.Resolve(new[] { root }), baseUrl, chunkSize, chunker, ct);
+        }
 
+        public async Task<Manifest> BuildAsync(
+            InputSet inputs,
+            Uri baseUrl,
+            int chunkSize,
+            IChunker chunker,
+            CancellationToken ct)
+        {
             Manifest manifest = new Manifest
             {
                 BaseUrl = baseUrl.ToString()
             };
 
-            List<FileInfo> files = new List<FileInfo>();
-            foreach (string filePath in Directory.EnumerateFiles(root.FullName, "*", SearchOption.AllDirectories))
-            {
-                files.Add(new FileInfo(filePath));
-            }
-
-            foreach (FileInfo file in files)
+            foreach (InputFile file in inputs.Files)
             {
                 ct.ThrowIfCancellationRequested();
 
-                using (FileStream fs = file.OpenRead())
+                FileInfo info = new FileInfo(file.AbsolutePath);
+                using (FileStream fs = info.OpenRead())
                 {
                     List<ManifestChunk> chunks = await chunker.ChunkAsync(fs, ct);
                     fs.Position = 0;
@@ -63,9 +64,9 @@ namespace Hina.Core.Manifest
 
                     manifest.Files.Add(new ManifestFile
                     {
-                        Path = Path.GetRelativePath(root.FullName, file.FullName).Replace('\\', '/'),
-                        Size = file.Length,
-                        MTimeUtc = file.LastWriteTimeUtc,
+                        Path = file.RelativePath,
+                        Size = info.Length,
+                        MTimeUtc = info.LastWriteTimeUtc,
                         FileHash = fileHash,
                         ChunkSize = chunkSize,
                         Chunks = chunks

--- a/docs/Builder-Guide.md
+++ b/docs/Builder-Guide.md
@@ -107,24 +107,33 @@ ship one **variant** per `(os[, arch])` and the client fetches just that variant
 
 **Publisher layout** — one subfolder per variant, named by its token `<os>[-<arch>]`
 (os ∈ `windows|macos|linux`, arch ∈ `x64|arm64|x86|arm`; omit arch for a build that works on
-any arch of that OS):
+any arch of that OS). Files identical on every OS (game data, assets) go in a `common/`
+folder instead of being copied into each variant:
 
 ```
 mygame-build/
+  common/        maps, art, sounds — OS-independent files, shared by every variant
   windows-x64/   Game.exe + dll
   macos-arm64/   MyGame.app/Contents/MacOS/MyGame
   macos-x64/     MyGame.app/Contents/MacOS/MyGame
   linux/         game + libs          # no arch ⇒ universal linux build
 ```
 
-Build each variant into the **same** `--out` with `--platform <token>` — chunks are
-content-addressed, so the shared store dedupes assets common to multiple variants:
+Build each variant into the **same** `--out` with `--platform <token>`, passing the shared
+folder with `--common` — its files are merged into every variant's manifest at their
+root-relative paths (a client installs `common/maps/map0.mul` as `maps/map0.mul`). Chunks
+are content-addressed, so the shared store stores each asset once no matter how many
+variants reference it, and an update to a common file delta-patches every platform:
 
 ```shell
-hina-builder build --input mygame-build/windows-x64 --platform windows-x64 --out patch --base https://patch.example.com/ --version 1.0.0 --sign-key keys/mygame.key.b64
-hina-builder build --input mygame-build/macos-arm64 --platform macos-arm64 --out patch --base https://patch.example.com/ --version 1.0.0 --sign-key keys/mygame.key.b64
-hina-builder build --input mygame-build/linux       --platform linux       --out patch --base https://patch.example.com/ --version 1.0.0 --sign-key keys/mygame.key.b64
+hina-builder build --input mygame-build/windows-x64 --common mygame-build/common --platform windows-x64 --out patch --base https://patch.example.com/ --version 1.0.0 --sign-key keys/mygame.key.b64
+hina-builder build --input mygame-build/macos-arm64 --common mygame-build/common --platform macos-arm64 --out patch --base https://patch.example.com/ --version 1.0.0 --sign-key keys/mygame.key.b64
+hina-builder build --input mygame-build/linux       --common mygame-build/common --platform linux       --out patch --base https://patch.example.com/ --version 1.0.0 --sign-key keys/mygame.key.b64
 ```
+
+If the same relative path exists in both `--common` and `--input`, the `--input` (variant)
+copy wins — so a variant can override a shared asset for one OS. Each override is logged
+during the build.
 
 **Host layout** (shared chunk store):
 
@@ -151,8 +160,9 @@ hina-builder build --input mygame-build/linux       --platform linux       --out
 The client picks the most specific variant for its machine; if there's no native build for an
 arm64 host it falls back to the `x64` build (Rosetta on macOS, emulation on Windows) with a
 warning, and errors cleanly when no variant serves the OS. `hina-builder init` detects these
-subfolders automatically and builds every variant for you. Apps with no `platforms` keep the
-legacy single-manifest behavior.
+subfolders automatically — including `common/` — and builds every variant for you. Apps with
+no `platforms` keep the legacy single-manifest behavior (there a folder named `common/` is
+ordinary app content).
 
 ---
 
@@ -174,6 +184,8 @@ Scans a directory, chunks every file, and produces a manifest plus a chunk store
 | `--max-chunk` | No | `65536` | Maximum CDC chunk size in bytes |
 | `--avg-chunk` | No | `8192` | Target average CDC chunk size in bytes |
 | `--sign-key` | No | -- | Path to Ed25519 private key file (`.key.b64`) for signing the manifest |
+| `--platform` | No | -- | Variant token `<os>[-<arch>]`; writes `manifest.<token>.json` into a shared `--out` store |
+| `--common` | No | -- | Folder of shared files merged into the build; on the same relative path the `--input` copy wins (per-OS override) |
 | `-v`, `--verbose` | No | off | Enable debug-level logging output |
 
 ### Examples

--- a/docs/Changelog.md
+++ b/docs/Changelog.md
@@ -4,6 +4,31 @@ All notable changes to Hina are documented in this file.
 
 ---
 
+## Unreleased
+
+### `hina-builder build --common` — shared files across platform variants
+
+- **New `--common <dir>` flag**: a folder of OS-independent files (game data, assets)
+  merged into the build at their root-relative paths, so a multi-platform app no longer
+  needs the shared assets physically copied into every variant input folder. The chunk
+  store is content-addressed, so each shared asset is stored once no matter how many
+  variants reference it, and an update to a common file delta-patches every platform.
+- On a relative-path collision the `--input` (variant) copy wins — a variant can override
+  a shared asset for one OS. Each override is logged; paths differing only by case are
+  flagged with a warning (they collide on Windows/macOS installs).
+- `hina-builder init` auto-detects a subfolder named `common/` next to the variant
+  folders and merges it into every variant build. **Behavior change:** in variant mode
+  such a folder used to be silently excluded from all manifests. In single-payload mode
+  nothing changes (`common/` is ordinary app content).
+- No client change needed: a merged manifest is indistinguishable from one built from
+  physically copied files.
+- Internal: manifest and chunk store are now produced from one shared, ordinal-sorted
+  file snapshot (`InputSet`) instead of two independent directory enumerations — manifest
+  file order is now deterministic across OSes and the manifest can no longer disagree
+  with the store if files change mid-build.
+
+---
+
 ## v1.4.3 — host proxy support, installer hardening, scoop fix
 
 11 fixes from bug-hunt rounds 9–10 (PR #30, PR #31). Test suite: 615 → 629 tests.

--- a/docs/Quick-Start.md
+++ b/docs/Quick-Start.md
@@ -55,6 +55,7 @@ universal build of that OS):
 
 ```
 game/
+  common/         OS-independent files (game data, assets) shared by every variant
   windows-x64/    your Windows build
   macos-arm64/    Apple Silicon build
   macos-x64/      Intel build
@@ -63,6 +64,10 @@ game/
 
 > Coming from `game_windows_x86_64`? Rename to `windows-x64`. The folder name must be exactly
 > the token, nothing else.
+
+Files in `common/` are merged into **every** variant's manifest at their root-relative paths
+(no copying into each folder needed); if a variant ships its own copy of the same path, the
+variant's file wins.
 
 **2. Run the wizard** — it detects the variant folders and builds each one:
 
@@ -79,9 +84,9 @@ write the descriptor yourself:
 
 ```sh
 hina-builder keygen --out keys --name game
-hina-builder build --input game/windows-x64 --platform windows-x64 --out patch --base https://you.example/ --version 1.0.0 --sign-key keys/game.key.b64
-hina-builder build --input game/macos-arm64 --platform macos-arm64 --out patch --base https://you.example/ --version 1.0.0 --sign-key keys/game.key.b64
-# …one per variant, same --out
+hina-builder build --input game/windows-x64 --common game/common --platform windows-x64 --out patch --base https://you.example/ --version 1.0.0 --sign-key keys/game.key.b64
+hina-builder build --input game/macos-arm64 --common game/common --platform macos-arm64 --out patch --base https://you.example/ --version 1.0.0 --sign-key keys/game.key.b64
+# …one per variant, same --out and same --common
 hina dev sign-descriptor --in hina.app.json --key keys/game.key.b64
 ```
 


### PR DESCRIPTION
Implements the shared-files feature planned for the Ultima Online-style use case: per-OS client binaries in variant folders, OS-independent game data (which updates over time) in one `common/` folder — no more physical copying into every variant input.

### What

- **`hina-builder build --common <dir>`**: the folder's tree is merged into the build at root-relative paths. Collision policy (user-decided): the `--input` (variant) copy wins, each override logged; case-clash hazards for Windows/macOS installs logged as warnings. Validations mirror the existing `--out`/`--input` rules (existence, no overlap with `--input` or `--out` in either direction).
- **`hina-builder init`** auto-detects a `common/` subfolder next to variant folders and merges it into every variant build. Behavior change: in variant mode that folder used to be **silently excluded** from all manifests. Single-payload mode unchanged.
- **`InputSet` (Hina.Core.Inputs)**: one ordinal-sorted, deterministic file snapshot consumed by BOTH the manifest builder and the chunk-store writer — eliminates the previous independent double enumeration (latent manifest/store skew) and guarantees no orphan chunks for overridden files. Existing single-root APIs delegate through it (additive, compatible).
- **No client changes**: a merged manifest is indistinguishable from one built from physically copied files; updates to common files ride the normal delta flow.

### Tests (629 → 650)

- `InputSetTests` (8): merge semantics, later-wins override, ordinal determinism, case-clash reporting.
- `BuildCommandTests` (+10): manifest merge, no-platform merge, override wins+logs, overridden chunks absent from store, full validation matrix.
- `InitCommandTests` (+2): common merged into every variant manifest; single-payload `common/` stays ordinary content.
- `CommonMergeRoundTripTests`: end-to-end proof — changed common file delta-updates exactly that file, variant binary not re-downloaded.

### Verified live

UO-like layout built with the real binary: merge stats logged ("2 common + 1 variant"), both variant manifests carry the shared file at its root-relative path, shared store holds 4 chunks for 2 variants (dedup), changing the common file and rebuilding both variants adds exactly 1 new chunk.

🤖 Generated with [Claude Code](https://claude.com/claude-code)