### PR TITLE
release: v1.5.0

### DIFF
--- a/Hina.PackageManager/Install/HinaVersion.cs
+++ b/Hina.PackageManager/Install/HinaVersion.cs
@@ -12,7 +12,7 @@ namespace Hina.PackageManager.Install
         // Single source of truth for the running version. The release tag MUST equal
         // "v" + this value (release.yml verifies it), so `hina version`, `hina check-update`,
         // and the published GitHub tag never drift.
-        public const string Current = "1.4.3";
+        public const string Current = "1.5.0";
 
         // True if running version >= required minimum. Both sides parsed as SemVer
         // major.minor.patch; pre-release / build-metadata suffix is tolerated but

--- a/docs/Changelog.md
+++ b/docs/Changelog.md
@@ -4,9 +4,11 @@ All notable changes to Hina are documented in this file.
 
 ---
 
-## Unreleased
+## v1.5.0 — shared files across platform variants
 
-### `hina-builder build --common` — shared files across platform variants
+Test suite: 629 → 650 tests.
+
+### `hina-builder build --common`
 
 - **New `--common <dir>` flag**: a folder of OS-independent files (game data, assets)
   merged into the build at their root-relative paths, so a multi-platform app no longer

--- a/docs/PackageManager-Guide.md
+++ b/docs/PackageManager-Guide.md
@@ -250,9 +250,15 @@ the variant matching its machine:
   warning; it errors cleanly when no variant serves the OS.
 - `platforms` (when non-empty) is authoritative and the `exec` map is ignored. Apps with no
   `platforms` keep the legacy single-manifest behavior unchanged.
+- OS-independent files shared by every variant (game data, assets — even ones that update
+  over time) don't need to be copied into each variant folder: keep them in a `common/`
+  folder and the builder merges them into every variant's manifest (`--common <dir>`). On
+  the same relative path the variant's copy wins, so a variant can still override a shared
+  asset for one OS.
 
 See the [Builder Guide](Builder-Guide.md) for the per-variant build commands and host layout;
-`hina-builder init` detects per-variant subfolders and builds them automatically.
+`hina-builder init` detects per-variant subfolders (including `common/`) and builds them
+automatically.
 
 ### The optional `sandbox` block
 
@@ -472,9 +478,11 @@ End-to-end:
    `hina install <descriptor-url>`.
 
 For a **multi-platform** app, build each variant subfolder with `--platform <token>` into the
-**same** `--out` (shared chunk store) and declare a `platforms` array instead of `exec` — see
-the [Builder Guide](Builder-Guide.md). Or just run `hina-builder init`, which detects the
-per-variant subfolders, writes the signed descriptor, and builds every variant for you.
+**same** `--out` (shared chunk store), pass OS-independent shared files with
+`--common <dir>`, and declare a `platforms` array instead of `exec` — see the
+[Builder Guide](Builder-Guide.md). Or just run `hina-builder init`, which detects the
+per-variant subfolders (and a `common/` folder), writes the signed descriptor, and builds
+every variant for you.
 
 ---
 


### PR DESCRIPTION
Cuts v1.5.0 with the `--common` feature (PR #33): shared OS-independent files merged into every platform variant's manifest at build time — no more copying game data into each variant folder; updates to shared files delta-patch every platform.

Changes: `HinaVersion.Current` 1.4.3 → 1.5.0, changelog Unreleased → v1.5.0, PackageManager-Guide mentions `common/` in both multi-platform sections. Suite 650 tests green locally.

After merge: `git tag v1.5.0 && git push origin v1.5.0` → release workflow builds the 46 assets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)